### PR TITLE
Add an `openapi.yaml` file to the server implementation.

### DIFF
--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -687,8 +687,14 @@ components:
       description: A request to append a record to a package log.
       additionalProperties: false
       required:
+        - name
         - record
       properties:
+        name:
+          type: string
+          description: The name of the package log being appended to.
+          maxLength: 128
+          example: wasi:http
         record:
           "$ref": "#/components/schemas/EnvelopeBody"
           description: The package record being appended to the log.

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -201,7 +201,7 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PublishPackageRecordResponse"
+                "$ref": "#/components/schemas/PackageRecord"
         default:
           description: An error occurred when processing the request.
           content:
@@ -508,7 +508,6 @@ paths:
           content:
             application/json:
               schema:
-                type: object
                 oneOf:
                   - "$ref": "#/components/schemas/BundleFailureError"
                 discriminator:
@@ -578,7 +577,6 @@ paths:
           content:
             application/json:
               schema:
-                type: object
                 oneOf:
                   - "$ref": "#/components/schemas/PackageNotIncludedError"
                   - "$ref": "#/components/schemas/IncorrectProofError"
@@ -734,23 +732,6 @@ components:
           maxItems: 128
           items:
             "$ref": "#/components/schemas/ContentSource"
-    PublishPackageRecordResponse:
-      type: object
-      description: A response containing the accepted package record.
-      additionalProperties: false
-      required:
-        - recordUrl
-        - record
-      properties:
-        recordUrl:
-          type: string
-          description: The URL of the package record.
-          example: https://example.com/package/sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c/sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
-          format: uri
-        record:
-          "$ref": "#/components/schemas/PackageRecord"
-          description: |
-            The package record that was accepted and is awaiting processing by the registry.
     PackageLog:
       type: object
       description: Information of a package log.
@@ -771,20 +752,27 @@ components:
           "$ref": "#/components/schemas/PackageMetadata"
           description: The metadata for the package log.
     PackageRecord:
-      type: object
       description: A package log record.
-      oneOf:
-        - "$ref": "#/components/schemas/SourcingRecord"
-        - "$ref": "#/components/schemas/ProcessingRecord"
-        - "$ref": "#/components/schemas/RejectedRecord"
-        - "$ref": "#/components/schemas/PublishedRecord"
-      discriminator:
-        propertyName: state
-        mapping:
-          sourcing: "#/components/schemas/SourcingRecord"
-          processing: "#/components/schemas/ProcessingRecord"
-          rejected: "#/components/schemas/RejectedRecord"
-          published: "#/components/schemas/PublishedRecord"
+      allOf:
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              "$ref": "#/components/schemas/AnyHash"
+              description: The record identifier.
+        - oneOf:
+            - "$ref": "#/components/schemas/SourcingRecord"
+            - "$ref": "#/components/schemas/ProcessingRecord"
+            - "$ref": "#/components/schemas/RejectedRecord"
+            - "$ref": "#/components/schemas/PublishedRecord"
+          discriminator:
+            propertyName: state
+            mapping:
+              sourcing: "#/components/schemas/SourcingRecord"
+              processing: "#/components/schemas/ProcessingRecord"
+              rejected: "#/components/schemas/RejectedRecord"
+              published: "#/components/schemas/PublishedRecord"
     PackageRecordContentSourcesRequest:
       type: object
       description: A request to set the content sources of a package record.
@@ -877,6 +865,7 @@ components:
       description: The package record is sourcing content.
       required:
         - state
+        - uploadSupported
         - missingContent
       properties:
         state:
@@ -884,14 +873,10 @@ components:
           description: The state of the package record.
           enum: [sourcing]
           example: sourcing
-        contentUrl:
-          type: string
-          description: |
-            The URL for posting record content.
-
-            If this field is not present, clients should update the content sources of the package record.
-          example: https://example.com/package/sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c/sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c/content
-          format: uri
+        uploadSupported:
+          type: boolean
+          description: Whether or not direct content uploading is supported by the registry.
+          example: true
         missingContent:
           type: array
           description: The array of content digests that are missing for the package record.
@@ -1054,7 +1039,6 @@ components:
           maxLength: 107
           example: "ecdsa-p256:MEUCIQCzWZBW6ux9LecP66Y+hjmLZTP/hZVz7puzlPTXcRT2wwIgQZO7nxP0nugtw18MwHZ26ROFWcJmgCtKOguK031Y1D0="
     ContentSource:
-      type: object
       description: A known content source.
       oneOf:
         - "$ref": "#/components/schemas/HttpSource"

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -315,6 +315,15 @@ paths:
               example:
                 status: 405
                 message: the package record is not in the `sourcing` state
+        "422":
+          description: The content was rejected by server policy.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                status: 422
+                message: the content is not valid WebAssembly
         default:
           description: An error occurred when processing the request.
           content:

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -783,10 +783,10 @@ components:
       properties:
         from:
           $ref: "#/components/schemas/AnyHash"
-          description: The starting checkpoint hash.
+          description: The starting log root hash.
         to:
           $ref: "#/components/schemas/AnyHash"
-          description: The ending checkpoint hash.
+          description: The ending log root hash.
     ProveConsistencyResponse:
       type: object
       description: A response containing the consistency proof bundle.

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -144,6 +144,13 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/PackageRecord"
+        "403":
+          description: |
+            The key used to sign the record was not authorized to publish a record to the log.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "501":
           description: |
             The server does not support publishing package records with explicitly

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -708,6 +708,9 @@ components:
       type: object
       description: A response containing the accepted package record.
       additionalProperties: false
+      required:
+        - recordUrl
+        - record
       properties:
         recordUrl:
           type: string

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -278,7 +278,7 @@ paths:
                 $ref: "#/components/schemas/Error"
     patch:
       summary: Update content sources of a package record.
-      operationId: addPackageRecordContentSources
+      operationId: updatePackageRecordContentSources
       security: []
       tags:
         - package
@@ -712,11 +712,8 @@ components:
           "$ref": "#/components/schemas/EnvelopeBody"
           description: The package record being published to the log.
         contentSources:
-          type: array
+          "$ref": "#/components/schemas/ContentSourceMap"
           description: The list of known content sources.
-          maxItems: 128
-          items:
-            "$ref": "#/components/schemas/ContentSource"
     PackageLog:
       type: object
       description: Information of a package log.
@@ -766,13 +763,8 @@ components:
         - contentSources
       properties:
         contentSources:
-          type: array
-          description: The list of known content sources.
-          minItems: 1
-          maxItems: 128
-          items:
-            "$ref": "#/components/schemas/ContentSource"
-        # TODO: sign the array entries so that only an accepted publisher can set the content sources?
+          "$ref": "#/components/schemas/ContentSourceMap"
+          description: The map of content digest to sources.
     ProveConsistencyRequest:
       type: object
       description: A request to prove the consistency of the registry.
@@ -916,11 +908,8 @@ components:
           "$ref": "#/components/schemas/EnvelopeBody"
           description: The package record.
         contentSources:
-          type: array
+          "$ref": "#/components/schemas/ContentSourceMap"
           description: The content sources for the package record.
-          maxItems: 128
-          items:
-            "$ref": "#/components/schemas/ContentSource"
     PackageMetadata:
       type: object
       additionalProperties: false
@@ -1026,6 +1015,21 @@ components:
           minLength: 107
           maxLength: 107
           example: "ecdsa-p256:MEUCIQCzWZBW6ux9LecP66Y+hjmLZTP/hZVz7puzlPTXcRT2wwIgQZO7nxP0nugtw18MwHZ26ROFWcJmgCtKOguK031Y1D0="
