### PR TITLE
Prefix all environment variables used by the server with `WARG_`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ updated to install the crates.io package once a proper release is made.
 
 ### Running the server
 
-Before running the server, set the `OPERATOR_KEY` environment
+Before running the server, set the `WARG_OPERATOR_KEY` environment
 variable:
 
 ```
-export OPERATOR_KEY="ecdsa-p256:I+UlDo0HxyBBFeelhPPWmD+LnklOpqZDkrFP5VduASk="
+export WARG_OPERATOR_KEY="ecdsa-p256:I+UlDo0HxyBBFeelhPPWmD+LnklOpqZDkrFP5VduASk="
 ```
 
-`OPERATOR_KEY` is the private key of the server operator.
+`WARG_OPERATOR_KEY` is the private key of the server operator.
 
 Currently this is sourced through an environment variable, but soon this will 
 be sourced via command line arguments or integration with system key rings.

--- a/ci/run-postgres-tests.sh
+++ b/ci/run-postgres-tests.sh
@@ -23,4 +23,4 @@ echo setting up database
 diesel database setup --database-url postgres://postgres:password@localhost:5433/test-registry --migration-dir crates/server/src/datastore/postgres/migrations
 
 echo running tests
-DATABASE_URL=postgres://postgres:password@localhost:5433/test-registry cargo test --features postgres $@
+WARG_DATABASE_URL=postgres://postgres:password@localhost:5433/test-registry cargo test --features postgres $@

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -11,11 +11,11 @@ The registry server can be started with either in-memory or PostgreSQL storage.
 With in-memory storage, the server will store all data in-memory and the data 
 will be lost when the server is stopped.
 
-To start the server, provide the `OPERATOR_KEY` environment variable, 
+To start the server, provide the `WARG_OPERATOR_KEY` environment variable,
 which is used to sign the entries in the server's operator log:
 
 ```console
-$ OPERATOR_KEY="ecdsa-p256:I+UlDo0HxyBBFeelhPPWmD+LnklOpqZDkrFP5VduASk=" cargo run -- --content-dir content
+$ WARG_OPERATOR_KEY="ecdsa-p256:I+UlDo0HxyBBFeelhPPWmD+LnklOpqZDkrFP5VduASk=" cargo run -- --content-dir content
 2023-04-18T23:48:52.149746Z  INFO warg_server::services::core: initializing core service
 2023-04-18T23:48:52.170199Z  INFO warg_server::services::core: core service is running
 2023-04-18T23:48:52.170233Z  INFO warg_server: listening on 127.0.0.1:8090
@@ -51,11 +51,11 @@ diesel database setup --database-url postgres://postgres:password@localhost/regi
 
 Here, `registry` is the database name that will be created.
 
-To start the registry server, provide both the `OPERATOR_KEY` and 
-`DATABASE_URL` environment variables:
+To start the registry server, provide both the `WARG_OPERATOR_KEY` and
+`WARG_DATABASE_URL` environment variables:
 
 ```console
