### PR TITLE
Implement error enums in the `api` crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,6 +3023,7 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_with",
+ "thiserror",
  "warg-crypto",
  "warg-protocol",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3128,6 +3128,7 @@ dependencies = [
  "indexmap",
  "reqwest",
  "tempfile",
+ "thiserror",
  "tokio",
  "tower-http",
  "tracing",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -11,4 +11,4 @@ warg-crypto = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
 indexmap = { workspace = true }
-thiserror.workspace = true
+thiserror = { workspace = true }

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -11,3 +11,4 @@ warg-crypto = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
 indexmap = { workspace = true }
+thiserror.workspace = true

--- a/crates/api/src/content.rs
+++ b/crates/api/src/content.rs
@@ -1,10 +1,9 @@
 //! Types relating to the content API.
 
+use crate::FromError;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use warg_crypto::hash::DynHash;
-
-use crate::FromError;
 
 /// Represents a content source.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/api/src/content.rs
+++ b/crates/api/src/content.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use warg_crypto::hash::DynHash;
 
+use crate::FromError;
+
 /// Represents a content source.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -48,4 +50,25 @@ pub enum ContentError {
     /// The service failed to persist the temporary file to the content directory.
     #[error("failed to persist temporary file to content directory")]
     FailedToPersist,
+    /// An error occurred while performing the requested operation.
+    #[error("an error occurred while performing the requested operation: {message}")]
+    Operation {
+        /// The error message.
+        message: String,
+    },
 }
+
+impl From<String> for ContentError {
+    fn from(message: String) -> Self {
+        Self::Operation { message }
+    }
+}
+
+impl FromError for ContentError {
+    fn from_error<E: std::error::Error>(error: E) -> Self {
+        Self::from(error.to_string())
+    }
+}
+
+/// Represents the result of a content API operation.
+pub type ContentResult<T> = Result<T, ContentError>;

--- a/crates/api/src/content.rs
+++ b/crates/api/src/content.rs
@@ -1,6 +1,7 @@
 //! Types relating to the content API.
 
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use warg_crypto::hash::DynHash;
 
 /// Represents a content source.
@@ -21,5 +22,36 @@ pub enum ContentSourceKind {
     HttpAnonymous {
         /// The URL of the content.
         url: String,
+    },
+}
+
+/// Represents an error from the content API.
+#[non_exhaustive]
+#[derive(Debug, Error, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum ContentError {
+    /// The service failed to allocate temporary file storage.
+    #[error("failed to allocate temporary file storage")]
+    TempFile,
+    /// The service failed to read the request body.
+    #[error("failed to read request body: {message}")]
+    BodyRead {
+        /// The error message.
+        message: String,
+    },
+    /// The service failed to write to temporary file storage.
+    #[error("an error occurred while writing to temporary file storage: {message}")]
+    IoError {
+        /// The error message.
+        message: String,
+    },
+    /// The service failed to persist the temporary file to the content directory.
+    #[error("failed to persist temporary file to content directory")]
+    FailedToPersist,
+    /// The content was not found.
+    #[error("content with digest `{digest}` was not found")]
+    ContentNotFound {
+        /// The digest of the content that was not found.
+        digest: DynHash,
     },
 }

--- a/crates/api/src/content.rs
+++ b/crates/api/src/content.rs
@@ -48,10 +48,4 @@ pub enum ContentError {
     /// The service failed to persist the temporary file to the content directory.
     #[error("failed to persist temporary file to content directory")]
     FailedToPersist,
-    /// The content was not found.
-    #[error("content with digest `{digest}` was not found")]
-    ContentNotFound {
-        /// The digest of the content that was not found.
-        digest: DynHash,
-    },
 }

--- a/crates/api/src/fetch.rs
+++ b/crates/api/src/fetch.rs
@@ -2,9 +2,10 @@
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use warg_crypto::hash::DynHash;
+use thiserror::Error;
+use warg_crypto::hash::{DynHash, Hash, Sha256};
 use warg_protocol::{
-    registry::{MapCheckpoint, RecordId},
+    registry::{LogId, MapCheckpoint, RecordId},
     ProtoEnvelopeBody, SerdeEnvelope,
 };
 
@@ -28,6 +29,43 @@ pub struct FetchResponse {
     pub operator: Vec<ProtoEnvelopeBody>,
     /// The package records appended since last known package record ids.
     pub packages: IndexMap<String, Vec<ProtoEnvelopeBody>>,
+}
+
+/// Represents an error from the fetch API.
+#[non_exhaustive]
+#[derive(Debug, Error, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum FetchError {
+    /// The provided checkpoint as not found.
+    #[error("checkpoint `{checkpoint}` not found")]
+    CheckpointNotFound {
+        /// The missing checkpoint.
+        checkpoint: Hash<Sha256>,
+    },
+    /// The provided package was not found.
+    #[error("package `{id}` not found")]
+    PackageNotFound {
+        /// The id of the missing package log.
+        id: LogId,
+    },
+    /// The provided package record was not found.
+    #[error("package record `{id}` not found")]
+    PackageRecordNotFound {
+        /// The id of the missing package record.
+        id: RecordId,
+    },
+    /// The provided operator record was not found.
+    #[error("operator record `{id}` not found")]
+    OperatorRecordNotFound {
+        /// The id of the missing operator record.
+        id: RecordId,
+    },
+    /// The provided checkpoint was invalid.
+    #[error("invalid checkpoint: {message}")]
+    InvalidCheckpoint {
+        /// The validation error message.
+        message: String,
+    },
 }
 
 /// Represents a checkpoint response.

--- a/crates/api/src/fetch.rs
+++ b/crates/api/src/fetch.rs
@@ -1,5 +1,6 @@
 //! Types relating to the fetch API.
 
+use crate::FromError;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -8,8 +9,6 @@ use warg_protocol::{
     registry::{LogId, MapCheckpoint, RecordId},
     ProtoEnvelopeBody, SerdeEnvelope,
 };
-
-use crate::FromError;
 
 /// Represents a fetch request.
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -5,3 +5,9 @@ pub mod content;
 pub mod fetch;
 pub mod package;
 pub mod proof;
+
+/// Implemented on API errors to convert from a `std::error::Error`.
+pub trait FromError {
+    /// Converts from a generic error type to an API error.
+    fn from_error<E: std::error::Error>(error: E) -> Self;
+}

--- a/crates/api/src/package.rs
+++ b/crates/api/src/package.rs
@@ -1,6 +1,6 @@
 //! Types relating to the package API.
 
-use crate::content::ContentSource;
+use crate::{content::ContentSource, FromError};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use thiserror::Error;
@@ -126,4 +126,25 @@ pub enum PackageError {
         /// The validation error message.
         message: String,
     },
+    /// An error occurred while performing the requested operation.
+    #[error("an error occurred while performing the requested operation: {message}")]
+    Operation {
+        /// The error message.
+        message: String,
+    },
 }
+
+impl From<String> for PackageError {
+    fn from(message: String) -> Self {
+        Self::Operation { message }
+    }
+}
+
+impl FromError for PackageError {
+    fn from_error<E: std::error::Error>(error: E) -> Self {
+        Self::from(error.to_string())
+    }
+}
+
+/// Represents the result of a package API operation.
+pub type PackageResult<T> = Result<T, PackageError>;

--- a/crates/api/src/package.rs
+++ b/crates/api/src/package.rs
@@ -3,7 +3,12 @@
 use crate::content::ContentSource;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use warg_protocol::{registry::MapCheckpoint, ProtoEnvelopeBody, SerdeEnvelope};
+use thiserror::Error;
+use warg_crypto::hash::{Hash, Sha256};
+use warg_protocol::{
+    registry::{LogId, MapCheckpoint, RecordId},
+    ProtoEnvelopeBody, SerdeEnvelope,
+};
 
 /// Represents a request to publish a package.
 #[derive(Serialize, Deserialize)]
