### PR TITLE
add info command

### DIFF
--- a/crates/api/src/content.rs
+++ b/crates/api/src/content.rs
@@ -15,7 +15,7 @@ pub struct ContentSource {
 
 /// Represents the supported kinds of content sources.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "camelCase")]
+#[serde(tag = "type", rename_all = "camelCase", content = "c")]
 pub enum ContentSourceKind {
     /// The content is located at an anonymous HTTP URL.
     HttpAnonymous(String),

--- a/crates/api/src/content.rs
+++ b/crates/api/src/content.rs
@@ -15,8 +15,11 @@ pub struct ContentSource {
 
 /// Represents the supported kinds of content sources.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "camelCase", content = "c")]
+#[serde(tag = "type", rename_all = "camelCase")]
 pub enum ContentSourceKind {
     /// The content is located at an anonymous HTTP URL.
-    HttpAnonymous(String),
+    HttpAnonymous { 
+      /// The URL for the content
+      url: String 
+    },
 }

--- a/crates/api/src/content.rs
+++ b/crates/api/src/content.rs
@@ -18,8 +18,8 @@ pub struct ContentSource {
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum ContentSourceKind {
     /// The content is located at an anonymous HTTP URL.
-    HttpAnonymous { 
-      /// The URL for the content
-      url: String 
+    HttpAnonymous {
+        /// The URL for the content
+        url: String,
     },
 }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -137,7 +137,7 @@ impl Client {
                     let url = client.upload_content(content).await?;
                     content_sources.push(ContentSource {
                         digest,
-                        kind: ContentSourceKind::HttpAnonymous(url),
+                        kind: ContentSourceKind::HttpAnonymous { url },
                     })
                 }
             }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -35,6 +35,18 @@ impl Client {
         Self { storage }
     }
 
+    pub async fn inform(&self, package: String) -> Result<(), ClientError> {
+        let state = self.storage.load_package_state(&package).await?;
+        println!("Versions");
+        state.releases().for_each(|r| {
+            println!(
+                "{}.{}.{}",
+                r.version.major, r.version.minor, r.version.patch
+            )
+        });
+        Ok(())
+    }
+
     async fn registry_info(&self) -> Result<RegistryInfo, ClientError> {
         match self.storage.load_registry_info().await? {
             Some(reg_info) => Ok(reg_info),

--- a/crates/server/src/api/package.rs
+++ b/crates/server/src/api/package.rs
@@ -78,7 +78,7 @@ pub(crate) async fn publish(
 
     for source in body.content_sources.iter() {
         match &source.kind {
-            ContentSourceKind::HttpAnonymous(url) => {
+            ContentSourceKind::HttpAnonymous{ url } => {
                 println!("Content {} - HttpAnonymous at {}", source.digest, url);
                 if url.starts_with(&config.base_url) {
                     let response = Client::builder().build()?.head(url).send().await?;

--- a/crates/server/src/api/package.rs
+++ b/crates/server/src/api/package.rs
@@ -78,7 +78,7 @@ pub(crate) async fn publish(
 
     for source in body.content_sources.iter() {
         match &source.kind {
-            ContentSourceKind::HttpAnonymous{ url } => {
+            ContentSourceKind::HttpAnonymous { url } => {
                 println!("Content {} - HttpAnonymous at {}", source.digest, url);
                 if url.starts_with(&config.base_url) {
                     let response = Client::builder().build()?.head(url).send().await?;

--- a/src/bin/warg-cli.rs
+++ b/src/bin/warg-cli.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
 use clap::Parser;
 use std::process::exit;
-use warg_cli::commands::{InitCommand, InstallCommand, PublishCommand, RunCommand, UpdateCommand};
+use warg_cli::commands::{
+    InfoCommand, InitCommand, InstallCommand, PublishCommand, RunCommand, UpdateCommand,
+};
 use warg_client::ClientError;
 
 fn version() -> &'static str {
@@ -18,6 +20,7 @@ fn version() -> &'static str {
 )]
 #[command(version = version())]
 enum WargCli {
+    Info(InfoCommand),
     Init(InitCommand),
     Install(InstallCommand),
     Update(UpdateCommand),
@@ -29,6 +32,7 @@ enum WargCli {
 #[tokio::main]
 async fn main() -> Result<()> {
     if let Err(e) = match WargCli::parse() {
+        WargCli::Info(cmd) => cmd.exec().await,
         WargCli::Init(cmd) => cmd.exec().await,
         WargCli::Install(cmd) => cmd.exec().await,
         WargCli::Update(cmd) => cmd.exec().await,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,12 +6,14 @@ use std::path::PathBuf;
 use warg_client::Client;
 use warg_client::FileSystemStorage;
 
+mod info;
 mod init;
 mod install;
 mod publish;
 mod run;
 mod update;
 
+pub use self::info::*;
 pub use self::init::*;
 pub use self::install::*;
 pub use self::publish::*;

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -9,7 +9,7 @@ pub struct InfoCommand {
     #[clap(flatten)]
     pub common: CommonOptions,
 
-    /// The name of the package to install.
+    /// The name of the package to inspect.
     #[clap(value_name = "PACKAGE")]
     pub package: String,
 }

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -1,0 +1,24 @@
+use super::CommonOptions;
+use anyhow::Result;
+use clap::Args;
+
+/// Update all local packages in the registry.
+#[derive(Args)]
+pub struct InfoCommand {
+    /// The common command options.
+    #[clap(flatten)]
+    pub common: CommonOptions,
+
+    /// The name of the package to install.
+    #[clap(value_name = "PACKAGE")]
+    pub package: String,
+}
+
+impl InfoCommand {
+    /// Executes the command.
+    pub async fn exec(self) -> Result<()> {
+        let mut client = self.common.create_client()?;
+        client.inform(self.package).await?;
+        Ok(())
+    }
+}

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -2,7 +2,7 @@ use super::CommonOptions;
 use anyhow::Result;
 use clap::Args;
 
-/// Update all local packages in the registry.
+/// Display information about registry packages.
 #[derive(Args)]
 pub struct InfoCommand {
     /// The common command options.


### PR DESCRIPTION
Adds command analogous to `yarn info`, printing versions and other stats about a package.
Initially I'm just enabling the printing of the version numbers that exist for a given package, but could easily add any other info that anybody identifies as significant.