### PR TITLE
Fix for docker compose v2

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,4 @@
 # Base in-memory configuration for the registry service
-version: '3'
-name: bytecodealliance-registry
 services:
   import-secrets:
     container_name: import-secrets

--- a/infra/local/down.sh
+++ b/infra/local/down.sh
@@ -19,7 +19,7 @@ if [[ ! -d "$REPO_DIR" ]]; then
   exit 2
 fi
 
-docker-compose --env-file "$SCRIPT_DIR/.env" \
+docker compose --env-file "$SCRIPT_DIR/.env" \
   -f "$REPO_DIR/docker-compose.yaml" \
   -f "$REPO_DIR/docker-compose.postgres.yaml" \
   down --remove-orphans --volumes

--- a/infra/local/locals.inc.sh
+++ b/infra/local/locals.inc.sh
@@ -17,7 +17,7 @@ function generate_locals {
   PSQL_FILE="$SCRIPT_DIR/psql.local.sh"
 
   # Extract the local randomly bound port number used for exposing postgres.
-  PGPORT=$(docker port bytecodealliance-registry-db-1 5432 | sed -e 's/.*://g')
+  PGPORT=$(docker port registry-db-1 5432 | sed -e 's/.*://g')
 
   PGPASS="localhost"
   PGPASS="$PGPASS:$PGPORT"

--- a/infra/local/rebuild.sh
+++ b/infra/local/rebuild.sh
@@ -27,7 +27,7 @@ fi
 
 generate_secrets
 
-docker-compose --env-file "$SCRIPT_DIR/.env" \
+docker compose --env-file "$SCRIPT_DIR/.env" \
   -f "$REPO_DIR/docker-compose.yaml" \
   -f "$REPO_DIR/docker-compose.postgres.yaml" \
   up --build -d

--- a/infra/local/stop.sh
+++ b/infra/local/stop.sh
@@ -19,7 +19,7 @@ if [[ ! -d "$REPO_DIR" ]]; then
   exit 2
 fi
 
-docker-compose --env-file "$SCRIPT_DIR/.env" \
+docker compose --env-file "$SCRIPT_DIR/.env" \
   -f "$REPO_DIR/docker-compose.yaml" \
   -f "$REPO_DIR/docker-compose.postgres.yaml" \
   stop

--- a/infra/local/up.sh
+++ b/infra/local/up.sh
@@ -27,7 +27,7 @@ fi
 
 generate_secrets
 
-docker-compose --env-file "$SCRIPT_DIR/.env" \
+docker compose --env-file "$SCRIPT_DIR/.env" \
   -f "$REPO_DIR/docker-compose.yaml" \
   -f "$REPO_DIR/docker-compose.postgres.yaml" \
   up -d


### PR DESCRIPTION
Docker Compose v2 was released in 2020 and switched to `docker compose` instead of `docker-compose` on the CLI.

The docker-compose.yaml also needed a few changes. Per docker [docs](https://docs.docker.com/compose/migrate/) and [here](https://docs.docker.com/compose/history/), `version` is ignored should be omitted and `name` field should be removed here.

Also, fixed a name mismatch on the database container `registry-db-1 ` vs `bytecodealliance-registry-db-1`.