@@ -48,4 +53,77 @@ pub struct RecordResponse {
     pub content_sources: Arc<Vec<ContentSource>>,
     /// The checkpoint of the record.
     pub checkpoint: Arc<SerdeEnvelope<MapCheckpoint>>,
+}
+
+/// Represents an error from the package API.
+#[non_exhaustive]
+#[derive(Debug, Error, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum PackageError {
+    /// The provided checkpoint as not found.
+    #[error("checkpoint `{checkpoint}` not found")]
+    CheckpointNotFound {
+        /// The missing checkpoint.
+        checkpoint: Hash<Sha256>,
+    },
+    /// The provided package id was invalid.
+    #[error("invalid package id: {message}")]
+    InvalidPackageId {
+        /// The validation error message.
+        message: String,
+    },
+    /// The provided record id was invalid.
+    #[error("invalid record id: {message}")]
+    InvalidRecordId {
+        /// The validation error message.
+        message: String,
+    },
+    /// The provided record was invalid.
+    #[error("invalid record: {message}")]
+    InvalidRecord {
+        /// The validation error message.
+        message: String,
+    },
+    /// The provided package was not found.
+    #[error("package `{id}` not found")]
+    PackageNotFound {
+        /// The id of the missing package log.
+        id: LogId,
+    },
+    /// The provided package record was not found.
+    #[error("package record `{id}` not found")]
+    PackageRecordNotFound {
+        /// The id of the missing package record.
+        id: RecordId,
+    },
+    /// Failed to fetch from the content source.
+    #[error("failed to fetch content: {message}")]
+    FailedToFetchContent {
+        /// The error message.
+        message: String,
+    },
+    /// An error response was returned from the content source.
+    #[error("cannot validate content source: {status_code} status returned from server")]
+    ContentFetchErrorResponse {
+        /// The error status code.
+        status_code: u16,
+    },
+    /// The provided content source is not from the current host.
+    #[error("content source `{url}` is not from the current host")]
+    ContentUrlInvalid {
+        /// The provided content source url.
+        url: String,
+    },
+    /// The provided operator record was not found.
+    #[error("operator record `{id}` not found")]
+    OperatorRecordNotFound {
+        /// The id of the missing operator record.
+        id: RecordId,
+    },
+    /// The provided checkpoint was invalid.
+    #[error("invalid checkpoint: {message}")]
+    InvalidCheckpoint {
+        /// The validation error message.
+        message: String,
+    },
 }

--- a/crates/api/src/proof.rs
+++ b/crates/api/src/proof.rs
@@ -1,12 +1,11 @@
 //! Types relating to the proof API.
 
+use crate::FromError;
 use serde::{Deserialize, Serialize};
 use serde_with::{base64::Base64, serde_as};
 use thiserror::Error;
 use warg_crypto::hash::{DynHash, Hash, Sha256};
 use warg_protocol::registry::{LogId, LogLeaf, MapCheckpoint};
-
-use crate::FromError;
 
 /// Represents a consistency proof request.
 #[derive(Serialize, Deserialize)]

--- a/crates/api/src/proof.rs
+++ b/crates/api/src/proof.rs
@@ -6,6 +6,8 @@ use thiserror::Error;
 use warg_crypto::hash::{DynHash, Hash, Sha256};
 use warg_protocol::registry::{LogId, LogLeaf, MapCheckpoint};
 
+use crate::FromError;
+
 /// Represents a consistency proof request.
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -98,4 +100,25 @@ pub enum ProofError {
         /// The found root.
         found: Hash<Sha256>,
     },
+    /// An error occurred while performing the requested operation.
+    #[error("an error occurred while performing the requested operation: {message}")]
+    Operation {
+        /// The error message.
+        message: String,
+    },
 }
+
+impl From<String> for ProofError {
+    fn from(message: String) -> Self {
+        Self::Operation { message }
+    }
+}
+
+impl FromError for ProofError {
+    fn from_error<E: std::error::Error>(error: E) -> Self {
+        Self::from(error.to_string())
+    }
+}
+
+/// Represents the result of a proof API operation.
+pub type ProofResult<T> = Result<T, ProofError>;

--- a/crates/api/src/proof.rs
+++ b/crates/api/src/proof.rs
@@ -2,8 +2,9 @@
 
 use serde::{Deserialize, Serialize};
 use serde_with::{base64::Base64, serde_as};
-use warg_crypto::hash::DynHash;
-use warg_protocol::registry::{LogLeaf, MapCheckpoint};
+use thiserror::Error;
+use warg_crypto::hash::{DynHash, Hash, Sha256};
+use warg_protocol::registry::{LogId, LogLeaf, MapCheckpoint};
 
 /// Represents a consistency proof request.
 #[derive(Serialize, Deserialize)]
@@ -46,4 +47,55 @@ pub struct InclusionResponse {
     /// The bytes of the map inclusion proof bundle.
     #[serde_as(as = "Base64")]
     pub map: Vec<u8>,
+}
+
+/// Represents an error from the proof API.
+#[non_exhaustive]
+#[derive(Debug, Error, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum ProofError {
+    /// The provided log root is invalid.
+    #[error("invalid log root: {message}")]
+    InvalidLogRoot {
+        /// The validation error message.
+        message: String,
+    },
+    /// The provided map root is invalid.
+    #[error("invalid map root: {message}")]
+    InvalidMapRoot {
+        /// The validation error message.
+        message: String,
+    },
+    /// The provided log root was not found.
+    #[error("root `{root}` was not found")]
+    RootNotFound {
+        /// The root that was not found.
+        root: Hash<Sha256>,
+    },
+    /// The provided log leaf was not found.
+    #[error("log leaf `{}:{}` was not found", .leaf.log_id, .leaf.record_id)]
+    LeafNotFound {
+        /// The leaf that was not found.
+        leaf: LogLeaf,
+    },
+    /// A failure was encountered while bundling proofs.
+    #[error("failed to bundle proofs: {message}")]
+    BundleFailure {
+        /// The failure message.
+        message: String,
+    },
+    /// Failed to prove inclusion of a package.
+    #[error("failed to prove inclusion of package `{id}`")]
+    PackageNotIncluded {
+        /// The id of the package.
+        id: LogId,
+    },
+    /// The provided root for an inclusion proof was incorrect.
+    #[error("failed to prove inclusion: found root `{found}` but was given root `{root}`")]
+    IncorrectProof {
+        /// The provided root.
+        root: Hash<Sha256>,
+        /// The found root.
+        found: Hash<Sha256>,
+    },
 }

--- a/crates/client/src/api.rs
+++ b/crates/client/src/api.rs
@@ -180,7 +180,7 @@ impl Client {
         )
         .await?;
 
