### PR TITLE
Refactor API types into a `warg-api` crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,9 +2386,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "8cdd151213925e7f1ab45a9bbfb129316bd00799784b174b7cc7bcd16961c49e"
 dependencies = [
  "serde_derive",
 ]
@@ -2414,9 +2414,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "4fc80d722935453bcafdc2c9a73cd6fac4dc1938f0346035d84bf99fa9e33217"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3034,6 +3034,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "warg-api"
+version = "0.1.0"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_with",
+ "warg-crypto",
+ "warg-protocol",
+]
+
+[[package]]
 name = "warg-cli"
 version = "0.1.0"
 dependencies = [
@@ -3057,7 +3068,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
  "bytes",
  "clap 4.0.32",
  "futures-util",
@@ -3068,11 +3078,9 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tracing",
- "tracing-subscriber",
+ "warg-api",
  "warg-crypto",
  "warg-protocol",
- "warg-server",
  "warg-transparency",
 ]
 
@@ -3129,13 +3137,12 @@ dependencies = [
  "futures",
  "indexmap",
  "reqwest",
- "serde",
- "serde_with",
  "tempfile",
  "tokio",
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "warg-api",
  "warg-crypto",
  "warg-protocol",
  "warg-transparency",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "warg-api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+warg-protocol = { path = "../protocol" }
+warg-crypto = { path = "../crypto" }
+serde = { version = "1.0.154", features = ["derive"] }
+serde_with = { version = "2.2.0", features = ["base64"] }
+indexmap = { version = "1.9.2", features = ["serde"] }

--- a/crates/api/src/content.rs
+++ b/crates/api/src/content.rs
@@ -1,0 +1,22 @@
+//! Types relating to the content API.
+
+use serde::{Deserialize, Serialize};
+use warg_crypto::hash::DynHash;
+
+/// Represents a content source.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContentSource {
+    /// The digest of the content.
+    pub digest: DynHash,
+    /// The kind of content source.
+    pub kind: ContentSourceKind,
+}
+
+/// Represents the supported kinds of content sources.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum ContentSourceKind {
+    /// The content is located at an anonymous HTTP URL.
+    HttpAnonymous(String),
+}

--- a/crates/api/src/fetch.rs
+++ b/crates/api/src/fetch.rs
@@ -1,0 +1,39 @@
+//! Types relating to the fetch API.
+
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+use warg_crypto::hash::DynHash;
+use warg_protocol::{
+    registry::{MapCheckpoint, RecordId},
+    ProtoEnvelopeBody, SerdeEnvelope,
+};
+
+/// Represents a fetch request.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FetchRequest {
+    /// The root of the registry.
+    pub root: DynHash,
+    /// The last known operator record.
+    pub operator: Option<RecordId>,
+    /// The map of packages to last known record ids.
+    pub packages: IndexMap<String, Option<RecordId>>,
+}
+
+/// Represents a fetch response.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FetchResponse {
+    /// The operator records appended since the last known operator record.
+    pub operator: Vec<ProtoEnvelopeBody>,
+    /// The package records appended since last known package record ids.
+    pub packages: IndexMap<String, Vec<ProtoEnvelopeBody>>,
+}
+
+/// Represents a checkpoint response.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckpointResponse {
+    /// The latest registry checkpoint.
+    pub checkpoint: SerdeEnvelope<MapCheckpoint>,
+}

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1,0 +1,7 @@
+//! The serializable types for the Warg API.
+#![deny(missing_docs)]
+
+pub mod content;
+pub mod fetch;
+pub mod package;
+pub mod proof;

