### PR TITLE
Improve fetch API error message when fetching logs for nonexistent package.

### DIFF
--- a/crates/api/src/fetch.rs
+++ b/crates/api/src/fetch.rs
@@ -51,6 +51,12 @@ pub enum FetchError {
         /// The missing checkpoint.
         checkpoint: Hash<Sha256>,
     },
+    /// The provided package name was not found.
+    #[error("package `{name}` not found")]
+    PackageNameNotFound {
+        /// The missing package name.
+        name: String,
+    },
     /// The provided package was not found.
     #[error("package `{id}` not found")]
     PackageNotFound {

--- a/crates/api/src/package.rs
+++ b/crates/api/src/package.rs
@@ -85,6 +85,12 @@ pub enum PackageError {
         message: String,
     },
     /// The provided package was not found.
+    #[error("package `{name}` not found")]
+    PackageNameNotFound {
+        /// The name of the missing package log.
+        name: String,
+    },
+    /// The provided package was not found.
     #[error("package `{id}` not found")]
     PackageNotFound {
         /// The id of the missing package log.

--- a/crates/server/src/api/fetch.rs
+++ b/crates/server/src/api/fetch.rs
@@ -38,6 +38,7 @@ impl From<CoreServiceError> for FetchApiError {
                 FetchError::CheckpointNotFound { checkpoint }
             }
             CoreServiceError::PackageNotFound(id) => FetchError::PackageNotFound { id },
+            CoreServiceError::PackageNameNotFound(name) => FetchError::PackageNameNotFound { name },
             CoreServiceError::PackageRecordNotFound(id) => FetchError::PackageRecordNotFound { id },
             CoreServiceError::OperatorRecordNotFound(id) => {
                 FetchError::OperatorRecordNotFound { id }
@@ -53,6 +54,7 @@ impl IntoResponse for FetchApiError {
     fn into_response(self) -> axum::response::Response {
         let status = match &self.0 {
             FetchError::CheckpointNotFound { .. }
+            | FetchError::PackageNameNotFound { .. }
             | FetchError::PackageNotFound { .. }
             | FetchError::PackageRecordNotFound { .. }
             | FetchError::OperatorRecordNotFound { .. } => StatusCode::NOT_FOUND,

--- a/crates/server/src/api/package.rs
+++ b/crates/server/src/api/package.rs
@@ -58,6 +58,9 @@ impl From<CoreServiceError> for PackageApiError {
             CoreServiceError::CheckpointNotFound(checkpoint) => {
                 PackageError::CheckpointNotFound { checkpoint }
             }
+            CoreServiceError::PackageNameNotFound(name) => {
+                PackageError::PackageNameNotFound { name }
+            }
             CoreServiceError::PackageNotFound(id) => PackageError::PackageNotFound { id },
             CoreServiceError::PackageRecordNotFound(id) => {
                 PackageError::PackageRecordNotFound { id }
@@ -82,7 +85,8 @@ impl IntoResponse for PackageApiError {
             | PackageError::ContentFetchErrorResponse { .. }
             | PackageError::ContentUrlInvalid { .. }
             | PackageError::InvalidCheckpoint { .. } => StatusCode::BAD_REQUEST,
-            PackageError::PackageNotFound { .. }
+            PackageError::PackageNameNotFound { .. }
+            | PackageError::PackageNotFound { .. }
             | PackageError::PackageRecordNotFound { .. }
             | PackageError::CheckpointNotFound { .. }
             | PackageError::OperatorRecordNotFound { .. } => StatusCode::NOT_FOUND,


### PR DESCRIPTION
This commit improves the error message displayed when fetching a log for a nonexistent package.

Previously it would print out the log id of the missing package, which isn't very friendly.

This commit allows the fetch API to return an error of the package name, specifically for fetching logs.