-        match Self::prove_inclusion_response(response, checkpoint, &heads) {
+        match Self::validate_inclusion_response(response, checkpoint, &heads) {
             Ok(()) => Ok(()),
             Err(e) => match e.downcast::<ProofError>() {
                 Ok(e) => Err(e),
@@ -279,7 +279,7 @@ impl Client {
         )
     }
 
-    fn prove_inclusion_response(
+    fn validate_inclusion_response(
         response: InclusionResponse,
         checkpoint: &MapCheckpoint,
         heads: &[LogLeaf],

--- a/crates/client/src/api.rs
+++ b/crates/client/src/api.rs
@@ -1,24 +1,87 @@
 //! A module for Warg registry API clients.
 
-use crate::ClientError;
 use anyhow::{anyhow, bail, Context, Result};
 use bytes::Bytes;
 use futures_util::{Stream, TryStreamExt};
-use reqwest::{Body, IntoUrl, Url};
-use std::time::Duration;
+use reqwest::{Body, IntoUrl, Response, StatusCode, Url};
+use serde::de::DeserializeOwned;
+use thiserror::Error;
 use url::Host;
 use warg_api::{
-    content::ContentSource,
-    fetch::{CheckpointResponse, FetchRequest, FetchResponse},
-    package::{PendingRecordResponse, PublishRequest, RecordResponse},
-    proof::{InclusionRequest, InclusionResponse},
+    content::{ContentError, ContentSource},
+    fetch::{CheckpointResponse, FetchError, FetchRequest, FetchResponse},
+    package::{PackageError, PendingRecordResponse, PublishRequest, RecordResponse},
+    proof::{InclusionRequest, InclusionResponse, ProofError},
 };
 use warg_crypto::hash::{DynHash, Sha256};
 use warg_protocol::{
     registry::{LogLeaf, MapCheckpoint, MapLeaf},
-    ProtoEnvelopeBody, SerdeEnvelope,
+    ProtoEnvelopeBody,
 };
 use warg_transparency::{log::LogProofBundle, map::MapProofBundle};
+
+/// Represents an error from the Warg API.
+#[derive(Debug, Error)]
+pub enum ApiError {
+    /// An error from the content API.
+    #[error(transparent)]
+    Content(#[from] ContentError),
+    /// An error from the fetch API.
+    #[error(transparent)]
+    Fetch(#[from] FetchError),
+    /// An error from the package API.
+    #[error(transparent)]
+    Package(#[from] PackageError),
+    /// An error from the proof API.
+    #[error(transparent)]
+    Proof(#[from] ProofError),
+    /// Failed to send a request to the API.
+    #[error("failed to send API request: {0}")]
+    Request(#[from] reqwest::Error),
+    /// The API returned JSON that could not be deserialized by the client.
+    #[error("failed to deserialize JSON: {message} (status code: {status})")]
+    DeserializationFailed {
+        /// The status code of the response.
+        status: StatusCode,
+        /// The deserialization error message.
+        message: String,
+    },
+    /// An error was encountered in the client.
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+    /// The API returned an unknown error.
+    #[error("the server returned an unknown response (status code: {0})")]
+    Unknown(StatusCode),
+}
+
+/// Represents an result from the Warg API client.
+pub type ApiResult<T> = Result<T, ApiError>;
+
+async fn deserialize<T: DeserializeOwned>(response: Response) -> ApiResult<T> {
+    let status = response.status();
+    match response.headers().get("content-type") {
+        Some(content_type) if content_type == "application/json" => {
+            match response.json::<T>().await {
+                Ok(e) => Ok(e),
+                Err(e) => Err(ApiError::DeserializationFailed {
+                    status,
+                    message: e.to_string(),
+                }),
+            }
+        }
+        _ => Err(ApiError::Unknown(status)),
+    }
+}
+
+async fn into_result<T: DeserializeOwned, E: DeserializeOwned + Into<ApiError>>(
+    response: Response,
+) -> ApiResult<T> {
+    if response.status().is_success() {
+        return deserialize::<T>(response).await;
+    }
+
+    Err(deserialize::<E>(response).await?.into())
+}
 
 /// Represents a Warg API client for communicating with
 /// a Warg registry server.
@@ -60,25 +123,14 @@ impl Client {
     }
 
     /// Gets the latest checkpoint from the registry.
-    pub async fn latest_checkpoint(&self) -> Result<SerdeEnvelope<MapCheckpoint>, ClientError> {
+    pub async fn latest_checkpoint(&self) -> ApiResult<CheckpointResponse> {
         let url = self.0.join("fetch/checkpoint").unwrap();
         tracing::debug!("getting latest checkpoint at `{url}`");
-
-        let response = reqwest::get(url).await?;
-        if !response.status().is_success() {
-            return Err(ClientError::ApiError {
-                registry: self.0.host_str().unwrap_or("").to_string(),
-                status: response.status().as_u16(),
-                body: response.text().await?,
-            });
-        }
-
-        let response = response.json::<CheckpointResponse>().await?;
-        Ok(response.checkpoint)
+        into_result::<_, FetchError>(reqwest::get(url).await?).await
     }
 
     /// Fetches package log entries from the registry.
-    pub async fn fetch_logs(&self, request: FetchRequest) -> Result<FetchResponse, ClientError> {
+    pub async fn fetch_logs(&self, request: FetchRequest) -> ApiResult<FetchResponse> {
         let client = reqwest::Client::new();
         let response = client
             .post(self.0.join("fetch/logs").unwrap())
@@ -86,15 +138,7 @@ impl Client {
             .send()
             .await?;
 
-        if !response.status().is_success() {
-            return Err(ClientError::ApiError {
-                registry: self.0.host_str().unwrap_or("").to_string(),
-                status: response.status().as_u16(),
-                body: response.text().await?,
-            });
-        }
-
-        Ok(response.json::<FetchResponse>().await?)
+        into_result::<_, FetchError>(response).await
     }
 
     /// Publishes a new package record to the registry.
@@ -103,7 +147,7 @@ impl Client {
         package_name: &str,
         record: ProtoEnvelopeBody,
         content_sources: Vec<ContentSource>,
-    ) -> Result<RecordResponse, ClientError> {
+    ) -> ApiResult<PendingRecordResponse> {
         let client = reqwest::Client::new();
         let request = PublishRequest {
             name: package_name.to_string(),
@@ -112,72 +156,25 @@ impl Client {
         };
 
         let url = self.0.join("package").unwrap();
-
         tracing::debug!("publishing package `{package_name}` to `{url}`");
-        let response = client.post(url).json(&request).send().await?;
-
-        if !response.status().is_success() {
-            return Err(ClientError::ApiError {
-                registry: self.0.host_str().unwrap_or("").to_string(),
-                status: response.status().as_u16(),
-                body: response.text().await?,
-            });
-        }
-
-        let mut response = response.json::<PendingRecordResponse>().await?;
-
-        loop {
-            match response {
-                PendingRecordResponse::Published { record_url } => {
-                    return self.get_package_record(&record_url).await
-                }
-                PendingRecordResponse::Rejected { reason } => {
-                    return Err(ClientError::PublishRejected {
-                        package: package_name.to_string(),
-                        reason,
-                    });
-                }
-                PendingRecordResponse::Processing { status_url } => {
-                    tokio::time::sleep(Duration::from_secs(1)).await;
-                    response = self.get_pending_package_record(&status_url).await?;
-                }
-            }
-        }
+        into_result::<_, PackageError>(client.post(url).json(&request).send().await?).await
     }
 
     /// Gets the pending package record from the registry.
     pub async fn get_pending_package_record(
         &self,
         route: &str,
-    ) -> Result<PendingRecordResponse, ClientError> {
+    ) -> ApiResult<PendingRecordResponse> {
         let url = self.0.join(route).unwrap();
         tracing::debug!("getting pending package record from `{url}`");
-        let response = reqwest::get(url).await?;
-        if !response.status().is_success() {
-            return Err(ClientError::ApiError {
-                registry: self.0.host_str().unwrap_or("").to_string(),
-                status: response.status().as_u16(),
-                body: response.text().await?,
-            });
-        }
-
-        Ok(response.json::<PendingRecordResponse>().await?)
+        into_result::<_, PackageError>(reqwest::get(url).await?).await
     }
 
     /// Gets the package record from the registry.
-    pub async fn get_package_record(&self, route: &str) -> Result<RecordResponse, ClientError> {
+    pub async fn get_package_record(&self, route: &str) -> ApiResult<RecordResponse> {
         let url = self.0.join(route).unwrap();
         tracing::debug!("getting package record from `{url}`");
-        let response = reqwest::get(url).await?;
-        if !response.status().is_success() {
-            return Err(ClientError::ApiError {
-                registry: self.0.host_str().unwrap_or("").to_string(),
-                status: response.status().as_u16(),
-                body: response.text().await?,
-            });
-        }
-
-        Ok(response.json::<RecordResponse>().await?)
+        into_result::<_, PackageError>(reqwest::get(url).await?).await
     }
 
     /// Proves the inclusion of the given package log heads in the registry.
@@ -185,7 +182,7 @@ impl Client {
         &self,
         checkpoint: &MapCheckpoint,
         heads: Vec<LogLeaf>,
-    ) -> Result<(), ClientError> {
+    ) -> ApiResult<()> {
         let client = reqwest::Client::new();
         let request = InclusionRequest {
             checkpoint: checkpoint.clone(),
@@ -194,48 +191,37 @@ impl Client {
 
         let url = self.0.join("proof/inclusion").unwrap();
         tracing::debug!("proving checkpoint inclusion from `{url}`");
-        let response = client.post(url).json(&request).send().await?;
-
-        if !response.status().is_success() {
-            return Err(ClientError::ApiError {
-                registry: self.0.host_str().unwrap_or("").to_string(),
-                status: response.status().as_u16(),
-                body: response.text().await?,
-            });
-        }
-
-        let response = response.json::<InclusionResponse>().await?;
+        let response = into_result::<InclusionResponse, ProofError>(
+            client.post(url).json(&request).send().await?,
+        )
+        .await?;
 
         let log_proof_bundle: LogProofBundle<Sha256, LogLeaf> =
             LogProofBundle::decode(response.log.as_slice())?;
         let (log_data, _, log_inclusions) = log_proof_bundle.unbundle();
         for (leaf, proof) in heads.iter().zip(log_inclusions.iter()) {
-            let root = proof.evaluate_value(&log_data, leaf)?;
-            if checkpoint.log_root != root.clone().into() {
-                return Err(ClientError::Other(anyhow!(
-                    "verification proof failed: expected log root `{expected}` but found `{root}`",
-                    expected = checkpoint.log_root,
-                    root = root
-                )));
+            let found = proof
+                .evaluate_value(&log_data, leaf)
+                .map_err(|e| ApiError::Other(anyhow!(e)))?;
+            let root = checkpoint.log_root.clone().try_into()?;
+            if found != root {
+                return Err(ApiError::Proof(ProofError::IncorrectProof { root, found }));
             }
         }
 
         let map_proof_bundle: MapProofBundle<Sha256, MapLeaf> =
             MapProofBundle::decode(response.map.as_slice())?;
         let map_inclusions = map_proof_bundle.unbundle();
-        for (leaf, proof) in heads.iter().zip(map_inclusions.iter()) {
-            let root = proof.evaluate(
+        for (leaf, proof) in heads.into_iter().zip(map_inclusions.iter()) {
+            let found = proof.evaluate(
                 &leaf.log_id,
                 &MapLeaf {
                     record_id: leaf.record_id.clone(),
                 },
             );
-            if checkpoint.map_root != root.clone().into() {
-                return Err(ClientError::Other(anyhow!(
-                    "verification proof failed: expected map root `{expected}` but found `{root}`",
-                    expected = checkpoint.map_root,
-                    root = root
-                )));
+            let root = checkpoint.map_root.clone().try_into()?;
+            if found != root {
+                return Err(ApiError::Proof(ProofError::IncorrectProof { root, found }));
             }
         }
 
@@ -243,7 +229,11 @@ impl Client {
     }
 
     /// Proves consistency of a new checkpoint with a previously known checkpoint.
-    pub async fn prove_log_consistency(&self, old_root: DynHash, new_root: DynHash) -> Result<()> {
+    pub async fn prove_log_consistency(
+        &self,
+        old_root: DynHash,
+        new_root: DynHash,
+    ) -> ApiResult<()> {
         dbg!(old_root);
         dbg!(new_root);
         todo!()
@@ -254,7 +244,7 @@ impl Client {
         &self,
         digest: &DynHash,
         content: impl Into<Body>,
-    ) -> Result<String, ClientError> {
+    ) -> ApiResult<String> {
         let client = reqwest::Client::new();
 
         let url = self.content_url(digest);
@@ -263,16 +253,12 @@ impl Client {
             return Ok(url);
         }
 
-        let url = self.0.join("content").unwrap();
         tracing::debug!("uploading content to `{url}`");
-        let response = client.post(url).body(content).send().await?;
 
+        let url = self.0.join("content").unwrap();
+        let response = client.post(url).body(content).send().await?;
         if !response.status().is_success() {
-            return Err(ClientError::ApiError {
-                registry: self.0.host_str().unwrap_or("").to_string(),
-                status: response.status().as_u16(),
-                body: response.text().await?,
-            });
+            return Err(deserialize::<ContentError>(response).await?.into());
         }
 
         let location = response
@@ -289,19 +275,14 @@ impl Client {
     pub async fn download_content(
         &self,
         digest: &DynHash,
-    ) -> Result<impl Stream<Item = Result<Bytes>>, ClientError> {
+    ) -> ApiResult<impl Stream<Item = Result<Bytes>>> {
         let url = self.content_url(digest);
 
         tracing::debug!("downloading content from `{url}`");
 
         let response = reqwest::get(url).await?;
-
         if !response.status().is_success() {
-            return Err(ClientError::ApiError {
-                registry: self.0.host_str().unwrap_or("").to_string(),
-                status: response.status().as_u16(),
-                body: response.text().await?,
-            });
+            return Err(deserialize::<ContentError>(response).await?.into());
         }
 
         Ok(response.bytes_stream().map_err(|e| anyhow!(e)))

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -4,15 +4,15 @@
 
 use crate::storage::PackageInfo;
 use anyhow::Result;
-use api::ApiError;
 use reqwest::Body;
 use std::{collections::HashMap, path::PathBuf, time::Duration};
 use storage::ClientStorage;
 use thiserror::Error;
 use warg_api::{
-    content::{ContentSource, ContentSourceKind},
-    fetch::{FetchRequest, FetchResponse},
-    package::{PendingRecordResponse, RecordResponse},
+    content::{ContentError, ContentSource, ContentSourceKind},
+    fetch::{FetchError, FetchRequest, FetchResponse},
+    package::{PackageError, PendingRecordResponse, RecordResponse},
+    proof::ProofError,
 };
 use warg_crypto::{
     hash::{DynHash, Hash, Sha256},
@@ -524,9 +524,21 @@ pub enum ClientError {
         reason: String,
     },
 
-    /// An error occurred while communicating with the registry.
+    /// An error occurred while communicating with the content service.
     #[error(transparent)]
-    Api(#[from] ApiError),
+    Content(#[from] ContentError),
+
+    /// An error occurred while communicating with the fetch service.
+    #[error(transparent)]
+    Fetch(#[from] FetchError),
+
+    /// An error occurred while communicating with the package service.
+    #[error(transparent)]
+    Package(#[from] PackageError),
+
+    /// An error occurred while communicating with the proof service.
+    #[error(transparent)]
+    Proof(#[from] ProofError),
 
     /// An error occurred while performing a client operation.
     #[error("{0:?}")]

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -4,13 +4,15 @@
 
 use crate::storage::PackageInfo;
 use anyhow::Result;
+use api::ApiError;
 use reqwest::Body;
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, path::PathBuf, time::Duration};
 use storage::ClientStorage;
 use thiserror::Error;
 use warg_api::{
     content::{ContentSource, ContentSourceKind},
     fetch::{FetchRequest, FetchResponse},
+    package::{PendingRecordResponse, RecordResponse},
 };
 use warg_crypto::{
     hash::{DynHash, Hash, Sha256},
@@ -34,7 +36,7 @@ pub struct Client<T> {
 
 impl<T: ClientStorage> Client<T> {
     /// Creates a new client with the given client storage.
-    pub async fn new(storage: T) -> Result<Self, ClientError> {
+    pub async fn new(storage: T) -> ClientResult<Self> {
         let api = storage
             .load_registry_info()
             .await?
@@ -53,7 +55,7 @@ impl<T: ClientStorage> Client<T> {
     /// Submits the publish information in client storage.
     ///
     /// If there's no publishing information in client storage, an error is returned.
-    pub async fn publish(&mut self, signing_key: &signing::PrivateKey) -> Result<(), ClientError> {
+    pub async fn publish(&mut self, signing_key: &signing::PrivateKey) -> ClientResult<()> {
         let info = self
             .storage
             .load_publish_info()
@@ -82,8 +84,11 @@ impl<T: ClientStorage> Client<T> {
 
         // If we're not initializing the package, update it to the latest checkpoint to get the current head
         if !initializing {
-            self.update_checkpoint(&self.api.latest_checkpoint().await?, [&mut package])
-                .await?;
+            self.update_checkpoint(
+                &self.api.latest_checkpoint().await?.checkpoint,
+                [&mut package],
+            )
+            .await?;
         }
 
         match (initializing, package.state.head().is_some()) {
@@ -127,9 +132,14 @@ impl<T: ClientStorage> Client<T> {
         }
 
         let response = self
-            .api
-            .publish(&package.name, record.into(), sources)
+            .wait_for_publish(
+                &package.name,
+                self.api
+                    .publish(&package.name, record.into(), sources)
+                    .await?,
+            )
             .await?;
+
         self.storage.store_publish_info(None).await?;
 
         // Finally, update the checkpoint again post-publish
@@ -144,8 +154,11 @@ impl<T: ClientStorage> Client<T> {
         tracing::info!("updating all packages to latest checkpoint");
 
         let mut updating = self.storage.load_packages().await?;
-        self.update_checkpoint(&self.api.latest_checkpoint().await?, &mut updating)
-            .await?;
+        self.update_checkpoint(
+            &self.api.latest_checkpoint().await?.checkpoint,
+            &mut updating,
+        )
+        .await?;
 
         Ok(())
     }
@@ -165,8 +178,11 @@ impl<T: ClientStorage> Client<T> {
             );
         }
 
-        self.update_checkpoint(&self.api.latest_checkpoint().await?, &mut updating)
-            .await?;
+        self.update_checkpoint(
+            &self.api.latest_checkpoint().await?.checkpoint,
+            &mut updating,
+        )
+        .await?;
 
         Ok(())
     }
@@ -302,7 +318,7 @@ impl<T: ClientStorage> Client<T> {
                     for record in records {
                         let record: ProtoEnvelope<package::PackageRecord> = record.try_into()?;
                         package.state.validate(&record).map_err(|inner| {
-                            ClientError::PackageValidationError {
+                            ClientError::PackageValidationFailed {
                                 package: name.clone(),
                                 inner,
                             }
@@ -342,8 +358,11 @@ impl<T: ClientStorage> Client<T> {
             }
             None => {
                 let mut info = PackageInfo::new(name);
-                self.update_checkpoint(&self.api.latest_checkpoint().await?, [&mut info])
-                    .await?;
+                self.update_checkpoint(
+                    &self.api.latest_checkpoint().await?.checkpoint,
+                    [&mut info],
+                )
+                .await?;
 
                 Ok(info)
             }
@@ -370,6 +389,31 @@ impl<T: ClientStorage> Client<T> {
                     .ok_or_else(|| ClientError::ContentNotFound {
                         digest: digest.clone(),
                     })
+            }
+        }
+    }
+
+    async fn wait_for_publish(
+        &self,
+        name: &str,
+        mut response: PendingRecordResponse,
+    ) -> ClientResult<RecordResponse> {
+        loop {
+            match response {
+                PendingRecordResponse::Published { record_url } => {
+                    return Ok(self.api.get_package_record(&record_url).await?);
+                }
+                PendingRecordResponse::Rejected { reason } => {
+                    return Err(ClientError::PublishRejected {
+                        package: name.to_string(),
+                        reason,
+                    });
+                }
+                PendingRecordResponse::Processing { status_url } => {
+                    // TODO: make the wait configurable
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    response = self.api.get_pending_package_record(&status_url).await?;
+                }
             }
         }
     }
@@ -450,7 +494,7 @@ pub enum ClientError {
 
     /// The package failed validation.
     #[error("package `{package}` failed validation: {inner}.")]
-    PackageValidationError {
+    PackageValidationFailed {
         /// The package that failed validation.
         package: String,
         /// The validation error.
@@ -481,25 +525,13 @@ pub enum ClientError {
     },
 
     /// An error occurred while communicating with the registry.
-    #[error("an error occurred while communicating with registry {registry} ({status}): {body}")]
-    ApiError {
-        /// The registry server that returned the error.
-        registry: String,
-        /// The status code of the API error.
-        status: u16,
-        /// The response body.
-        body: String,
-    },
-
-    /// An error occurred while proving the inclusion of a package in a registry checkpoint.
     #[error(transparent)]
-    InclusionProof(#[from] warg_transparency::log::InclusionProofError),
+    Api(#[from] ApiError),
 
-    /// An error occurred while communicating with the registry.
-    #[error(transparent)]
-    Reqwest(#[from] reqwest::Error),
-
-    /// An error occurred while performing a client operation
+    /// An error occurred while performing a client operation.
     #[error("{0:?}")]
     Other(#[from] anyhow::Error),
 }
+
+/// Represents the result of a client operation.
+pub type ClientResult<T> = Result<T, ClientError>;

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -21,3 +21,4 @@ tower-http = { workspace = true, features = ["trace"]}
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 indexmap = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/server/src/api/content.rs
+++ b/crates/server/src/api/content.rs
@@ -96,5 +96,5 @@ async fn upload_content(
         .map_err(|_| ContentApiError::FailedToPersist)?;
 
     let location = format!("{}/{}", orig_uri.path().trim_end_matches('/'), dest_name);
-    Ok((StatusCode::ACCEPTED, [(LOCATION, location)]))
+    Ok((StatusCode::CREATED, [(LOCATION, location)]))
 }

--- a/crates/server/src/api/content.rs
+++ b/crates/server/src/api/content.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use axum::{
     body::boxed,
     debug_handler,
@@ -22,8 +21,8 @@ pub struct ContentConfig {
 }
 
 impl ContentConfig {
-    pub fn build_router(self) -> Result<Router> {
-        Ok(Router::new()
+    pub fn build_router(self) -> Router {
+        Router::new()
             .route("/", post(upload_content))
             .fallback_service(get_service(ServeDir::new(&self.content_path)).handle_error(
                 |err| async move {
@@ -31,7 +30,7 @@ impl ContentConfig {
                     StatusCode::INTERNAL_SERVER_ERROR
                 },
             ))
-            .with_state(Arc::new(self)))
+            .with_state(Arc::new(self))
     }
 }
 

--- a/crates/server/src/api/content.rs
+++ b/crates/server/src/api/content.rs
@@ -32,12 +32,8 @@ struct ContentApiError(ContentError);
 
 impl IntoResponse for ContentApiError {
     fn into_response(self) -> axum::response::Response {
-        let status = match &self.0 {
-            ContentError::ContentNotFound { .. } => StatusCode::NOT_FOUND,
-            // Currently all other responses from the content service are 500s
-            _ => StatusCode::INTERNAL_SERVER_ERROR,
-        };
-
+        // Currently all responses from the content service are 500s
+        let status = StatusCode::INTERNAL_SERVER_ERROR;
         (status, Json(self.0)).into_response()
     }
 }

--- a/crates/server/src/api/content.rs
+++ b/crates/server/src/api/content.rs
@@ -1,18 +1,17 @@
 use axum::{
-    body::boxed,
     debug_handler,
     extract::{BodyStream, OriginalUri, State},
     http::{header::LOCATION, StatusCode},
     response::IntoResponse,
     routing::{get_service, post},
-    Router,
+    Json, Router,
 };
 use futures::StreamExt;
 use std::{path::PathBuf, sync::Arc};
 use tempfile::NamedTempFile;
-use thiserror::Error;
 use tokio::io::AsyncWriteExt;
 use tower_http::services::ServeDir;
+use warg_api::content::ContentError;
 use warg_crypto::hash::{Digest, Sha256};
 
 #[derive(Debug)]
@@ -24,40 +23,22 @@ impl ContentConfig {
     pub fn build_router(self) -> Router {
         Router::new()
             .route("/", post(upload_content))
-            .fallback_service(get_service(ServeDir::new(&self.content_path)).handle_error(
-                |err| async move {
-                    tracing::error!("ServeDir error: {err}");
-                    StatusCode::INTERNAL_SERVER_ERROR
-                },
-            ))
+            .fallback_service(get_service(ServeDir::new(&self.content_path)))
             .with_state(Arc::new(self))
     }
 }
 
-#[derive(Debug, Error)]
-pub(crate) enum ContentApiError {
-    #[error("failed to allocate temporary file storage")]
-    TempFile,
-    #[error("failed to read request body: {0}")]
-    BodyRead(axum::Error),
-    #[error("an error occurred while writing to temporary file storage: {0}")]
-    IoError(tokio::io::Error),
-    #[error("failed to persist temporary file to content directory")]
-    FailedToPersist,
-}
+struct ContentApiError(ContentError);
 
 impl IntoResponse for ContentApiError {
     fn into_response(self) -> axum::response::Response {
-        let status = match self {
-            Self::TempFile | Self::BodyRead(_) | Self::IoError(_) | Self::FailedToPersist => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
+        let status = match &self.0 {
+            ContentError::ContentNotFound { .. } => StatusCode::NOT_FOUND,
+            // Currently all other responses from the content service are 500s
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
 
-        axum::response::Response::builder()
-            .status(status)
-            .body(boxed(self.to_string()))
-            .unwrap()
+        (status, Json(self.0)).into_response()
     }
 }
 
@@ -68,7 +49,7 @@ async fn upload_content(
     mut stream: BodyStream,
 ) -> Result<impl IntoResponse, ContentApiError> {
     let tmp_path = NamedTempFile::new_in(&state.content_path)
-        .map_err(|_| ContentApiError::TempFile)?
+        .map_err(|_| ContentApiError(ContentError::TempFile))?
         .into_temp_path();
 
     tracing::debug!("Uploading to {tmp_path:?}");
@@ -76,24 +57,24 @@ async fn upload_content(
     let mut hasher = Sha256::new();
     let mut tmp_file = tokio::fs::File::create(&tmp_path)
         .await
-        .map_err(|_| ContentApiError::TempFile)?;
-    while let Some(chunk) = stream
-        .next()
-        .await
-        .transpose()
-        .map_err(ContentApiError::BodyRead)?
-    {
+        .map_err(|_| ContentApiError(ContentError::TempFile))?;
+    while let Some(chunk) = stream.next().await.transpose().map_err(|e| {
+        ContentApiError(ContentError::BodyRead {
+            message: e.to_string(),
+        })
+    })? {
         hasher.update(&chunk);
-        tmp_file
-            .write_all(&chunk)
-            .await
-            .map_err(ContentApiError::IoError)?;
+        tmp_file.write_all(&chunk).await.map_err(|e| {
+            ContentApiError(ContentError::IoError {
+                message: e.to_string(),
+            })
+        })?;
     }
 
     let dest_name = format!("sha256-{:x}", hasher.finalize());
     tmp_path
         .persist(state.content_path.join(&dest_name))
-        .map_err(|_| ContentApiError::FailedToPersist)?;
+        .map_err(|_| ContentApiError(ContentError::FailedToPersist))?;
 
     let location = format!("{}/{}", orig_uri.path().trim_end_matches('/'), dest_name);
     Ok((StatusCode::CREATED, [(LOCATION, location)]))

--- a/crates/server/src/api/content.rs
+++ b/crates/server/src/api/content.rs
@@ -1,6 +1,6 @@
-use crate::AnyError;
 use anyhow::Result;
 use axum::{
+    body::boxed,
     debug_handler,
     extract::{BodyStream, OriginalUri, State},
     http::{header::LOCATION, StatusCode},
@@ -11,6 +11,7 @@ use axum::{
 use futures::StreamExt;
 use std::{path::PathBuf, sync::Arc};
 use tempfile::NamedTempFile;
+use thiserror::Error;
 use tokio::io::AsyncWriteExt;
 use tower_http::services::ServeDir;
 use warg_crypto::hash::{Digest, Sha256};
@@ -34,25 +35,67 @@ impl ContentConfig {
     }
 }
 
+#[derive(Debug, Error)]
+pub(crate) enum ContentApiError {
+    #[error("failed to allocate temporary file storage")]
+    TempFile,
+    #[error("failed to read request body: {0}")]
+    BodyRead(axum::Error),
+    #[error("an error occurred while writing to temporary file storage: {0}")]
+    IoError(tokio::io::Error),
+    #[error("failed to persist temporary file to content directory")]
+    FailedToPersist,
+}
+
+impl IntoResponse for ContentApiError {
+    fn into_response(self) -> axum::response::Response {
+        let status = match self {
+            Self::TempFile | Self::BodyRead(_) | Self::IoError(_) | Self::FailedToPersist => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        };
+
+        axum::response::Response::builder()
+            .status(status)
+            .body(boxed(self.to_string()))
+            .unwrap()
+    }
+}
+
 #[debug_handler]
 async fn upload_content(
     State(state): State<Arc<ContentConfig>>,
     OriginalUri(orig_uri): OriginalUri,
     mut stream: BodyStream,
-) -> Result<impl IntoResponse, AnyError> {
-    let tmp_path = NamedTempFile::new_in(&state.content_path)?.into_temp_path();
+) -> Result<impl IntoResponse, ContentApiError> {
+    let tmp_path = NamedTempFile::new_in(&state.content_path)
+        .map_err(|_| ContentApiError::TempFile)?
+        .into_temp_path();
+
     tracing::debug!("Uploading to {tmp_path:?}");
 
     let mut hasher = Sha256::new();
-    let mut tmp_file = tokio::fs::File::create(&tmp_path).await?;
-    while let Some(chunk) = stream.next().await.transpose()? {
+    let mut tmp_file = tokio::fs::File::create(&tmp_path)
+        .await
+        .map_err(|_| ContentApiError::TempFile)?;
+    while let Some(chunk) = stream
+        .next()
+        .await
+        .transpose()
+        .map_err(ContentApiError::BodyRead)?
+    {
         hasher.update(&chunk);
-        tmp_file.write_all(&chunk).await?;
+        tmp_file
+            .write_all(&chunk)
+            .await
+            .map_err(ContentApiError::IoError)?;
     }
 
     let dest_name = format!("sha256-{:x}", hasher.finalize());
-    tmp_path.persist(state.content_path.join(&dest_name))?;
+    tmp_path
+        .persist(state.content_path.join(&dest_name))
+        .map_err(|_| ContentApiError::FailedToPersist)?;
 
     let location = format!("{}/{}", orig_uri.path().trim_end_matches('/'), dest_name);
-    Ok((StatusCode::CREATED, [(LOCATION, location)]))
+    Ok((StatusCode::ACCEPTED, [(LOCATION, location)]))
 }

--- a/crates/server/src/api/fetch.rs
+++ b/crates/server/src/api/fetch.rs
@@ -1,5 +1,4 @@
 use crate::services::core::{CoreService, CoreServiceError};
-use anyhow::Result;
 use axum::{
     debug_handler,
     extract::State,

--- a/crates/server/src/api/package.rs
+++ b/crates/server/src/api/package.rs
@@ -1,5 +1,4 @@
 use crate::services::core::{CoreService, CoreServiceError, PackageRecordInfo, RecordState};
-use anyhow::{Error, Result};
 use axum::body::boxed;
 use axum::{
     debug_handler,
@@ -58,7 +57,7 @@ pub(crate) enum PackageApiError {
     #[error("invalid record id: {0}")]
     InvalidRecordId(DynHashParseError),
     #[error("invalid record: {0}")]
-    InvalidRecord(Error),
+    InvalidRecord(anyhow::Error),
     #[error("package record `{0}` not found")]
     RecordNotFound(RecordId),
     #[error("failed to fetch content: {0}")]

--- a/crates/server/src/api/package.rs
+++ b/crates/server/src/api/package.rs
@@ -1,5 +1,5 @@
 use crate::services::core::{CoreService, CoreServiceError, PackageRecordInfo, RecordState};
-use axum::body::boxed;
+use anyhow::Error;
 use axum::{
     debug_handler,
     extract::{Path, State},
@@ -11,12 +11,12 @@ use axum::{
 use reqwest::Client;
 use std::str::FromStr;
 use std::sync::Arc;
-use thiserror::Error;
+use warg_api::package::PackageError;
 use warg_api::{
     content::ContentSourceKind,
     package::{PendingRecordResponse, PublishRequest, RecordResponse},
 };
-use warg_crypto::hash::{DynHash, DynHashParseError, Sha256};
+use warg_crypto::hash::{DynHash, Sha256};
 use warg_protocol::registry::{LogId, RecordId};
 
 #[derive(Clone)]
@@ -50,46 +50,46 @@ fn pending_record_url(package_id: &LogId, record_id: &RecordId) -> String {
     format!("/package/{package_id}/pending/{record_id}")
 }
 
-#[derive(Debug, Error)]
-pub(crate) enum PackageApiError {
-    #[error("invalid package id: {0}")]
-    InvalidPackageId(DynHashParseError),
-    #[error("invalid record id: {0}")]
-    InvalidRecordId(DynHashParseError),
-    #[error("invalid record: {0}")]
-    InvalidRecord(anyhow::Error),
-    #[error("package record `{0}` not found")]
-    RecordNotFound(RecordId),
-    #[error("failed to fetch content: {0}")]
-    FailedToFetchContent(reqwest::Error),
-    #[error("cannot validate content source: {0} status returned from server")]
-    ContentFetchErrorResponse(StatusCode),
-    #[error("content source `{0}` is not from the current host")]
-    ContentUrlInvalid(String),
-    #[error("{0}")]
-    CoreService(#[from] CoreServiceError),
+struct PackageApiError(PackageError);
+
+impl From<CoreServiceError> for PackageApiError {
+    fn from(value: CoreServiceError) -> Self {
+        Self(match value {
+            CoreServiceError::CheckpointNotFound(checkpoint) => {
+                PackageError::CheckpointNotFound { checkpoint }
+            }
+            CoreServiceError::PackageNotFound(id) => PackageError::PackageNotFound { id },
+            CoreServiceError::PackageRecordNotFound(id) => {
+                PackageError::PackageRecordNotFound { id }
+            }
+            CoreServiceError::OperatorRecordNotFound(id) => {
+                PackageError::OperatorRecordNotFound { id }
+            }
+            CoreServiceError::InvalidCheckpoint(e) => PackageError::InvalidCheckpoint {
+                message: e.to_string(),
+            },
+        })
+    }
 }
 
 impl IntoResponse for PackageApiError {
     fn into_response(self) -> axum::response::Response {
-        let status = match &self {
-            Self::InvalidPackageId(_)
-            | Self::InvalidRecordId(_)
-            | Self::InvalidRecord(_)
-            | Self::FailedToFetchContent(_)
-            | Self::ContentFetchErrorResponse(_)
-            | Self::ContentUrlInvalid(_) => StatusCode::BAD_REQUEST,
-            Self::RecordNotFound(_) => StatusCode::NOT_FOUND,
-            Self::CoreService(_) => match self {
-                Self::CoreService(e) => return e.into_response(),
-                _ => unreachable!(),
-            },
+        let status = match &self.0 {
+            PackageError::InvalidPackageId { .. }
+            | PackageError::InvalidRecordId { .. }
+            | PackageError::InvalidRecord { .. }
+            | PackageError::FailedToFetchContent { .. }
+            | PackageError::ContentFetchErrorResponse { .. }
+            | PackageError::ContentUrlInvalid { .. }
+            | PackageError::InvalidCheckpoint { .. } => StatusCode::BAD_REQUEST,
+            PackageError::PackageNotFound { .. }
+            | PackageError::PackageRecordNotFound { .. }
+            | PackageError::CheckpointNotFound { .. }
+            | PackageError::OperatorRecordNotFound { .. } => StatusCode::NOT_FOUND,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
 
-        axum::response::Response::builder()
-            .status(status)
-            .body(boxed(self.to_string()))
-            .unwrap()
+        (status, Json(self.0)).into_response()
     }
 }
 
@@ -111,15 +111,15 @@ fn create_pending_response(
 }
 
 #[debug_handler]
-pub(crate) async fn publish(
+async fn publish(
     State(config): State<Config>,
     Json(body): Json<PublishRequest>,
 ) -> Result<Json<PendingRecordResponse>, PackageApiError> {
-    let record = Arc::new(
-        body.record
-            .try_into()
-            .map_err(PackageApiError::InvalidRecord)?,
-    );
+    let record = Arc::new(body.record.try_into().map_err(|e: Error| {
+        PackageApiError(PackageError::InvalidRecord {
+            message: e.to_string(),
+        })
+    })?);
     let record_id = RecordId::package_record::<Sha256>(&record);
 
     for source in body.content_sources.iter() {
@@ -128,18 +128,28 @@ pub(crate) async fn publish(
                 if url.starts_with(&config.base_url) {
                     let response = Client::builder()
                         .build()
-                        .map_err(PackageApiError::FailedToFetchContent)?
+                        .map_err(|e| {
+                            PackageApiError(PackageError::FailedToFetchContent {
+                                message: e.to_string(),
+                            })
+                        })?
                         .head(url)
                         .send()
                         .await
-                        .map_err(PackageApiError::FailedToFetchContent)?;
+                        .map_err(|e| {
+                            PackageApiError(PackageError::FailedToFetchContent {
+                                message: e.to_string(),
+                            })
+                        })?;
                     if !response.status().is_success() {
-                        return Err(PackageApiError::ContentFetchErrorResponse(
-                            response.status(),
-                        ));
+                        return Err(PackageApiError(PackageError::ContentFetchErrorResponse {
+                            status_code: response.status().as_u16(),
+                        }));
                     }
                 } else {
-                    return Err(PackageApiError::ContentUrlInvalid(url.clone()));
+                    return Err(PackageApiError(PackageError::ContentUrlInvalid {
+                        url: url.clone(),
+                    }));
                 }
             }
         }
@@ -160,20 +170,28 @@ pub(crate) async fn publish(
 }
 
 #[debug_handler]
-pub(crate) async fn get_record(
+async fn get_record(
     State(config): State<Config>,
-    Path((log_id, record_id)): Path<(String, String)>,
+    Path((package_id, record_id)): Path<(String, String)>,
 ) -> Result<Json<RecordResponse>, PackageApiError> {
-    let log_id: LogId = DynHash::from_str(&log_id)
-        .map_err(PackageApiError::InvalidPackageId)?
+    let package_id: LogId = DynHash::from_str(&package_id)
+        .map_err(|e| {
+            PackageApiError(PackageError::InvalidPackageId {
+                message: e.to_string(),
+            })
+        })?
         .into();
     let record_id: RecordId = DynHash::from_str(&record_id)
-        .map_err(PackageApiError::InvalidRecordId)?
+        .map_err(|e| {
+            PackageApiError(PackageError::InvalidRecordId {
+                message: e.to_string(),
+            })
+        })?
         .into();
 
     match config
         .core_service
-        .get_package_record_info(log_id, record_id.clone())
+        .get_package_record_info(package_id, record_id.clone())
         .await?
     {
         PackageRecordInfo {
@@ -185,20 +203,30 @@ pub(crate) async fn get_record(
             content_sources,
             checkpoint,
         })),
-        _ => Err(PackageApiError::RecordNotFound(record_id)),
+        _ => Err(PackageApiError(PackageError::PackageRecordNotFound {
+            id: record_id,
+        })),
     }
 }
 
 #[debug_handler]
-pub(crate) async fn get_pending_record(
+async fn get_pending_record(
     State(config): State<Config>,
     Path((package_id, record_id)): Path<(String, String)>,
 ) -> Result<Json<PendingRecordResponse>, PackageApiError> {
     let package_id: LogId = DynHash::from_str(&package_id)
-        .map_err(PackageApiError::InvalidPackageId)?
+        .map_err(|e| {
+            PackageApiError(PackageError::InvalidPackageId {
+                message: e.to_string(),
+            })
+        })?
         .into();
     let record_id: RecordId = DynHash::from_str(&record_id)
-        .map_err(PackageApiError::InvalidRecordId)?
+        .map_err(|e| {
+            PackageApiError(PackageError::InvalidRecordId {
+                message: e.to_string(),
+            })
+        })?
         .into();
 
     let status = config

--- a/crates/server/src/api/proof.rs
+++ b/crates/server/src/api/proof.rs
@@ -1,5 +1,4 @@
 use crate::services::data::{self, DataServiceError};
-use anyhow::{Error, Result};
 use axum::{
     body::boxed, debug_handler, extract::State, http::StatusCode, response::IntoResponse,
     routing::post, Json, Router,
@@ -37,13 +36,13 @@ impl Config {
 #[derive(Debug, Error)]
 pub(crate) enum ProofApiError {
     #[error("invalid old root: {0}")]
-    InvalidOldRoot(Error),
+    InvalidOldRoot(anyhow::Error),
     #[error("invalid new root: {0}")]
-    InvalidNewRoot(Error),
+    InvalidNewRoot(anyhow::Error),
     #[error("invalid log root: {0}")]
-    InvalidLogRoot(Error),
+    InvalidLogRoot(anyhow::Error),
     #[error("invalid map root: {0}")]
-    InvalidMapRoot(Error),
+    InvalidMapRoot(anyhow::Error),
     #[error("{0}")]
     DataService(#[from] DataServiceError),
 }

--- a/crates/server/src/api/proof.rs
+++ b/crates/server/src/api/proof.rs
@@ -1,10 +1,11 @@
-use crate::{services::data, AnyError};
-use anyhow::Result;
+use crate::services::data::{self, DataServiceError};
+use anyhow::{Error, Result};
 use axum::{
-    debug_handler, extract::State, http::StatusCode, response::IntoResponse, routing::post, Json,
-    Router,
+    body::boxed, debug_handler, extract::State, http::StatusCode, response::IntoResponse,
+    routing::post, Json, Router,
 };
 use std::sync::Arc;
+use thiserror::Error;
 use tokio::sync::RwLock;
 use warg_api::proof::{
     ConsistencyRequest, ConsistencyResponse, InclusionRequest, InclusionResponse,
@@ -33,47 +34,91 @@ impl Config {
     }
 }
 
+#[derive(Debug, Error)]
+pub(crate) enum ProofApiError {
+    #[error("invalid old root: {0}")]
+    InvalidOldRoot(Error),
+    #[error("invalid new root: {0}")]
+    InvalidNewRoot(Error),
+    #[error("invalid log root: {0}")]
+    InvalidLogRoot(Error),
+    #[error("invalid map root: {0}")]
+    InvalidMapRoot(Error),
+    #[error("{0}")]
+    DataService(#[from] DataServiceError),
+}
+
+impl IntoResponse for ProofApiError {
+    fn into_response(self) -> axum::response::Response {
+        let status = match self {
+            Self::InvalidOldRoot(_)
+            | Self::InvalidNewRoot(_)
+            | Self::InvalidLogRoot(_)
+            | Self::InvalidMapRoot(_) => StatusCode::BAD_REQUEST,
+            Self::DataService(_) => match self {
+                Self::DataService(e) => return e.into_response(),
+                _ => unreachable!(),
+            },
+        };
+
+        axum::response::Response::builder()
+            .status(status)
+            .body(boxed(self.to_string()))
+            .unwrap()
+    }
+}
+
 #[debug_handler]
 pub(crate) async fn prove_consistency(
     State(config): State<Config>,
     Json(body): Json<ConsistencyRequest>,
-) -> Result<impl IntoResponse, AnyError> {
+) -> Result<Json<ConsistencyResponse>, ProofApiError> {
     let log = config.log.as_ref().read().await;
 
-    let old_root: Hash<Sha256> = body.old_root.try_into()?;
-    let new_root: Hash<Sha256> = body.new_root.try_into()?;
+    let old_root: Hash<Sha256> = body
+        .old_root
+        .try_into()
+        .map_err(ProofApiError::InvalidOldRoot)?;
+    let new_root: Hash<Sha256> = body
+        .new_root
+        .try_into()
+        .map_err(ProofApiError::InvalidNewRoot)?;
 
-    let bundle = log.consistency(old_root, new_root)?;
+    let bundle = log.consistency(&old_root, &new_root)?;
 
-    let response = ConsistencyResponse {
+    Ok(Json(ConsistencyResponse {
         proof: bundle.encode(),
-    };
-
-    Ok((StatusCode::OK, Json(response)))
+    }))
 }
 
 #[debug_handler]
 pub(crate) async fn prove_inclusion(
     State(config): State<Config>,
     Json(body): Json<InclusionRequest>,
-) -> Result<impl IntoResponse, AnyError> {
-    let log_root: Hash<Sha256> = body.checkpoint.log_root.try_into()?;
-    let map_root = body.checkpoint.map_root.try_into()?;
+) -> Result<Json<InclusionResponse>, ProofApiError> {
+    let log_root = body
+        .checkpoint
+        .log_root
+        .try_into()
+        .map_err(ProofApiError::InvalidLogRoot)?;
+    let map_root = body
+        .checkpoint
+        .map_root
+        .try_into()
+        .map_err(ProofApiError::InvalidMapRoot)?;
 
     let log_bundle = {
         let log = config.log.as_ref().read().await;
-        log.inclusion(log_root, body.heads.as_slice())?
+        log.inclusion(&log_root, body.heads.as_slice())?
     };
 
     let map_bundle = {
         let map = config.map.as_ref().read().await;
-        map.inclusion(map_root, body.heads.as_slice())?
+        map.inclusion(&map_root, body.heads.as_slice())?
     };
 
-    let response = InclusionResponse {
+    Ok(Json(InclusionResponse {
         log: log_bundle.encode(),
         map: map_bundle.encode(),
-    };
-
-    Ok((StatusCode::OK, Json(response)))
+    }))
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use api::content::ContentConfig;
 use axum::{body::Body, http::Request, Router};
 use std::{fmt, path::PathBuf};
@@ -42,10 +41,10 @@ impl Config {
         self
     }
 
-    pub fn build_router(self) -> Result<Router> {
+    pub fn build_router(self) -> Router {
         let mut router = Router::new();
         if let Some(upload) = self.content {
-            router = router.nest("/content", upload.build_router()?);
+            router = router.nest("/content", upload.build_router());
         }
 
         let (core, data) = services::init(self.signing_key);
@@ -53,7 +52,7 @@ impl Config {
         let fetch_config = api::fetch::Config::new(core);
         let proof_config = api::proof::Config::new(data.log_data, data.map_data);
 
-        Ok(router
+        router
             .nest("/package", package_config.build_router())
             .nest("/fetch", fetch_config.build_router())
             .nest("/proof", proof_config.build_router())
@@ -68,6 +67,6 @@ impl Config {
                             .level(Level::INFO)
                             .latency_unit(LatencyUnit::Micros),
                     ),
-            ))
+            )
     }
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,24 +1,17 @@
-pub mod api;
-mod policy;
-pub mod services;
-
-use std::{fmt, path::PathBuf};
-
 use anyhow::Result;
-use axum::{
-    body::Body,
-    http::{Request, StatusCode},
-    response::IntoResponse,
-    Router,
-};
-
 use api::content::ContentConfig;
+use axum::{body::Body, http::Request, Router};
+use std::{fmt, path::PathBuf};
 use tower_http::{
     trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer},
     LatencyUnit,
 };
 use tracing::{Level, Span};
 use warg_crypto::signing::PrivateKey;
+
+pub mod api;
+mod policy;
+pub mod services;
 
 pub struct Config {
     base_url: String,
@@ -76,25 +69,5 @@ impl Config {
                             .latency_unit(LatencyUnit::Micros),
                     ),
             ))
-    }
-}
-
-pub(crate) struct AnyError(anyhow::Error);
-
-impl<E: Into<anyhow::Error>> From<E> for AnyError {
-    fn from(err: E) -> Self {
-        Self(err.into())
-    }
-}
-
-impl IntoResponse for AnyError {
-    fn into_response(self) -> axum::response::Response {
-        tracing::error!("Handler failed: {}", self.0);
-        // TODO: don't return arbitrary errors to clients
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Error: {}", self.0),
-        )
-            .into_response()
     }
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,8 +1,6 @@
-use std::{net::SocketAddr, path::PathBuf};
-
 use anyhow::Result;
 use clap::Parser;
-
+use std::{net::SocketAddr, path::PathBuf};
 use tracing_subscriber::filter::LevelFilter;
 use warg_server::Config;
 
@@ -50,7 +48,7 @@ async fn main() -> Result<()> {
     }
     tracing::debug!("Config: {config:?}");
 
-    let router = config.build_router()?;
+    let router = config.build_router();
 
     tracing::info!("Listening on {:?}", args.listen);
     axum::Server::try_bind(&args.listen)?

--- a/crates/server/src/services/core.rs
+++ b/crates/server/src/services/core.rs
@@ -1,5 +1,3 @@
-use axum::{body::boxed, response::IntoResponse};
-use reqwest::StatusCode;
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
@@ -121,23 +119,6 @@ pub enum CoreServiceError {
     OperatorRecordNotFound(RecordId),
     #[error("invalid checkpoint: {0}")]
     InvalidCheckpoint(anyhow::Error),
-}
-
-impl IntoResponse for CoreServiceError {
-    fn into_response(self) -> axum::response::Response {
-        let status = match &self {
-            Self::CheckpointNotFound(_)
-            | Self::PackageNotFound(_)
-            | Self::PackageRecordNotFound(_)
-            | Self::OperatorRecordNotFound(_) => StatusCode::NOT_FOUND,
-            Self::InvalidCheckpoint(_) => StatusCode::BAD_REQUEST,
-        };
-
-        axum::response::Response::builder()
-            .status(status)
-            .body(boxed(self.to_string()))
-            .unwrap()
-    }
 }
 
 pub struct CoreService {

--- a/crates/server/src/services/core.rs
+++ b/crates/server/src/services/core.rs
@@ -1,4 +1,3 @@
-use anyhow::Error;
 use axum::{body::boxed, response::IntoResponse};
 use reqwest::StatusCode;
 use std::{
@@ -121,7 +120,7 @@ pub enum CoreServiceError {
     #[error("operator record `{0}` not found")]
     OperatorRecordNotFound(RecordId),
     #[error("invalid checkpoint: {0}")]
-    InvalidCheckpoint(Error),
+    InvalidCheckpoint(anyhow::Error),
 }
 
 impl IntoResponse for CoreServiceError {

--- a/crates/server/src/services/data/map.rs
+++ b/crates/server/src/services/data/map.rs
@@ -47,7 +47,7 @@ impl MapData {
         for LogLeaf { log_id, record_id } in leaves {
             let proof = map
                 .prove(log_id)
-                .ok_or_else(|| DataServiceError::ProofFailure(log_id.clone()))?;
+                .ok_or_else(|| DataServiceError::PackageNotIncluded(log_id.clone()))?;
             let leaf = MapLeaf {
                 record_id: record_id.clone(),
             };
@@ -55,7 +55,7 @@ impl MapData {
             if found_root != *root {
                 return Err(DataServiceError::IncorrectProof {
                     root: root.clone(),
-                    expected: found_root,
+                    found: found_root,
                 });
             }
             proofs.push(proof);

--- a/crates/server/src/services/data/mod.rs
+++ b/crates/server/src/services/data/mod.rs
@@ -1,15 +1,51 @@
+use super::transparency::VerifiableMap;
+use anyhow::Error;
+use axum::{body::boxed, response::IntoResponse};
+use reqwest::StatusCode;
 use std::sync::Arc;
-
+use thiserror::Error;
 use tokio::{
     sync::{mpsc::Receiver, RwLock},
     task::JoinHandle,
 };
-use warg_protocol::registry::LogLeaf;
-
-use super::transparency::VerifiableMap;
+use warg_crypto::hash::{Hash, Sha256};
+use warg_protocol::registry::{LogId, LogLeaf};
 
 pub mod log;
 pub mod map;
+
+#[derive(Debug, Error)]
+pub enum DataServiceError {
+    #[error("root `{0}` was not found")]
+    RootNotFound(Hash<Sha256>),
+    #[error("log leaf `{}:{}` was not found", .0.log_id, .0.record_id)]
+    LeafNotFound(LogLeaf),
+    #[error("failed to bundle proofs: {0}")]
+    BundleFailure(Error),
+    #[error("failed to proof inclusion of package `{0}`")]
+    ProofFailure(LogId),
+    #[error("incorrect proof: expected `{expected}`, got `{root}`")]
+    IncorrectProof {
+        root: Hash<Sha256>,
+        expected: Hash<Sha256>,
+    },
+}
+
+impl IntoResponse for DataServiceError {
+    fn into_response(self) -> axum::response::Response {
+        let status = match &self {
+            Self::RootNotFound(_) | Self::LeafNotFound(_) => StatusCode::NOT_FOUND,
+            Self::BundleFailure(_) | Self::ProofFailure(_) | Self::IncorrectProof { .. } => {
+                StatusCode::BAD_REQUEST
+            }
+        };
+
+        axum::response::Response::builder()
+            .status(status)
+            .body(boxed(self.to_string()))
+            .unwrap()
+    }
+}
 
 pub struct Input {
     pub log_data: log::ProofData,

--- a/crates/server/src/services/data/mod.rs
+++ b/crates/server/src/services/data/mod.rs
@@ -1,5 +1,4 @@
 use super::transparency::VerifiableMap;
-use anyhow::Error;
 use axum::{body::boxed, response::IntoResponse};
 use reqwest::StatusCode;
 use std::sync::Arc;
@@ -21,7 +20,7 @@ pub enum DataServiceError {
     #[error("log leaf `{}:{}` was not found", .0.log_id, .0.record_id)]
     LeafNotFound(LogLeaf),
     #[error("failed to bundle proofs: {0}")]
-    BundleFailure(Error),
+    BundleFailure(anyhow::Error),
     #[error("failed to proof inclusion of package `{0}`")]
     ProofFailure(LogId),
     #[error("incorrect proof: expected `{expected}`, got `{root}`")]

--- a/src/bin/warg-cli.rs
+++ b/src/bin/warg-cli.rs
@@ -65,7 +65,7 @@ fn describe_client_error(e: &ClientError) {
                 "error: package `{package}` is not initialized; use the `--init` option when publishing"
             )
         }
-        ClientError::PackageValidationError { package, inner } => {
+        ClientError::PackageValidationFailed { package, inner } => {
             eprintln!("error: the log for package `{package}` is invalid: {inner:?}")
         }
         ClientError::PackageLogEmpty { package } => {


### PR DESCRIPTION
This PR adds error enumerations to the `api` crate that are shared between the server and client implementations.

Both the client and server crates have been updated to use the error enums.