### PR TITLE
fix: return bound endpoints after server started

### DIFF
--- a/tests/server.rs
+++ b/tests/server.rs
@@ -4,7 +4,6 @@ use std::{fs, str::FromStr};
 use warg_client::{api, Config, FileSystemClient, StorageLockResult};
 use warg_crypto::{signing::PrivateKey, Encode, Signable};
 use wit_component::DecodedWasm;
-
 mod support;
 
 #[cfg(feature = "postgres")]

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -82,10 +82,10 @@ pub async fn spawn_server(
     }
 
     let mut server = Server::new(config);
-    let addr = server.bind()?;
+    let endpoints = server.start().await?;
 
     let task = tokio::spawn(async move {
-        server.run().await.unwrap();
+        server.join().await.unwrap();
     });
 
     let instance = ServerInstance {
@@ -94,7 +94,7 @@ pub async fn spawn_server(
     };
 
     let config = warg_client::Config {
-        default_url: Some(format!("http://{addr}")),
+        default_url: Some(format!("http://{addr}", addr = endpoints.api)),
         registries_dir: Some(root.join("registries")),
         content_dir: Some(root.join("content")),
     };


### PR DESCRIPTION
The impetus behind the change is to support adding monitoring endpoints with an optional additional TCP listener. While refactoring the server it was discovered that the run method moves the Server self, and so fixed #112 to also ensure that the API endpoint was running before tests could discover the listener's locally bound port.

In addition a common cancellation token is added to the server to propagate shutdown to both the core service as well as the API server endpoint. It can be later used to support additional services later such as a monitoring endpoint(s).