--- a/crates/api/src/package.rs
+++ b/crates/api/src/package.rs
@@ -1,0 +1,49 @@
+//! Types relating to the package API.
+
+use crate::content::ContentSource;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use warg_protocol::{registry::MapCheckpoint, ProtoEnvelopeBody, SerdeEnvelope};
+
+/// Represents a request to publish a package.
+#[derive(Serialize, Deserialize)]
+#[serde(rename = "camelCase")]
+pub struct PublishRequest {
+    /// The publish record to add to the package log.
+    pub record: ProtoEnvelopeBody,
+    /// The content sources for the record.
+    pub content_sources: Vec<ContentSource>,
+}
+
+/// Represents a pending record response.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "state", rename = "camelCase")]
+pub enum PendingRecordResponse {
+    /// The record has been published.
+    Published {
+        /// The URL of the published record.
+        record_url: String,
+    },
+    /// The record has been rejected.
+    Rejected {
+        /// The reason the record was rejected.
+        reason: String,
+    },
+    /// The record is still being processed.
+    Processing {
+        /// The URL of the publishing status.
+        status_url: String,
+    },
+}
+
+/// Represents a response to a record request.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RecordResponse {
+    /// The body of the record.
+    pub record: ProtoEnvelopeBody,
+    /// The content sources of the record.
+    pub content_sources: Arc<Vec<ContentSource>>,
+    /// The checkpoint of the record.
+    pub checkpoint: Arc<SerdeEnvelope<MapCheckpoint>>,
+}

--- a/crates/api/src/proof.rs
+++ b/crates/api/src/proof.rs
@@ -1,0 +1,49 @@
+//! Types relating to the proof API.
+
+use serde::{Deserialize, Serialize};
+use serde_with::{base64::Base64, serde_as};
+use warg_crypto::hash::DynHash;
+use warg_protocol::registry::{LogLeaf, MapCheckpoint};
+
+/// Represents a consistency proof request.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsistencyRequest {
+    /// The old root to check for consistency.
+    pub old_root: DynHash,
+    /// The new root to check for consistency.
+    pub new_root: DynHash,
+}
+
+/// Represents a consistency proof response.
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsistencyResponse {
+    /// The bytes of the consistency proof bundle.
+    #[serde_as(as = "Base64")]
+    pub proof: Vec<u8>,
+}
+
+/// Represents an inclusion proof request.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InclusionRequest {
+    /// The checkpoint to check for inclusion.
+    pub checkpoint: MapCheckpoint,
+    /// The heads to check for inclusion.
+    pub heads: Vec<LogLeaf>,
+}
+
+/// Represents an inclusion proof response.
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct InclusionResponse {
+    /// The bytes of the log log proof bundle.
+    #[serde_as(as = "Base64")]
+    pub log: Vec<u8>,
+    /// The bytes of the map inclusion proof bundle.
+    #[serde_as(as = "Base64")]
+    pub map: Vec<u8>,
+}

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -3,26 +3,20 @@ name = "warg-client"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
+warg-crypto = { path = "../crypto" }
+warg-protocol = { path = "../protocol" }
+warg-api ={ path = "../api" }
+warg-transparency = { path = "../transparency" }
 anyhow = "1.0.68"
 thiserror = "1.0"
-axum = { version = "0.6.1", features = ["http2", "headers", "macros"] }
 clap = { version = "4.0.32", features = ["derive"] }
 serde = { version = "1.0.152", features = ["rc"] }
 serde_json = "1.0"
 tokio = { version = "1.23.1", features = ["full"] }
 tempfile = "3.3.0"
-tracing = "0.1.37"
-tracing-subscriber = "0.3.16"
 reqwest = { version = "0.11.14", features = ["json", "stream"] }
 indexmap = { version = "1.9.2", features = ["serde"] }
-
-warg-crypto = { path = "../crypto" }
-warg-protocol = { path = "../protocol" }
-warg-server ={ path = "../server" }
-warg-transparency = { path = "../transparency" }
 futures-util = "0.3.26"
 async-trait = "0.1.64"
 bytes = "1.4.0"

--- a/crates/client/src/api.rs
+++ b/crates/client/src/api.rs
@@ -1,24 +1,20 @@
-use std::{sync::Arc, time::Duration};
-
 use anyhow::{Context, Error, Result};
 use bytes::Bytes;
 use futures_util::Stream;