+    ContentSourceMap:
+      type: object
+      description: The map of content digest to sources.
+      patternProperties:
+        "^sha256:[a-f0-9]{64,64}$":
+          type: array
+          items:
+            "$ref": "#/components/schemas/ContentSource"
+          description: The array of sources for the content digest.
+          minItems: 1
+          maxItems: 128
+      example:
+        ? "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded9773"
+        : - type: http
+            url: https://example.com/7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded9773
     ContentSource:
       description: A known content source.
       oneOf:
@@ -1043,9 +1047,6 @@ components:
           description: The type of content source.
           enum: [http]
           example: http
-        digest:
-          "$ref": "#/components/schemas/AnyHash"
-          description: The digest of the content.
         url:
           type: string
           description: The URL of the content.

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -90,7 +90,7 @@ paths:
                 $ref: "#/components/schemas/Error"
   /fetch/checkpoint:
     get:
-      summary: Get latest registry checkpoint
+      summary: Fetch latest registry checkpoint
       operationId: getCheckpoint
       security: []
       tags:
@@ -103,47 +103,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/FetchCheckpointResponse"
-        default:
-          description: An error occurred when processing the request.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-  /package:
-    post:
-      summary: Create a package log.
-      operationId: createPackageLog
-      security: []
-      tags:
-        - package
-      description: |
-        Creates a new empty package log.
-
-        The signature must be from a key that is authorized to create a package log for the given name.
-
-        The signature is of the package name; the package metadata is not signed.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CreatePackageLogRequest"
-      responses:
-        "200":
-          description: A new package log was created.
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/PackageLog"
-        "303":
-          description: The package log already exists.
-          headers:
-            Location:
-              description: The URL of the existing package log.
-              schema:
-                type: string
-                format: uri
-                example: https://example.com/package/sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
         default:
           description: An error occurred when processing the request.
           content:
@@ -202,44 +161,6 @@ paths:
                     "$ref": "#/components/schemas/AnyHash"
                     description: |
                       The identifier of the entity that was not found.
-        default:
-          description: An error occurred when processing the request.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-    patch:
-      summary: Update the information of a package log.
-      operationId: updatePackageLog
-      security: []
-      tags:
-        - package
-      description: |
-        Updates the information of a package log.
-
-        The signature must be from a key that is authorized to update the package log.
-
-        The signature is of the package log identifier; the package metadata is not signed.
-      parameters:
-        - name: logId
-          in: path
-          description: The package log identifier.
-          required: true
-          schema:
-            "$ref": "#/components/schemas/AnyHash"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/UpdatePackageLogRequest"
-      responses:
-        "200":
-          description: The package log information was updated.
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/PackageLog"
         default:
           description: An error occurred when processing the request.
           content:
@@ -674,11 +595,11 @@ components:
       description: A request to fetch logs from the registrsy.
       additionalProperties: false
       required:
-        - root
+        - checkpoint
       properties:
-        root:
+        checkpoint:
           $ref: "#/components/schemas/AnyHash"
-          description: The root checkpoint of the registry.
+          description: The checkpoint of the registry to fetch from.
         maximumRecords:
           type: integer
           description: The maximum number of operator or package records to return.
@@ -720,7 +641,7 @@ components:
           example: false
         operator:
           type: array
-          description: The operator log records for the given root checkpoint since the last known record.
+          description: The operator log records for the given checkpoint since the last known record.
           maxItems: 1000
           items:
             $ref: "#/components/schemas/EnvelopeBody"
@@ -730,7 +651,7 @@ components:
           patternProperties:
             "^sha256:[a-f0-9]{64,64}$":
               type: array
-              description: The package log records for the given root checkpoint since the last known record.
+              description: The package log records for the given checkpoint since the last known record.
               maxItems: 1000
               items:
                 $ref: "#/components/schemas/EnvelopeBody"
@@ -761,33 +682,6 @@ components:
                 contents:
                   $ref: "#/components/schemas/MapCheckpoint"
             - $ref: "#/components/schemas/Signature"
-    CreatePackageLogRequest:
-      type: object
-      description: A request to create a new package log.
-      allOf:
-        - type: object
-          required:
-            - name
-          properties:
-            name:
-              type: string
-              description: The name of the package log.
-              maxLength: 128
-              example: wasi:http
-            metadata:
-              "$ref": "#/components/schemas/PackageMetadata"
-              description: The metadata for the package log.
-        - $ref: "#/components/schemas/Signature"
-    UpdatePackageLogRequest:
-      type: object
-      description: A request to update information for a package log.
-      allOf:
-        - type: object
-          properties:
-            metadata:
-              "$ref": "#/components/schemas/PackageMetadata"
-              description: The metadata to update for the package log.
-        - $ref: "#/components/schemas/Signature"
     AppendPackageRecordRequest:
       type: object
       description: A request to append a record to a package log.
@@ -823,7 +717,6 @@ components:
       description: Information of a package log.
       additionalProperties: false
       required:
-        - name
         - id
       properties:
         name:

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -557,9 +557,7 @@ components:
       type: string
       description: Represents a supported hash.
       example: sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
-      pattern: ^(sha256:[a-f0-9]{64,64})$
-      minLength: 71
-      maxLength: 71
+      pattern: ^[a-z0-9-]+:[a-f0-9]+$
     FetchLogsRequest:
       type: object
       description: A request to fetch logs from the registry.
@@ -588,7 +586,7 @@ components:
 
             If the last package record identifier is null, records are returned from the start of the log.
           patternProperties:
-            "^sha256:[a-f0-9]{64,64}$":
+            "^[a-z0-9-]+:[a-f0-9]+$":
               $ref: "#/components/schemas/AnyHash"
               description: The last known package record identifier.
               nullable: true
@@ -619,7 +617,7 @@ components:
           type: object
           description: The map of package log identifier to package records.
           patternProperties:
-            "^sha256:[a-f0-9]{64,64}$":
+            "^[a-z0-9-]+:[a-f0-9]+$":
               type: array
               description: The package log records for the given checkpoint since the last known record.
               maxItems: 1000
@@ -900,16 +898,14 @@ components:
           description: The signing key identifier.
         signature:
           type: string
-          description: The bytes of the signature.
-          pattern: ^(ecdsa-p256:(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{4}|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{2}={2}))$
-          minLength: 107
-          maxLength: 107
+          description: The algorithm-prefixed bytes of the signature (base64 encoded).
+          pattern: ^[a-z0-9-]+:(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{4}|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{2}={2})$
           example: "ecdsa-p256:MEUCIQCzWZBW6ux9LecP66Y+hjmLZTP/hZVz7puzlPTXcRT2wwIgQZO7nxP0nugtw18MwHZ26ROFWcJmgCtKOguK031Y1D0="
     ContentSourceMap:
       type: object
       description: The map of content digest to sources.
       patternProperties:
-        "^sha256:[a-f0-9]{64,64}$":
+        "^[a-z0-9-]+:[a-f0-9]+$":
           type: array
           items:
             "$ref": "#/components/schemas/ContentSource"

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -169,17 +169,17 @@ paths:
                 $ref: "#/components/schemas/Error"
   /package/{logId}/record:
     post:
-      summary: Append a new package log record.
-      operationId: appendPackageRecord
+      summary: Publish a new record to a package log.
+      operationId: publishPackageRecord
       security: []
       tags:
         - package
       description: |
-        Attempts to append a new record to a package log.
+        Attempts to publish a new record to a package log.
 
-        Appending package records is an asynchronous operation.
+        Publishing package records is an asynchronous operation.
 
-        The record must be signed by a key that is authorized to append records to the package log.
+        The record must be signed by a key that is authorized to modify the package log.
 
         TODO: document package record format.
       parameters:
