### PR TITLE
fix: use postgres feature in vscode for analyzer workaround

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "rust-analyzer.check.command": "clippy",
+    "rust-analyzer.cargo.features": ["postgres"],
     "protoc": {
         "options": [
             "--proto_path=${workspaceFolder}/proto",


### PR DESCRIPTION
Build seemed to work, but vscode rust-analyzer claimed error.

- workaround for #106