+use std::{sync::Arc, time::Duration};
+use warg_api::{
+    content::ContentSource,
+    fetch::{CheckpointResponse, FetchRequest, FetchResponse},
+    package::{PendingRecordResponse, PublishRequest, RecordResponse},
+    proof::{InclusionRequest, InclusionResponse},
+};
 use warg_crypto::hash::{DynHash, Sha256};
 use warg_protocol::{
     package,
     registry::{LogLeaf, MapCheckpoint, MapLeaf},
     ProtoEnvelope, SerdeEnvelope,
 };
-use warg_server::api::{
-    fetch::CheckpointResponse,
-    package::{PendingRecordResponse, PublishRequest, RecordResponse},
-    proof::{InclusionRequest, InclusionResponse},
-};
 use warg_transparency::{log::LogProofBundle, map::MapProofBundle};
-
-pub use warg_server::api::fetch::{FetchRequest, FetchResponse};
-
-pub use warg_server::services::core::{ContentSource, ContentSourceKind};
 
 pub struct Client {
     server_url: String,

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -4,20 +4,18 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+warg-api = { path = "../api" }
+warg-crypto ={ path = "../crypto" }
+warg-protocol = { path = "../protocol" }
+warg-transparency = { path = "../transparency" }
 anyhow = "1.0.68"
 axum = { version = "0.6.1", features = ["http2", "headers", "macros"] }
 clap = { version = "4.0.32", features = ["derive"] }
 futures = "0.3.25"
 reqwest = "0.11.14"
-serde = { version = "1.0.152", features = ["rc"] }
-serde_with = { version = "2.2.0", features = ["base64"] }
 tempfile = "3.3.0"
 tokio = { version = "1.23.1", features = ["full"] }
 tower-http = { version = "0.3.5", features = ["fs"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
-indexmap = { version = "1.9.2", features = ["serde"] }
-
-warg-crypto ={ path = "../crypto" }
-warg-protocol = { path = "../protocol" }
-warg-transparency = { path = "../transparency" }
+indexmap = { version = "1.9.2" }

--- a/crates/server/src/api/content.rs
+++ b/crates/server/src/api/content.rs
@@ -1,5 +1,4 @@
-use std::{path::PathBuf, sync::Arc};
-
+use crate::AnyError;
 use anyhow::Result;
 use axum::{
     debug_handler,
@@ -10,12 +9,11 @@ use axum::{
     Router,
 };
 use futures::StreamExt;
+use std::{path::PathBuf, sync::Arc};
 use tempfile::NamedTempFile;
 use tokio::io::AsyncWriteExt;
 use tower_http::services::ServeDir;
 use warg_crypto::hash::{Digest, Sha256};
-
-use crate::AnyError;
 
 #[derive(Debug)]
 pub struct ContentConfig {
@@ -56,5 +54,5 @@ async fn upload_content(
     tmp_path.persist(state.content_path.join(&dest_name))?;
 
     let location = format!("{}/{}", orig_uri.path().trim_end_matches('/'), dest_name);
-    Ok((StatusCode::OK, [(LOCATION, location)]))
+    Ok((StatusCode::CREATED, [(LOCATION, location)]))
 }

--- a/crates/server/src/api/fetch.rs
+++ b/crates/server/src/api/fetch.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
-
+use crate::services::core::CoreService;
+use crate::AnyError;
 use anyhow::Result;
 use axum::extract::State;
 use axum::{
@@ -10,14 +10,8 @@ use axum::{
     Json, Router,
 };
 use indexmap::IndexMap;
-use serde::{Deserialize, Serialize};
-
-use warg_crypto::hash::DynHash;
-use warg_protocol::registry::{MapCheckpoint, RecordId};
-use warg_protocol::{ProtoEnvelopeBody, SerdeEnvelope};
-
-use crate::services::core::CoreService;
-use crate::AnyError;
+use std::sync::Arc;
+use warg_api::fetch::{CheckpointResponse, FetchRequest, FetchResponse};
 
 #[derive(Clone)]
 pub struct Config {
@@ -35,19 +29,6 @@ impl Config {
             .route("/checkpoint", get(fetch_checkpoint))
             .with_state(self)
     }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct FetchRequest {
-    pub root: DynHash,
-    pub operator: Option<RecordId>,
-    pub packages: IndexMap<String, Option<RecordId>>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct FetchResponse {
-    pub operator: Vec<ProtoEnvelopeBody>,
-    pub packages: IndexMap<String, Vec<ProtoEnvelopeBody>>,
 }
 
 #[debug_handler]
@@ -77,11 +58,6 @@ async fn fetch_logs(
     }
     let response = FetchResponse { operator, packages };
     Ok((StatusCode::OK, Json(response)))
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct CheckpointResponse {
-    pub checkpoint: SerdeEnvelope<MapCheckpoint>,
 }
 
 #[debug_handler]

--- a/crates/server/src/api/proof.rs
+++ b/crates/server/src/api/proof.rs
@@ -1,17 +1,15 @@
-use std::sync::Arc;
-
-use anyhow::Result;
-use axum::extract::State;
-use axum::{debug_handler, http::StatusCode, response::IntoResponse, routing::post, Json, Router};
-use serde::{Deserialize, Serialize};
-use serde_with::base64::Base64;
-use serde_with::serde_as;
-use tokio::sync::RwLock;
-
-use warg_crypto::hash::{DynHash, Hash, Sha256};
-use warg_protocol::registry::{LogLeaf, MapCheckpoint};
-
 use crate::{services::data, AnyError};
+use anyhow::Result;
+use axum::{
+    debug_handler, extract::State, http::StatusCode, response::IntoResponse, routing::post, Json,
+    Router,
+};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use warg_api::proof::{
+    ConsistencyRequest, ConsistencyResponse, InclusionRequest, InclusionResponse,
+};
+use warg_crypto::hash::{Hash, Sha256};
 
 #[derive(Clone)]
 pub struct Config {
@@ -35,17 +33,6 @@ impl Config {
     }
 }
 
-#[derive(Serialize, Deserialize)]
-pub struct ConsistencyRequest {
-    old_root: DynHash,
-    new_root: DynHash,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct ConsistencyResponse {
-    proof: Vec<u8>,
-}
-
 #[debug_handler]
 pub(crate) async fn prove_consistency(
     State(config): State<Config>,
@@ -63,21 +50,6 @@ pub(crate) async fn prove_consistency(
     };
 
     Ok((StatusCode::OK, Json(response)))
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct InclusionRequest {
-    pub checkpoint: MapCheckpoint,
-    pub heads: Vec<LogLeaf>,
-}
-
-#[serde_as]
-#[derive(Serialize, Deserialize, Debug)]
-pub struct InclusionResponse {
-    #[serde_as(as = "Base64")]
-    pub log: Vec<u8>,
-    #[serde_as(as = "Base64")]
-    pub map: Vec<u8>,
 }
 
 #[debug_handler]

--- a/crates/server/src/services/core.rs
+++ b/crates/server/src/services/core.rs
@@ -1,12 +1,11 @@
 use anyhow::Error;
-use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use tokio::sync::Mutex;
-
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::sync::oneshot;
+use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
+use warg_api::content::ContentSource;
 use warg_crypto::hash::{DynHash, Hash, Sha256};
 use warg_protocol::registry::LogLeaf;
 use warg_protocol::{
@@ -93,19 +92,7 @@ pub struct PackageRecordInfo {
     pub state: RecordState,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ContentSource {
-    pub content_digest: DynHash,
-    pub kind: ContentSourceKind,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "type")]
-pub enum ContentSourceKind {
-    HttpAnonymous { url: String },
-}
-
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum RecordState {
     #[default]
     Unknown,
@@ -344,7 +331,7 @@ async fn new_record(
         Ok(contents) => {
             let provided_contents: HashSet<DynHash> = content_sources
                 .iter()
-                .map(|source| source.content_digest.clone())
+                .map(|source| source.digest.clone())
                 .collect();
             for needed_content in contents {
                 if !provided_contents.contains(&needed_content) {


### PR DESCRIPTION
This PR the serializable API types from the server crate into a
`warg-api` crate.

The client and server now share these types via the `warg-api` crate.

This change allows crates dependent upon the `warg-client` crate to not have to
build server-related dependencies.