@@ -194,14 +194,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AppendPackageRecordRequest"
+              $ref: "#/components/schemas/PublishPackageRecordRequest"
       responses:
         "202":
           description: The package record was accepted.
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/AppendPackageRecordResponse"
+                "$ref": "#/components/schemas/PublishPackageRecordResponse"
         default:
           description: An error occurred when processing the request.
           content:
@@ -222,7 +222,7 @@ paths:
           * `sourcing`: The package record needs content sources.
           * `processing`: The package record is being processed.
           * `rejected`: The package record was rejected.
-          * `appended`: The package record was appended to the log.
+          * `published`: The package record was published to the log.
 
         TODO: document package record format.
       parameters:
@@ -712,9 +712,9 @@ components:
                 contents:
                   $ref: "#/components/schemas/MapCheckpoint"
             - $ref: "#/components/schemas/Signature"
-    AppendPackageRecordRequest:
+    PublishPackageRecordRequest:
       type: object
-      description: A request to append a record to a package log.
+      description: A request to publish a record to a package log.
       additionalProperties: false
       required:
         - name
@@ -722,19 +722,19 @@ components:
       properties:
         name:
           type: string
-          description: The name of the package log being appended to.
+          description: The name of the package log being published to.
           maxLength: 128
           example: wasi:http
         record:
           "$ref": "#/components/schemas/EnvelopeBody"
-          description: The package record being appended to the log.
+          description: The package record being published to the log.
         contentSources:
           type: array
           description: The list of known content sources.
           maxItems: 128
           items:
             "$ref": "#/components/schemas/ContentSource"
-    AppendPackageRecordResponse:
+    PublishPackageRecordResponse:
       type: object
       description: A response containing the accepted package record.
       additionalProperties: false
@@ -777,14 +777,14 @@ components:
         - "$ref": "#/components/schemas/SourcingRecord"
         - "$ref": "#/components/schemas/ProcessingRecord"
         - "$ref": "#/components/schemas/RejectedRecord"
-        - "$ref": "#/components/schemas/AppendedRecord"
+        - "$ref": "#/components/schemas/PublishedRecord"
       discriminator:
         propertyName: state
         mapping:
           sourcing: "#/components/schemas/SourcingRecord"
           processing: "#/components/schemas/ProcessingRecord"
           rejected: "#/components/schemas/RejectedRecord"
-          appended: "#/components/schemas/AppendedRecord"
+          published: "#/components/schemas/PublishedRecord"
     PackageRecordContentSourcesRequest:
       type: object
       description: A request to set the content sources of a package record.
@@ -926,9 +926,9 @@ components:
           type: string
           description: The reason the package record was rejected.
           example: the first entry of the log is not `init`
-    AppendedRecord:
+    PublishedRecord:
       type: object
-      description: A record that has been appended to the log.
+      description: A record that has been published to the log.
       required:
         - state
         - checkpoint
@@ -937,8 +937,8 @@ components:
         state:
           type: string
           description: The state of the package record.
-          enum: [appended]
-          example: appended
+          enum: [published]
+          example: published
         checkpoint:
           description: The checkpoint of the record.
           allOf:

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -503,6 +503,18 @@ paths:
                     "$ref": "#/components/schemas/AnyHash"
                     description: |
                       The identifier of the entity that was not found.
+        "422":
+          description: The proof bundle could not be generated.
+          content:
+            application/json:
+              schema:
+                type: object
+                oneOf:
+                  - "$ref": "#/components/schemas/BundleFailureError"
+                discriminator:
+                  propertyName: reason
+                  mapping:
+                    failure: "#/components/schemas/BundleFailureError"
         default:
           description: An error occurred when processing the request.
           content:
@@ -553,12 +565,30 @@ paths:
                   type:
                     type: string
                     description: The type of entity that was not found.
-                    enum: [checkpoint, log, record]
+                    enum: [checkpoint, leaf]
                     example: checkpoint
                   id:
                     "$ref": "#/components/schemas/AnyHash"
                     description: |
                       The identifier of the entity that was not found.
+
+                      For leafs, the format is `<logId>|<recordId>`.
+        "422":
+          description: The proof bundle could not be generated.
+          content:
+            application/json:
+              schema:
+                type: object
+                oneOf:
+                  - "$ref": "#/components/schemas/PackageNotIncludedError"
+                  - "$ref": "#/components/schemas/IncorrectProofError"
+                  - "$ref": "#/components/schemas/BundleFailureError"
+                discriminator:
+                  propertyName: reason
+                  mapping:
+                    packageNotIncluded: "#/components/schemas/PackageNotIncludedError"
+                    incorrectProof: "#/components/schemas/IncorrectProofError"
+                    failure: "#/components/schemas/BundleFailureError"
         default:
           description: An error occurred when processing the request.
           content:
@@ -592,14 +622,14 @@ components:
       maxLength: 71
     FetchLogsRequest:
       type: object
-      description: A request to fetch logs from the registrsy.
+      description: A request to fetch logs from the registry.
       additionalProperties: false
       required:
         - checkpoint
       properties:
         checkpoint:
           $ref: "#/components/schemas/AnyHash"
-          description: The checkpoint of the registry to fetch from.
+          description: The registry checkpoint hash to fetch from.
         maximumRecords:
           type: integer
           description: The maximum number of operator or package records to return.
@@ -780,10 +810,10 @@ components:
       properties:
         from:
           $ref: "#/components/schemas/AnyHash"
-          description: The starting checkpoint.
+          description: The starting checkpoint hash.
         to:
           $ref: "#/components/schemas/AnyHash"
-          description: The ending checkpoint.
+          description: The ending checkpoint hash.
     ProveConsistencyResponse:
       type: object
       description: A response containing the consistency proof bundle.
@@ -1049,3 +1079,49 @@ components:
           description: The URL of the content.
           example: https://example.com/contents.wasm
           format: uri
+    PackageNotIncludedError:
+      type: object
+      additionalProperties: false
+      required:
+        - reason
+        - logId
+      properties:
+        reason:
+          type: string
+          description: The reason why the bundle could not be generated.
+          enum: [packageNotIncluded]
+        logId:
+          "$ref": "#/components/schemas/AnyHash"
+          description: The identifier of the log that was not included.
+    IncorrectProofError:
+      type: object
+      additionalProperties: false
+      required:
+        - reason
+        - root
+        - found
+      properties:
+        reason:
+          type: string
+          description: The reason why the bundle could not be generated.
+          enum: [incorrectProof]
+        root:
+          "$ref": "#/components/schemas/AnyHash"
+          description: The map or log root hash from the checkpoint that was provided.
+        found:
+          "$ref": "#/components/schemas/AnyHash"
+          description: The hash that was found in the proof.
+    BundleFailureError:
+      type: object
+      additionalProperties: false
+      required:
+        - reason
+        - message
+      properties:
+        reason:
+          type: string
+          description: The reason why the bundle could not be generated.
+          enum: [failure]
+        message:
+          type: string
+          description: The failure error message.

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -109,64 +109,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  /package/{logId}:
-    get:
-      summary: Get package log information.
-      operationId: getPackageLogInformation
-      security: []
-      tags:
-        - package
-      description: |
-        Gets the information of a package log.
-
-        A package log identifier is a hash of the following concatenation:
-          * A prefix of the byte string `WARG-PACKAGE-LOG-ID-V0`
-          * The package name
-      parameters:
-        - name: logId
-          in: path
-          description: The package log identifier.
-          required: true
-          schema:
-            "$ref": "#/components/schemas/AnyHash"
-      responses:
-        "200":
-          description: The package information.
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/PackageLog"
-        "404":
-          description: A requested entity was not found.
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: false
-                required:
-                  - status
-                  - type
-                  - id
-                properties:
-                  status:
-                    type: integer
-                    description: The HTTP status code for the error.
-                    example: 404
-                  type:
-                    type: string
-                    description: The type of entity that was not found.
-                    enum: [log]
-                    example: log
-                  id:
-                    "$ref": "#/components/schemas/AnyHash"
-                    description: |
-                      The identifier of the entity that was not found.
-        default:
-          description: An error occurred when processing the request.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
   /package/{logId}/record:
     post:
       summary: Publish a new record to a package log.