-DATABASE_URL=postgres://postgres:password@localhost/registry OPERATOR_KEY="ecdsa-p256:I+UlDo0HxyBBFeelhPPWmD+LnklOpqZDkrFP5VduASk=" cargo run -p warg-server --features postgres -- --content-dir content --data-store postgres
+WARG_DATABASE_URL=postgres://postgres:password@localhost/registry WARG_OPERATOR_KEY="ecdsa-p256:I+UlDo0HxyBBFeelhPPWmD+LnklOpqZDkrFP5VduASk=" cargo run -p warg-server --features postgres -- --content-dir content --data-store postgres
 ```
 
 The `--data-store postgres` flag starts the server with PostgreSQL data storage.

--- a/crates/server/src/bin/warg-server.rs
+++ b/crates/server/src/bin/warg-server.rs
@@ -17,19 +17,19 @@ enum DataStoreKind {
 #[derive(Parser)]
 struct Args {
     /// Use verbose output
-    #[arg(short, long, env = "VERBOSE", action = clap::ArgAction::Count)]
+    #[arg(short, long, env = "WARG_VERBOSE", action = clap::ArgAction::Count)]
     verbose: u8,
 
     /// Address to listen to
-    #[arg(short, long, env = "LISTEN", default_value = "127.0.0.1:8090")]
+    #[arg(short, long, env = "WARG_LISTEN", default_value = "127.0.0.1:8090")]
     listen: SocketAddr,
 
     /// The content storage directory to use.
-    #[arg(long, env = "CONTENT_DIR")]
+    #[arg(long, env = "WARG_CONTENT_DIR")]
     content_dir: PathBuf,
 
     /// The data store to use for the server.
-    #[arg(long, env = "DATA_STORE", default_value = "memory")]
+    #[arg(long, env = "WARG_DATA_STORE", default_value = "memory")]
     data_store: DataStoreKind,
 
     /// The database connection URL if data-store is set to postgres.
@@ -37,22 +37,22 @@ struct Args {
     /// Prefer using `database-url-file`, or environment variable variation,
     /// to avoid exposing sensitive information.
     #[cfg(feature = "postgres")]
-    #[arg(long, env = "DATABASE_URL")]
+    #[arg(long, env = "WARG_DATABASE_URL")]
     database_url: Option<String>,
 
     /// The path to the operator key.
     #[cfg(feature = "postgres")]
-    #[arg(long, env = "DATABASE_URL_FILE", conflicts_with = "database_url")]
+    #[arg(long, env = "WARG_DATABASE_URL_FILE", conflicts_with = "database_url")]
     database_url_file: Option<PathBuf>,
 
     /// The operator key.
     ///
     /// Prefer using `operator-key-file`, or environment variable variation.
-    #[arg(long, env = "OPERATOR_KEY")]
+    #[arg(long, env = "WARG_OPERATOR_KEY")]
     operator_key: Option<String>,
 
     /// The path to the operator key.
-    #[arg(long, env = "OPERATOR_KEY_FILE", conflicts_with = "operator_key")]
+    #[arg(long, env = "WARG_OPERATOR_KEY_FILE", conflicts_with = "operator_key")]
     operator_key_file: Option<PathBuf>,
 }
 

--- a/demo/setup-server.sh
+++ b/demo/setup-server.sh
@@ -2,4 +2,4 @@ rm -rf .server-content
 mkdir .server-content
 
 alias warg-server=../target/debug/warg-server
-OPERATOR_KEY="ecdsa-p256:I+UlDo0HxyBBFeelhPPWmD+LnklOpqZDkrFP5VduASk=" warg-server --content-dir .server-content
+WARG_OPERATOR_KEY="ecdsa-p256:I+UlDo0HxyBBFeelhPPWmD+LnklOpqZDkrFP5VduASk=" warg-server --content-dir .server-content

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,8 +19,8 @@ services:
     # Set the base settings with environment variables.
     # NOTE: Test for cli environment variables support.
     environment:
-      - CONTENT_DIR=/var/run/warg/server-content
-      - OPERATOR_KEY_FILE=/var/secrets/warg/operator_key
+      - WARG_CONTENT_DIR=/var/run/warg/server-content
+      - WARG_OPERATOR_KEY_FILE=/var/secrets/warg/operator_key
     volumes:
       - warg-server-content:/var/run/warg/server-content:rw
       - warg-secrets:/var/secrets/warg:ro

--- a/infra/local/secrets.inc.sh
+++ b/infra/local/secrets.inc.sh
@@ -32,7 +32,7 @@ function generate_secrets {
     echo -n "postgres://postgres:$(<"$POSTGRES_CREDS_DIR/password")@db:5432/warg_registry" >"$POSTGRES_CREDS_DIR/database_url"
   fi
   if [[ ! -f "$POSTGRES_CREDS_DIR/database_url_env" ]]; then
-    echo "DATABASE_URL=$(<"$POSTGRES_CREDS_DIR/database_url")" >"$POSTGRES_CREDS_DIR/database_url_env"
+    echo "WARG_DATABASE_URL=$(<"$POSTGRES_CREDS_DIR/database_url")" >"$POSTGRES_CREDS_DIR/database_url_env"
   fi
 
   # TODO: generate operator-key dynamically

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -7,8 +7,8 @@ use warg_server::datastore::{DataStore, PostgresDataStore};
 
 fn data_store() -> Result<Box<dyn DataStore>> {
     Ok(Box::new(PostgresDataStore::new(
-        std::env::var("DATABASE_URL")
-            .context("failed to get `DATABASE_URL` environment variable")?,
+        std::env::var("WARG_DATABASE_URL")
+            .context("failed to get `WARG_DATABASE_URL` environment variable")?,
     )?))
 }
 


### PR DESCRIPTION
This commit prefixes all environment variables respected in the server CLI to use a `WARG_` prefix.

Also does the same for an environment variable used in Postgres tests.