### PR TITLE
fix: entity to package rename

### DIFF
--- a/crates/prototype-server/src/server.rs
+++ b/crates/prototype-server/src/server.rs
@@ -261,15 +261,15 @@ impl Server {
         let app = Router::new()
             .route("/releases/", post(create_unpublished_release))
             .route(
-                "/:entity_collection/:entity_name/v:version/unpublished",
+                "/:package_collection/:package_name/v:version/unpublished",
                 get(get_unpublished_release),
             )
             .route(
-                "/:entity_collection/:entity_name/v:version/publish",
+                "/:package_collection/:package_name/v:version/publish",
                 post(publish_release),
             )
             .route(
-                "/:entity_collection/:entity_name/v:version",
+                "/:package_collection/:package_name/v:version",
                 get(get_release),
             )
             // Prototype routes to enable testing

--- a/crates/test-client/src/main.rs
+++ b/crates/test-client/src/main.rs
@@ -111,7 +111,7 @@ impl PublishCommand {
             .context("Failed to reset content file cursor")?;
 
         let release = ReleaseManifest {
-            entity_type: EntityType::Component,
+            package_type: EntityType::Component,
             name: self.name,
             version: self.version,
             content_digest: TypedDigest::Sha256(digest),

--- a/src/client.rs
+++ b/src/client.rs
@@ -95,11 +95,11 @@ impl<C: HttpClient> Client<C> {
 
     pub async fn get_release(
         &self,
-        entity_type: EntityType,
+        package_type: EntityType,
         name: EntityName,
         version: semver::Version,
     ) -> Result<Release, ClientError> {
-        let path = Release::build_resource_path(&entity_type, &name, &version);
+        let path = Release::build_resource_path(&package_type, &name, &version);
         self.get_json(&path).await
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub enum Error {
     #[error("invalid name: {0}")]
     InvalidEntityName(ErrorMsg),
 
-    #[error("invalid entityType: {0}")]
+    #[error("invalid packageType: {0}")]
     InvalidEntityType(ErrorMsg),
 
     #[error("invalid signature: {0}")]

--- a/src/release.rs
+++ b/src/release.rs
@@ -60,7 +60,7 @@ impl FromStr for EntityName {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReleaseManifest {
-    pub entity_type: EntityType,
+    pub package_type: EntityType,
     pub name: EntityName,
     // TODO: Do we want to enforce semver at this level? Is this implementation acceptable?
     pub version: semver::Version,
@@ -69,7 +69,7 @@ pub struct ReleaseManifest {
 
 impl ReleaseManifest {
     pub fn resource_path(&self) -> String {
-        Release::build_resource_path(&self.entity_type, &self.name, &self.version)
+        Release::build_resource_path(&self.package_type, &self.name, &self.version)
     }
 }
 
@@ -123,13 +123,13 @@ impl Release {
     }
 
     pub fn build_resource_path(
-        entity_type: &EntityType,
+        package_type: &EntityType,
         name: &EntityName,
         version: &semver::Version,
     ) -> String {
         format!(
             "/{}/{}/v{}",
-            entity_type.collection_name(),
+            package_type.collection_name(),
             name.as_ref(),
             version
         )


### PR DESCRIPTION
Per discussion in [SIG-Registry](https://github.com/bytecodealliance/SIG-Registries/discussions/21), this renames entity to package.