@@ -714,25 +656,6 @@ components:
         contentSources:
           "$ref": "#/components/schemas/ContentSourceMap"
           description: The list of known content sources.
-    PackageLog:
-      type: object
-      description: Information of a package log.
-      additionalProperties: false
-      required:
-        - id
-      properties:
-        name:
-          type: string
-          description: The name of the package log.
-          format: package-name
-          maxLength: 128
-          example: wasi:http
-        id:
-          "$ref": "#/components/schemas/AnyHash"
-          description: The identifier of the package log.
-        metadata:
-          "$ref": "#/components/schemas/PackageMetadata"
-          description: The metadata for the package log.
     PackageRecord:
       description: A package log record.
       allOf:
@@ -910,39 +833,6 @@ components:
         contentSources:
           "$ref": "#/components/schemas/ContentSourceMap"
           description: The content sources for the package record.
-    PackageMetadata:
-      type: object
-      additionalProperties: false
-      description: The metadata for a registry package.
-      properties:
-        description:
-          type: string
-          description: The description of the package.
-          maxLength: 1024
-          example: A package for the WebAssembly System Interface (WASI) HTTP API.
-        homepage:
-          type: string
-          description: The URL of the package homepage.
-          format: uri
-          example: https://example.com/wasi/http
-        repository:
-          type: string
-          description: The URL of the package repository.
-          format: uri
-          example: https://example.com/wasi/http.git
-        license:
-          type: string
-          description: The SPDX license identifier of the package.
-          example: Apache-2.0
-        keywords:
-          type: array
-          description: The list of keywords for the package.
-          maxItems: 128
-          items:
-            type: string
-            description: A keyword for the package.
-            maxLength: 128
-            example: wasi
     MapCheckpoint:
       type: object
       description: |

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -1143,3 +1143,4 @@ components:
         message:
           type: string
           description: The failure error message.
+          example: bundle must contain proofs for the same root

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -1,0 +1,1149 @@
+openapi: 3.1.0
+
+info:
+  version: 1.0.0
+  title: Warg Registry API
+  description: |
+    [warg](https://warg.io/) is an open source protocol for WebAssembly component registries.
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
+# The Warg APIs currently do not use an authentication scheme
+# Publishing requires that entries are signed with an acceptable key
+x-42c-no-authentication: true
+
+# Ignore warnings regarding strings in responses not having a pattern or maximum length
+x-42c-skipIssues:
+  - v3-schema-response-string-pattern
+  - v3-schema-response-string-maxlength
+
+tags:
+  - name: fetch
+    description: API for fetching checkpoints and logs from the registry.
+  - name: package
+    description: API for managing package logs in the registry.
+  - name: proof
+    description: API for proving the integrity of the registry.
+
+servers:
+  - url: http://localhost:8090/v1
+    description: Local development server
+
+paths:
+  /fetch/logs:
+    post:
+      summary: Fetch registry logs
+      operationId: fetchLogs
+      security: []
+      tags:
+        - fetch
+      description: |
+        Fetch the operator and packages logs from the registry.
+
+        TODO: document operator record format.
+
+        TODO: document package record format.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FetchLogsRequest"
+      responses:
+        "200":
+          description: The logs were successfully fetched.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FetchLogsResponse"
+        "404":
+          description: A requested entity was not found.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required:
+                  - status
+                  - type
+                  - id
+                properties:
+                  status:
+                    type: integer
+                    description: The HTTP status code for the error.
+                    example: 404
+                  type:
+                    type: string
+                    description: The type of entity that was not found.
+                    enum: [checkpoint, log, record]
+                    example: checkpoint
+                  id:
+                    type: string
+                    description: The identifier of the entity that was not found.
+                    example: sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
+        default:
+          description: An error occurred when processing the request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /fetch/checkpoint:
+    get:
+      summary: Get latest registry checkpoint
+      operationId: getCheckpoint
+      security: []
+      tags:
+        - fetch
+      description: Fetch the latest checkpoint from the registry.
+      responses:
+        "200":
+          description: The checkpoint was successfully fetched.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FetchCheckpointResponse"
+        default:
+          description: An error occurred when processing the request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /package:
+    post:
+      summary: Create a package log.
+      operationId: createPackageLog
+      security: []
+      tags:
+        - package
+      description: |
+        Creates a new empty package log.
+
+        The signature must be from a key that is authorized to create a package log for the given name.
+
+        The signature is of the package name; the package metadata is not signed.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreatePackageLogRequest"
+      responses:
+        "200":
+          description: A new package log was created.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PackageLog"
+        "303":
+          description: The package log already exists.
+          headers:
+            Location:
+              description: The URL of the existing package log.
+              schema:
+                type: string
+                format: uri
+                example: https://example.com/package/sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
+        default:
+          description: An error occurred when processing the request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /package/{logId}:
+    get:
+      summary: Get package log information.
+      operationId: getPackageLogInformation
+      security: []
+      tags:
+        - package
+      description: |
+        Gets the information of a package log.
+
+        A package log identifier is a hash of the following concatenation:
+          * A prefix of the byte string `WARG-PACKAGE-LOG-ID-V0`
+          * The package name
+      parameters:
+        - name: logId
+          in: path
+          description: The package log identifier.
+          required: true
+          schema:
+            "$ref": "#/components/schemas/AnyHash"
+      responses:
+        "200":
+          description: The package information.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PackageLog"
+        "404":
+          description: A requested entity was not found.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required:
+                  - status
+                  - type
+                  - id
+                properties:
+                  status:
+                    type: integer
+                    description: The HTTP status code for the error.
+                    example: 404
+                  type:
+                    type: string
+                    description: The type of entity that was not found.
+                    enum: [log]
+                    example: log
+                  id:
+                    "$ref": "#/components/schemas/AnyHash"
+                    description: |
+                      The identifier of the entity that was not found.
+        default:
+          description: An error occurred when processing the request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    patch:
+      summary: Update the information of a package log.
+      operationId: updatePackageLog
+      security: []
+      tags:
+        - package
+      description: |
+        Updates the information of a package log.
+
+        The signature must be from a key that is authorized to update the package log.
+
+        The signature is of the package log identifier; the package metadata is not signed.
+      parameters:
+        - name: logId
+          in: path
+          description: The package log identifier.
+          required: true
+          schema:
+            "$ref": "#/components/schemas/AnyHash"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdatePackageLogRequest"
+      responses:
+        "200":
+          description: The package log information was updated.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PackageLog"
+        default:
+          description: An error occurred when processing the request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /package/{logId}/record:
+    post:
+      summary: Append a new package log record.
+      operationId: appendPackageRecord
+      security: []
+      tags:
+        - package
+      description: |
+        Attempts to append a new record to a package log.
+
+        Appending package records is an asynchronous operation.
+
+        The record must be signed by a key that is authorized to append records to the package log.
+
+        TODO: document package record format.
+      parameters:
+        - name: logId
+          in: path
+          description: The package log identifier.
+          required: true
+          schema:
+            "$ref": "#/components/schemas/AnyHash"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AppendPackageRecordRequest"
+      responses:
+        "202":
+          description: The package record was accepted.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/AppendPackageRecordResponse"
+        default:
+          description: An error occurred when processing the request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /package/{logId}/record/{recordId}:
+    get:
+      summary: Get a package record.
+      operationId: getPackageRecord
+      security: []
+      tags:
+        - package
+      description: |
+        Gets a package record from the registry.
+
+        A package record is in one of the following states:
+          * `sourcing`: The package record needs content sources.
+          * `processing`: The package record is being processed.
+          * `rejected`: The package record was rejected.
+          * `appended`: The package record was appended to the log.
+
+        TODO: document package record format.
+      parameters:
+        - name: logId
+          in: path
+          description: The package log identifier.
+          required: true
+          schema:
+            "$ref": "#/components/schemas/AnyHash"
+        - name: recordId
+          in: path
+          description: The record identifier.
+          required: true
+          schema:
+            "$ref": "#/components/schemas/AnyHash"
+      responses:
+        "200":
+          description: The package record.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PackageRecord"
+        "404":
+          description: A requested entity was not found.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required:
+                  - status
+                  - type
+                  - id
+                properties:
+                  status:
+                    type: integer
+                    description: The HTTP status code for the error.
+                    example: 404
+                  type:
+                    type: string
+                    description: The type of entity that was not found.
+                    enum: [log, record]
+                    example: log
+                  id:
+                    "$ref": "#/components/schemas/AnyHash"
+                    description: |
+                      The identifier of the entity that was not found.
+        default:
+          description: An error occurred when processing the request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    patch:
+      summary: Update content sources of a package record.
+      operationId: addPackageRecordContentSources
+      security: []
+      tags:
+        - package
+      description: |
+        Updates the content sources for an existing package record.
+
+        The package record must be in the `sourcing` state.
+
+        Only missing content sources can be specified.
+      parameters:
+        - name: logId
+          in: path
+          description: The package log identifier.
+          required: true
+          schema:
+            "$ref": "#/components/schemas/AnyHash"
+        - name: recordId
+          in: path
+          description: The record identifier.
+          required: true
+          schema:
+            "$ref": "#/components/schemas/AnyHash"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PackageRecordContentSourcesRequest"
+      responses:
+        "200":
+          description: The package record was updated.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PackageRecord"
+        "404":
+          description: A requested entity was not found.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required:
+                  - status
+                  - type
+                  - id
+                properties:
+                  status:
+                    type: integer
+                    description: The HTTP status code for the error.
+                    example: 404
+                  type:
+                    type: string
+                    description: The type of entity that was not found.
+                    enum: [log, record]
+                    example: log
+                  id:
+                    "$ref": "#/components/schemas/AnyHash"
+                    description: |
+                      The identifier of the entity that was not found.
+        "405":
+          description: The package record is not in the `sourcing` state.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                status: 405
+                message: the package record is not in the `sourcing` state
+        "501":
+          description: Updating package content sources is not supported.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                status: 501
+                message: adding content sources is not supported
+        default:
+          description: An error occurred when processing the request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /package/{logId}/record/{recordId}/content:
+    post:
+      summary: Post content for a package record.
+      operationId: postPackageRecordContent
+      security: []
+      tags:
+        - package
+      description: |
+        Posts package record content directly to the registry.
+
+        The package record must be in the `sourcing` state.
+
+        If an implementation does not support this endpoint, clients should update the content sources of the record.
+      parameters:
+        - name: logId
+          in: path
+          description: The package log identifier.
+          required: true
+          schema:
+            "$ref": "#/components/schemas/AnyHash"
+        - name: recordId
+          in: path
+          description: The record identifier.
+          required: true
+          schema:
+            "$ref": "#/components/schemas/AnyHash"
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+              maxLength: 1073741824 # 1 GiB limit
+      responses:
+        "201":
+          description: The content was successfully uploaded.
+          headers:
+            Location:
+              description: The URL for accessing the uploaded content.
+              schema:
+                type: string
+                format: uri
+                example: https://example.com/content/sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
+        "404":
+          description: A requested entity was not found.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required:
+                  - status
+                  - type
+                  - id
+                properties:
+                  status:
+                    type: integer
+                    description: The HTTP status code for the error.
+                    example: 404
+                  type:
+                    type: string
+                    description: The type of entity that was not found.
+                    enum: [log, record]
+                    example: log
+                  id:
+                    "$ref": "#/components/schemas/AnyHash"
+                    description: |
+                      The identifier of the entity that was not found.
+        "405":
+          description: The package record is not in the `sourcing` state.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                status: 405
+                message: the package record is not in the `sourcing` state
+        "501":
+          description: Uploading of package content is unsupported.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                status: 501
+                message: package content uploading is not supported
+        default:
+          description: An error occurred when processing the request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /proof/consistency:
+    post:
+      summary: Prove registry checkpoint consistency.
+      operationId: proveConsistency
+      security: []
+      tags:
+        - proof
+      description: |
+        Proves the consistency of the registry between two specified checkpoints.
+
+        TODO: document the consistency proof bundle format.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProveConsistencyRequest"
+      responses:
+        "200":
+          description: The consistency proof was generated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProveConsistencyResponse"
+        "404":
+          description: A requested entity was not found.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required:
+                  - status
+                  - type
+                  - id
+                properties:
+                  status:
+                    type: integer
+                    description: The HTTP status code for the error.
+                    example: 404
+                  type:
+                    type: string
+                    description: The type of entity that was not found.
+                    enum: [checkpoint]
+                    example: checkpoint
+                  id:
+                    "$ref": "#/components/schemas/AnyHash"
+                    description: |
+                      The identifier of the entity that was not found.
+        default:
+          description: An error occurred when processing the request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /proof/inclusion:
+    post:
+      summary: Prove log leaf inclusion.
+      operationId: proveInclusion
+      security: []
+      tags:
+        - proof
+      description: |
+        Proves that the given log leafs are present in the given registry checkpoint.
+
+        TODO: document the log inclusion proof bundle format.
+
+        TODO: document the map inclusion proof bundle format.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProveInclusionRequest"
+      responses:
+        "200":
+          description: The inclusion proof was generated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProveInclusionResponse"
+        "404":
+          description: A requested entity was not found.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required:
+                  - status
+                  - type
+                  - id
+                properties:
+                  status:
+                    type: integer
+                    description: The HTTP status code for the error.
+                    example: 404
+                  type:
+                    type: string
+                    description: The type of entity that was not found.
+                    enum: [checkpoint, log, record]
+                    example: checkpoint
+                  id:
+                    "$ref": "#/components/schemas/AnyHash"
+                    description: |
+                      The identifier of the entity that was not found.
+        default:
+          description: An error occurred when processing the request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Error:
+      type: object
+      description: A generic error response.
+      additionalProperties: false
+      required:
+        - status
+        - message
+      properties:
+        status:
+          type: integer
+          description: The HTTP status code for the error.
+          example: 406
+        message:
+          type: string
+          description: The error message.
+          example: the server cannot produce an acceptable response
+    AnyHash:
+      type: string
+      description: Represents a supported hash.
+      example: sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
+      pattern: ^(sha256:[a-f0-9]{64,64})$
+      minLength: 71
+      maxLength: 71
+    FetchLogsRequest:
+      type: object
+      description: A request to fetch logs from the registrsy.
+      additionalProperties: false
+      required:
+        - root
+      properties:
+        root:
+          $ref: "#/components/schemas/AnyHash"
+          description: The root checkpoint of the registry.
+        maximumRecords:
+          type: integer
+          description: The maximum number of operator or package records to return.
+          example: 100
+          default: 100
+          minimum: 1
+          maximum: 1000
+          format: int16
+        operator:
+          $ref: "#/components/schemas/AnyHash"
+          description: The last known operator record identifier.
+        packages:
+          type: object
+          description: |
+            The map of package log identifier to last known package record identifier.
+
+            If the last package record identifier is null, records are returned from the start of the log.
+          patternProperties:
+            "^sha256:[a-f0-9]{64,64}$":
+              $ref: "#/components/schemas/AnyHash"
+              description: The last known package record identifier.
+              nullable: true
+          example:
+            "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded9773": "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730"
+            "sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c": null
+    FetchLogsResponse:
+      type: object
+      description: A response containing the requested logs.
+      additionalProperties: false
+      properties:
+        more:
+          type: boolean
+          description: |
+            Whether there may be more records available.
+
+            This occurs when the maximum number of records is returned for a log.
+
+            If `true`, the client should make another request with the new last known record identifiers.
+          example: false
+        operator:
+          type: array
+          description: The operator log records for the given root checkpoint since the last known record.
+          maxItems: 1000
+          items:
+            $ref: "#/components/schemas/EnvelopeBody"
+        packages:
+          type: object
+          description: The map of package log identifier to package records.
+          patternProperties:
+            "^sha256:[a-f0-9]{64,64}$":
+              type: array
+              description: The package log records for the given root checkpoint since the last known record.
+              maxItems: 1000
+              items:
+                $ref: "#/components/schemas/EnvelopeBody"
+          example:
+            ? "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730"
+            : - contentBytes: "ZXhhbXBsZQ=="
+                keyId: "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730"
+                signature: "ecdsa-p256:MEUCIQCzWZBW6ux9LecP66Y+hjmLZTP/hZVz7puzlPTXcRT2wwIgQZO7nxP0nugtw18MwHZ26ROFWcJmgCtKOguK031Y1D0="
+              - contentBytes: "ZXhhbXBsZQ=="
+                keyId: "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730"
+                signature: "ecdsa-p256:MEUCIQCzWZBW6ux9LecP66Y+hjmLZTP/hZVz7puzlPTXcRT2wwIgQZO7nxP0nugtw18MwHZ26ROFWcJmgCtKOguK031Y1D0="
+            ? "sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
+            : - contentBytes: "ZXhhbXBsZQ=="
+                keyId: "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730"
+                signature: "ecdsa-p256:MEUCIQCzWZBW6ux9LecP66Y+hjmLZTP/hZVz7puzlPTXcRT2wwIgQZO7nxP0nugtw18MwHZ26ROFWcJmgCtKOguK031Y1D0="
+    FetchCheckpointResponse:
+      type: object
+      description: A response containing the latest registry checkpoint.
+      additionalProperties: false
+      properties:
+        checkpoint:
+          description: The latest checkpoint of the registry.
+          allOf:
+            - type: object
+              required:
+                - contents
+              properties:
+                contents:
+                  $ref: "#/components/schemas/MapCheckpoint"
+            - $ref: "#/components/schemas/Signature"
+    CreatePackageLogRequest:
+      type: object
+      description: A request to create a new package log.
+      allOf:
+        - type: object
+          required:
+            - name
+          properties:
+            name:
+              type: string
+              description: The name of the package log.
+              maxLength: 128
+              example: wasi:http
+            metadata:
+              "$ref": "#/components/schemas/PackageMetadata"
+              description: The metadata for the package log.
+        - $ref: "#/components/schemas/Signature"
+    UpdatePackageLogRequest:
+      type: object
+      description: A request to update information for a package log.
+      allOf:
+        - type: object
+          properties:
+            metadata:
+              "$ref": "#/components/schemas/PackageMetadata"
+              description: The metadata to update for the package log.
+        - $ref: "#/components/schemas/Signature"
+    AppendPackageRecordRequest:
+      type: object
+      description: A request to append a record to a package log.
+      additionalProperties: false
+      required:
+        - record
+      properties:
+        record:
+          "$ref": "#/components/schemas/EnvelopeBody"
+          description: The package record being appended to the log.
+        contentSources:
+          type: array
+          description: The list of known content sources.
+          maxItems: 128
+          items:
+            "$ref": "#/components/schemas/ContentSource"
+    AppendPackageRecordResponse:
+      type: object
+      description: A response containing the accepted package record.
+      additionalProperties: false
+      properties:
+        recordUrl:
+          type: string
+          description: The URL of the package record.
+          example: https://example.com/package/sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c/sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
+          format: uri
+        record:
+          "$ref": "#/components/schemas/PackageRecord"
+          description: |
+            The package record that was accepted and is awaiting processing by the registry.
+    PackageLog:
+      type: object
+      description: Information of a package log.
+      additionalProperties: false
+      required:
+        - name
+        - id
+      properties:
+        name:
+          type: string
+          description: The name of the package log.
+          format: package-name
+          maxLength: 128
+          example: wasi:http
+        id:
+          "$ref": "#/components/schemas/AnyHash"
+          description: The identifier of the package log.
+        metadata:
+          "$ref": "#/components/schemas/PackageMetadata"
+          description: The metadata for the package log.
+    PackageRecord:
+      type: object
+      description: A package log record.
+      oneOf:
+        - "$ref": "#/components/schemas/SourcingRecord"
+        - "$ref": "#/components/schemas/ProcessingRecord"
+        - "$ref": "#/components/schemas/RejectedRecord"
+        - "$ref": "#/components/schemas/AppendedRecord"
+      discriminator:
+        propertyName: state
+        mapping:
+          sourcing: "#/components/schemas/SourcingRecord"
+          processing: "#/components/schemas/ProcessingRecord"
+          rejected: "#/components/schemas/RejectedRecord"
+          appended: "#/components/schemas/AppendedRecord"
+    PackageRecordContentSourcesRequest:
+      type: object
+      description: A request to set the content sources of a package record.
+      additionalProperties: false
+      required:
+        - contentSources
+      properties:
+        contentSources:
+          type: array
+          description: The list of known content sources.
+          minItems: 1
+          maxItems: 128
+          items:
+            "$ref": "#/components/schemas/ContentSource"
+        # TODO: sign the array entries so that only an accepted publisher can set the content sources?
+    ProveConsistencyRequest:
+      type: object
+      description: A request to prove the consistency of the registry.
+      additionalProperties: false
+      required:
+        - from
+        - to
+      properties:
+        from:
+          $ref: "#/components/schemas/AnyHash"
+          description: The starting checkpoint.
+        to:
+          $ref: "#/components/schemas/AnyHash"
+          description: The ending checkpoint.
+    ProveConsistencyResponse:
+      type: object
+      description: A response containing the consistency proof bundle.
+      additionalProperties: false
+      required:
+        - proof
+      properties:
+        proof:
+          type: string
+          description: The consistency proof bundle.
+          format: byte
+          example: "ZXhhbXBsZQ=="
+    ProveInclusionRequest:
+      type: object
+      description: A request to prove the inclusion of log leafs in a checkpoint.
+      additionalProperties: false
+      required:
+        - from
+        - to
+      properties:
+        checkpoint:
+          $ref: "#/components/schemas/MapCheckpoint"
+          description: The checkpoint to prove the inclusion for.
+        leafs:
+          type: array
+          maxItems: 1000
+          description: The log leafs to prove the inclusion for.
+          items:
+            type: object
+            description: A log leaf.
+            required:
+              - logId
+              - recordId
+            properties:
+              logId:
+                $ref: "#/components/schemas/AnyHash"
+                description: The log identifier.
+              recordId:
+                $ref: "#/components/schemas/AnyHash"
+                description: The record identifier.
+    ProveInclusionResponse:
+      type: object
+      description: A response containing the inclusion proof bundle.
+      additionalProperties: false
+      required:
+        - log
+        - map
+      properties:
+        log:
+          type: string
+          description: The log inclusion proof bundle.
+          format: byte
+          example: "ZXhhbXBsZQ=="
+        map:
+          type: string
+          description: The map inclusion proof bundle.
+          format: byte
+          example: "ZXhhbXBsZQ=="
+    SourcingRecord:
+      type: object
+      description: The package record is sourcing content.
+      required:
+        - state
+        - missingContent
+      properties:
+        state:
+          type: string
+          description: The state of the package record.
+          enum: [sourcing]
+          example: sourcing
+        contentUrl:
+          type: string
+          description: |
+            The URL for posting record content.
+
+            If this field is not present, clients should update the content sources of the package record.
+          example: https://example.com/package/sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c/sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c/content
+          format: uri
+        missingContent:
+          type: array
+          description: The array of content digests that are missing for the package record.
+          minItems: 1
+          maxItems: 128
+          items:
+            "$ref": "#/components/schemas/AnyHash"
+    ProcessingRecord:
+      type: object
+      description: A record that is being processed.
+      required:
+        - state
+      properties:
+        state:
+          type: string
+          description: The state of the package record.
+          enum: [processing]
+          example: processing
+    RejectedRecord:
+      type: object
+      description: A rejected package record.
+      required:
+        - state
+        - reason
+      properties:
+        state:
+          type: string
+          description: The state of the package record.
+          enum: [rejected]
+          example: rejected
+        reason:
+          type: string
+          description: The reason the package record was rejected.
+          example: the first entry of the log is not `init`
+    AppendedRecord:
+      type: object
+      description: A record that has been appended to the log.
+      required:
+        - state
+        - checkpoint
+        - record
+      properties:
+        state:
+          type: string
+          description: The state of the package record.
+          enum: [appended]
+          example: appended
+        checkpoint:
+          description: The checkpoint of the record.
+          allOf:
+            - type: object
+              required:
+                - contents
+              properties:
+                contents:
+                  $ref: "#/components/schemas/MapCheckpoint"
+            - $ref: "#/components/schemas/Signature"
+        record:
+          "$ref": "#/components/schemas/EnvelopeBody"
+          description: The package record.
+        contentSources:
+          type: array
+          description: The content sources for the package record.
+          maxItems: 128
+          items:
+            "$ref": "#/components/schemas/ContentSource"
+    PackageMetadata:
+      type: object
+      additionalProperties: false
+      description: The metadata for a registry package.
+      properties:
+        description:
+          type: string
+          description: The description of the package.
+          maxLength: 1024
+          example: A package for the WebAssembly System Interface (WASI) HTTP API.
+        homepage:
+          type: string
+          description: The URL of the package homepage.
+          format: uri
+          example: https://example.com/wasi/http
+        repository:
+          type: string
+          description: The URL of the package repository.
+          format: uri
+          example: https://example.com/wasi/http.git
+        license:
+          type: string
+          description: The SPDX license identifier of the package.
+          example: Apache-2.0
+        keywords:
+          type: array
+          description: The list of keywords for the package.
+          maxItems: 128
+          items:
+            type: string
+            description: A keyword for the package.
+            maxLength: 128
+            example: wasi
+    MapCheckpoint:
+      type: object
+      description: |
+        A registry checkpoint.
+
+        Checkpoints are hashed by concatenating the following:
+          * A prefix of the byte string `WARG-MAP-CHECKPOINT-V0`
+          * The LEB128-encoded `logLength`
+          * The LEB128-length-prefixed `logRoot`
+          * The LEB128-length-prefixed `mapRoot`
+      additionalProperties: false
+      required:
+        - logLength
+        - logRoot
+        - mapRoot
+      properties:
+        logLength:
+          type: integer
+          description: The log length of the checkpoint.
+          minimum: 1
+          example: 42
+        logRoot:
+          $ref: "#/components/schemas/AnyHash"
+          description: The log root hash of the checkpoint.
+        mapRoot:
+          $ref: "#/components/schemas/AnyHash"
+          description: The map root hash of the checkpoint.
+    EnvelopeBody:
+      description: A signed envelope body.
+      allOf:
+        - type: object
+          required:
+            - contentBytes
+          properties:
+            contentBytes:
+              type: string
+              description: |
+                Base64-encoded bytes of the content.
+
+                The content of an envelope body is typically a serialized protocol buffer
+                representing an operator or package record.
+              format: byte
+              maxLength: 1048576
+              example: "ZXhhbXBsZQ=="
+        - $ref: "#/components/schemas/Signature"
+    Signature:
+      type: object
+      description: Represents a signature of content.
+      required:
+        - keyId
+        - signature
+      properties:
+        keyId:
+          $ref: "#/components/schemas/AnyHash"
+          description: The signing key identifier.
+        signature:
+          type: string
+          description: The bytes of the signature.
+          pattern: ^(ecdsa-p256:(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{4}|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{2}={2}))$
+          minLength: 107
+          maxLength: 107
+          example: "ecdsa-p256:MEUCIQCzWZBW6ux9LecP66Y+hjmLZTP/hZVz7puzlPTXcRT2wwIgQZO7nxP0nugtw18MwHZ26ROFWcJmgCtKOguK031Y1D0="
+    ContentSource:
+      type: object
+      description: A known content source.
+      oneOf:
+        - "$ref": "#/components/schemas/HttpSource"
+      discriminator:
+        propertyName: type
+        mapping:
+          http: "#/components/schemas/HttpSource"
+    HttpSource:
+      type: object
+      description: A known HTTP content source.
+      properties:
+        type:
+          type: string
+          description: The type of content source.
+          enum: [http]
+          example: http
+        digest:
+          "$ref": "#/components/schemas/AnyHash"
+          description: The digest of the content.
+        url:
+          type: string
+          description: The URL of the content.
+          example: https://example.com/contents.wasm
+          format: uri

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -899,8 +899,8 @@ components:
       description: A request to prove the inclusion of log leafs in a checkpoint.
       additionalProperties: false
       required:
-        - from
-        - to
+        - checkpoint
+        - leafs
       properties:
         checkpoint:
           $ref: "#/components/schemas/MapCheckpoint"

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -218,94 +218,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-    patch:
-      summary: Update content sources of a package record.
-      operationId: updatePackageRecordContentSources
-      security: []
-      tags:
-        - package
-      description: |
-        Updates the content sources for an existing package record.
-
-        The package record must be in the `sourcing` state.
-
-        Only missing content sources can be specified.
-      parameters:
-        - name: logId
-          in: path
-          description: The package log identifier.
-          required: true
-          schema:
-            "$ref": "#/components/schemas/AnyHash"
-        - name: recordId
-          in: path
-          description: The record identifier.
-          required: true
-          schema:
-            "$ref": "#/components/schemas/AnyHash"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PackageRecordContentSourcesRequest"
-      responses:
-        "200":
-          description: The package record was updated.
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/PackageRecord"
-        "404":
-          description: A requested entity was not found.
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: false
-                required:
-                  - status
-                  - type
-                  - id
-                properties:
-                  status:
-                    type: integer
-                    description: The HTTP status code for the error.
-                    example: 404
-                  type:
-                    type: string
-                    description: The type of entity that was not found.
-                    enum: [log, record]
-                    example: log
-                  id:
-                    "$ref": "#/components/schemas/AnyHash"
-                    description: |
-                      The identifier of the entity that was not found.
-        "405":
-          description: The package record is not in the `sourcing` state.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-              example:
-                status: 405
-                message: the package record is not in the `sourcing` state
-        "501":
-          description: Updating package content sources is not supported.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-              example:
-                status: 501
-                message: adding content sources is not supported
-        default:
-          description: An error occurred when processing the request.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-  /package/{logId}/record/{recordId}/content:
+  /package/{logId}/record/{recordId}/content/{digest}:
     post:
       summary: Post content for a package record.
       operationId: postPackageRecordContent
@@ -315,9 +228,8 @@ paths:
       description: |
         Posts package record content directly to the registry.
 
-        The package record must be in the `sourcing` state.
-
-        If an implementation does not support this endpoint, clients should update the content sources of the record.
+        The package record must be in the `sourcing` state and the digest of the uploaded
+        content must match the digest parameter.
       parameters:
         - name: logId
           in: path
@@ -328,6 +240,12 @@ paths:
         - name: recordId
           in: path
           description: The record identifier.
+          required: true
+          schema:
+            "$ref": "#/components/schemas/AnyHash"
+        - name: digest
+          in: path
+          description: The digest of the content being uploaded.
           required: true
           schema:
             "$ref": "#/components/schemas/AnyHash"
@@ -382,15 +300,6 @@ paths:
               example:
                 status: 405
                 message: the package record is not in the `sourcing` state
-        "501":
-          description: Uploading of package content is unsupported.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-              example:
-                status: 501
-                message: package content uploading is not supported
         default:
           description: An error occurred when processing the request.
           content:
@@ -651,9 +560,6 @@ components:
         record:
           "$ref": "#/components/schemas/EnvelopeBody"
           description: The package record being published to the log.
-        contentSources:
-          "$ref": "#/components/schemas/ContentSourceMap"
-          description: The list of known content sources.
     PackageRecord:
       description: A package log record.
       allOf:
@@ -676,16 +582,6 @@ components:
               processing: "#/components/schemas/ProcessingRecord"
               rejected: "#/components/schemas/RejectedRecord"
               published: "#/components/schemas/PublishedRecord"
-    PackageRecordContentSourcesRequest:
-      type: object
-      description: A request to set the content sources of a package record.
-      additionalProperties: false
-      required:
-        - contentSources
-      properties:
-        contentSources:
-          "$ref": "#/components/schemas/ContentSourceMap"
-          description: The map of content digest to sources.
     ProveConsistencyRequest:
       type: object
       description: A request to prove the consistency of the registry.
@@ -763,7 +659,6 @@ components:
       description: The package record is sourcing content.
       required:
         - state
-        - uploadSupported
         - missingContent
       properties:
         state:
@@ -771,10 +666,6 @@ components:
           description: The state of the package record.
           enum: [sourcing]
           example: sourcing
-        uploadSupported:
-          type: boolean
-          description: Whether or not direct content uploading is supported by the registry.
-          example: true
         missingContent:
           type: array
           description: The array of content digests that are missing for the package record.

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -144,6 +144,14 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/PackageRecord"
+        "501":
+          description: |
+            The server does not support publishing package records with explicitly
+            specified content source locations.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         default:
           description: An error occurred when processing the request.
           content:
@@ -477,9 +485,9 @@ components:
         checkpoint:
           $ref: "#/components/schemas/AnyHash"
           description: The registry checkpoint hash to fetch from.
-        maximumRecords:
+        limit:
           type: integer
-          description: The maximum number of operator or package records to return.
+          description: The limit of operator and packages records to return for the fetch request.
           example: 100
           default: 100
           minimum: 1
@@ -512,7 +520,7 @@ components:
           description: |
             Whether there may be more records available.
 
-            This occurs when the maximum number of records is returned for a log.
+            This occurs when the number of records returned for a log reaches the requested limit.
 
             If `true`, the client should make another request with the new last known record identifiers.
           example: false
@@ -560,6 +568,15 @@ components:
         record:
           "$ref": "#/components/schemas/EnvelopeBody"
           description: The package record being published to the log.
+        contentSources:
+          "$ref": "#/components/schemas/ContentSourceMap"
+          description: |
+            The map of all content sources for the record.
+
+            A registry may not support specifying content sources for a record.
+
+            If a registry does not support content sources, a 501 will be returned
+            and content will need to be directly uploaded to the registry.
     PackageRecord:
       description: A package log record.
       allOf:

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -1083,13 +1083,19 @@ components:
       type: object
       additionalProperties: false
       required:
+        - status
         - reason
         - logId
       properties:
+        status:
+          type: integer
+          description: The HTTP status code for the error.
+          example: 422
         reason:
           type: string
           description: The reason why the bundle could not be generated.
           enum: [packageNotIncluded]
+          example: packageNotIncluded
         logId:
           "$ref": "#/components/schemas/AnyHash"
           description: The identifier of the log that was not included.
@@ -1097,14 +1103,20 @@ components:
       type: object
       additionalProperties: false
       required:
+        - status
         - reason
         - root
         - found
       properties:
+        status:
+          type: integer
+          description: The HTTP status code for the error.
+          example: 422
         reason:
           type: string
           description: The reason why the bundle could not be generated.
           enum: [incorrectProof]
+          example: incorrectProof
         root:
           "$ref": "#/components/schemas/AnyHash"
           description: The map or log root hash from the checkpoint that was provided.
@@ -1115,13 +1127,19 @@ components:
       type: object
       additionalProperties: false
       required:
+        - status
         - reason
         - message
       properties:
+        status:
+          type: integer
+          description: The HTTP status code for the error.
+          example: 422
         reason:
           type: string
           description: The reason why the bundle could not be generated.
           enum: [failure]
+          example: failure
         message:
           type: string
           description: The failure error message.

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -102,7 +102,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/FetchCheckpointResponse"
+                $ref: "#/components/schemas/SignedMapCheckpoint"
         default:
           description: An error occurred when processing the request.
           content:
@@ -695,21 +695,6 @@ components:
             : - contentBytes: "ZXhhbXBsZQ=="
                 keyId: "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730"
                 signature: "ecdsa-p256:MEUCIQCzWZBW6ux9LecP66Y+hjmLZTP/hZVz7puzlPTXcRT2wwIgQZO7nxP0nugtw18MwHZ26ROFWcJmgCtKOguK031Y1D0="
-    FetchCheckpointResponse:
-      type: object
-      description: A response containing the latest registry checkpoint.
-      additionalProperties: false
-      properties:
-        checkpoint:
-          description: The latest checkpoint of the registry.
-          allOf:
-            - type: object
-              required:
-                - contents
-              properties:
-                contents:
-                  $ref: "#/components/schemas/MapCheckpoint"
-            - $ref: "#/components/schemas/Signature"
     PublishPackageRecordRequest:
       type: object
       description: A request to publish a record to a package log.
@@ -925,15 +910,8 @@ components:
           enum: [published]
           example: published
         checkpoint:
+          "$ref": "#/components/schemas/SignedMapCheckpoint"
           description: The checkpoint of the record.
-          allOf:
-            - type: object
-              required:
-                - contents
-              properties:
-                contents:
-                  $ref: "#/components/schemas/MapCheckpoint"
-            - $ref: "#/components/schemas/Signature"
         record:
           "$ref": "#/components/schemas/EnvelopeBody"
           description: The package record.
@@ -1003,6 +981,16 @@ components:
         mapRoot:
           $ref: "#/components/schemas/AnyHash"
           description: The map root hash of the checkpoint.
+    SignedMapCheckpoint:
+      description: A signed registry checkpoint.
+      allOf:
+        - type: object
+          required:
+            - contents
+          properties:
+            contents:
+              $ref: "#/components/schemas/MapCheckpoint"
+        - $ref: "#/components/schemas/Signature"
     EnvelopeBody:
       description: A signed envelope body.
       allOf:


### PR DESCRIPTION
[Rendered API documentation](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/bytecodealliance/registry/62d8a9cfaa4ce424740c10d76d640b906836d753/crates/server/openapi.yaml)

This PR creates a single OpenAPI specification for the Warg registry server.

It is intended to (ultimately) be the complete specification of a Warg registry server's REST API.

The specification proposed here is not what is currently implemented by `warg-server`, but it is inspired heavily by both the existing implementation and previously proposed APIs.

We can use this as a starting point to finalize an API specification for the initial version.

An API around streaming records to federated registries is not currently included in the specification, so design around this is welcome.
