### PR TITLE
Renamed DynHash to AnyHash

### DIFF
--- a/crates/api/src/v1/fetch.rs
+++ b/crates/api/src/v1/fetch.rs
@@ -4,7 +4,7 @@ use crate::Status;
 use serde::{de::Unexpected, Deserialize, Serialize, Serializer};
 use std::{borrow::Cow, collections::HashMap};
 use thiserror::Error;
-use warg_crypto::hash::DynHash;
+use warg_crypto::hash::AnyHash;
 use warg_protocol::{
     registry::{LogId, RecordId},
     ProtoEnvelopeBody,
@@ -15,7 +15,7 @@ use warg_protocol::{
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct FetchLogsRequest<'a> {
     /// The root checkpoint hash of the registry.
-    pub root: Cow<'a, DynHash>,
+    pub root: Cow<'a, AnyHash>,
     /// The limit for the number of operator and package records to fetch.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<u16>,
@@ -48,7 +48,7 @@ pub struct FetchLogsResponse {
 pub enum FetchError {
     /// The provided checkpoint was not found.
     #[error("checkpoint `{0}` was not found")]
-    CheckpointNotFound(DynHash),
+    CheckpointNotFound(AnyHash),
     /// The provided log was not found.
     #[error("log `{0}` was not found")]
     LogNotFound(LogId),
@@ -148,14 +148,14 @@ impl<'de> Deserialize<'de> for FetchError {
                     })?))
                 }
                 EntityType::Log => Ok(Self::LogNotFound(
-                    id.parse::<DynHash>()
+                    id.parse::<AnyHash>()
                         .map_err(|_| {
                             serde::de::Error::invalid_value(Unexpected::Str(&id), &"a valid log id")
                         })?
                         .into(),
                 )),
                 EntityType::Record => Ok(Self::RecordNotFound(
-                    id.parse::<DynHash>()
+                    id.parse::<AnyHash>()
                         .map_err(|_| {
                             serde::de::Error::invalid_value(
                                 Unexpected::Str(&id),

--- a/crates/api/src/v1/paths.rs
+++ b/crates/api/src/v1/paths.rs
@@ -1,6 +1,6 @@
 //! The paths of the Warg REST API.
 
-use warg_crypto::hash::DynHash;
+use warg_crypto::hash::AnyHash;
 use warg_protocol::registry::{LogId, RecordId};
 
 /// The path of the "fetch logs" API.
@@ -24,7 +24,7 @@ pub fn package_record(log_id: &LogId, record_id: &RecordId) -> String {
 }
 
 /// The path for a package record's content.
-pub fn package_record_content(log_id: &LogId, record_id: &RecordId, digest: &DynHash) -> String {
+pub fn package_record_content(log_id: &LogId, record_id: &RecordId, digest: &AnyHash) -> String {
     format!("v1/package/{log_id}/record/{record_id}/content/{digest}")
 }
 

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -17,7 +17,7 @@ use warg_api::v1::{
     proof::{ConsistencyRequest, InclusionRequest},
 };
 use warg_crypto::{
-    hash::{DynHash, Hash, Sha256},
+    hash::{AnyHash, Hash, Sha256},
     signing,
 };
 use warg_protocol::{
@@ -355,7 +355,7 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
         checkpoint: &SerdeEnvelope<MapCheckpoint>,
         packages: impl IntoIterator<Item = &mut PackageInfo>,
     ) -> Result<(), ClientError> {
-        let root: DynHash = Hash::<Sha256>::of(checkpoint.as_ref()).into();
+        let root: AnyHash = Hash::<Sha256>::of(checkpoint.as_ref()).into();
         tracing::info!("updating to checkpoint `{root}`");
 
         let mut operator = self.registry.load_operator().await?.unwrap_or_default();
@@ -536,7 +536,7 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
         &self,
         log_id: &LogId,
         record_id: &RecordId,
-        digest: &DynHash,
+        digest: &AnyHash,
     ) -> Result<PathBuf, ClientError> {
         match self.content.content_location(digest) {
             Some(path) => {
@@ -632,7 +632,7 @@ pub struct PackageDownload {
     /// The package version that was downloaded.
     pub version: Version,
     /// The digest of the package contents.
-    pub digest: DynHash,
+    pub digest: AnyHash,
     /// The path to the downloaded package contents.
     pub path: PathBuf,
 }
@@ -705,7 +705,7 @@ pub enum ClientError {
     #[error("content with digest `{digest}` was not found in client storage")]
     ContentNotFound {
         /// The digest of the missing content.
-        digest: DynHash,
+        digest: AnyHash,
     },
 
     /// The package log is empty and cannot be validated.

--- a/crates/client/src/storage.rs
+++ b/crates/client/src/storage.rs
@@ -7,7 +7,7 @@ use futures_util::Stream;
 use serde::{Deserialize, Serialize};
 use std::{path::PathBuf, pin::Pin, time::SystemTime};
 use warg_crypto::{
-    hash::{DynHash, HashAlgorithm},
+    hash::{AnyHash, HashAlgorithm},
     signing,
 };
 use warg_protocol::{
@@ -75,14 +75,14 @@ pub trait ContentStorage: Send + Sync {
     /// exists as a file on disk.
     ///
     /// Returns `None` if the content is not present on disk.
-    fn content_location(&self, digest: &DynHash) -> Option<PathBuf>;
+    fn content_location(&self, digest: &AnyHash) -> Option<PathBuf>;
 
     /// Loads the content associated with the given digest as a stream.
     ///
     /// If the content is not found, `Ok(None)` is returned.
     async fn load_content(
         &self,
-        digest: &DynHash,
+        digest: &AnyHash,
     ) -> Result<Option<Pin<Box<dyn Stream<Item = Result<Bytes>> + Send + Sync>>>>;
 
     /// Stores the given stream as content.
@@ -95,8 +95,8 @@ pub trait ContentStorage: Send + Sync {
     async fn store_content(
         &self,
         stream: Pin<Box<dyn Stream<Item = Result<Bytes>> + Send + Sync>>,
-        expected_digest: Option<&DynHash>,
-    ) -> Result<DynHash>;
+        expected_digest: Option<&AnyHash>,
+    ) -> Result<AnyHash>;
 }
 
 /// Represents information about a registry operator.
@@ -144,7 +144,7 @@ pub enum PublishEntry {
         /// The version of the release.
         version: Version,
         /// The content digest of the release.
-        content: DynHash,
+        content: AnyHash,
     },
 }
 

--- a/crates/crypto/src/hash/mod.rs
+++ b/crates/crypto/src/hash/mod.rs
@@ -7,7 +7,7 @@ mod dynamic;
 mod r#static;
 
 pub use digest::{Digest, Output};
-pub use dynamic::{DynHash, DynHashError};
+pub use dynamic::{AnyHash, AnyHashError};
 pub use r#static::Hash;
 pub use sha2::Sha256;
 
@@ -54,9 +54,9 @@ mod private {
     impl Sealed for Sha256 {}
 }
 
-impl<D: SupportedDigest> From<Hash<D>> for DynHash {
+impl<D: SupportedDigest> From<Hash<D>> for AnyHash {
     fn from(value: Hash<D>) -> Self {
-        DynHash {
+        AnyHash {
             algo: D::ALGORITHM,
             bytes: value.digest.to_vec(),
         }
@@ -79,10 +79,10 @@ pub enum HashError {
     },
 }
 
-impl<D: SupportedDigest> TryFrom<DynHash> for Hash<D> {
+impl<D: SupportedDigest> TryFrom<AnyHash> for Hash<D> {
     type Error = HashError;
 
-    fn try_from(value: DynHash) -> Result<Self, Self::Error> {
+    fn try_from(value: AnyHash) -> Result<Self, Self::Error> {
         if value.algorithm() == D::ALGORITHM {
             let len = value.bytes.len();
             match Hash::try_from(value.bytes) {

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -1,6 +1,6 @@
 use serde::{de::DeserializeOwned, Serialize};
 use std::collections::HashSet;
-use warg_crypto::{hash::DynHash, Decode};
+use warg_crypto::{hash::AnyHash, Decode};
 
 pub mod operator;
 pub mod package;
@@ -17,7 +17,7 @@ pub trait Record: Clone + Decode + Send + Sync {
     /// Gets the set of content hashes associated with the record.
     ///
     /// An empty set indicates that the record has no associated content.
-    fn contents(&self) -> HashSet<&DynHash>;
+    fn contents(&self) -> HashSet<&AnyHash>;
 }
 
 /// Trait implemented by the validator types.

--- a/crates/protocol/src/operator/mod.rs
+++ b/crates/protocol/src/operator/mod.rs
@@ -2,7 +2,7 @@ use crate::{protobuf, registry::RecordId};
 use anyhow::{Context, Error};
 use prost::Message;
 use thiserror::Error;
-use warg_crypto::{hash::DynHash, Decode, Encode, Signable};
+use warg_crypto::{hash::AnyHash, Decode, Encode, Signable};
 
 mod model;
 mod validate;
@@ -25,7 +25,7 @@ impl TryFrom<protobuf::OperatorRecord> for model::OperatorRecord {
     fn try_from(record: protobuf::OperatorRecord) -> Result<Self, Self::Error> {
         let prev: Option<RecordId> = match record.prev {
             Some(hash_string) => {
-                let digest: DynHash = hash_string.parse()?;
+                let digest: AnyHash = hash_string.parse()?;
                 Some(digest.into())
             }
             None => None,

--- a/crates/protocol/src/operator/model.rs
+++ b/crates/protocol/src/operator/model.rs
@@ -3,7 +3,7 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::{str::FromStr, time::SystemTime};
-use warg_crypto::hash::{DynHash, HashAlgorithm};
+use warg_crypto::hash::{AnyHash, HashAlgorithm};
 use warg_crypto::signing;
 
 /// An operator record is a collection of entries published together by the same author
@@ -20,7 +20,7 @@ pub struct OperatorRecord {
 }
 
 impl crate::Record for OperatorRecord {
-    fn contents(&self) -> HashSet<&DynHash> {
+    fn contents(&self) -> HashSet<&AnyHash> {
         Default::default()
     }
 }

--- a/crates/protocol/src/package/mod.rs
+++ b/crates/protocol/src/package/mod.rs
@@ -2,7 +2,7 @@ use crate::{protobuf, registry::RecordId};
 use anyhow::Error;
 use prost::Message;
 use thiserror::Error;
-use warg_crypto::{hash::DynHash, Decode, Encode, Signable};
+use warg_crypto::{hash::AnyHash, Decode, Encode, Signable};
 
 mod model;
 mod validate;
@@ -25,7 +25,7 @@ impl TryFrom<protobuf::PackageRecord> for model::PackageRecord {
     fn try_from(record: protobuf::PackageRecord) -> Result<Self, Self::Error> {
         let prev: Option<RecordId> = match record.prev {
             Some(hash_string) => {
-                let hash: DynHash = hash_string.parse()?;
+                let hash: AnyHash = hash_string.parse()?;
                 Some(hash.into())
             }
             None => None,

--- a/crates/protocol/src/package/model.rs
+++ b/crates/protocol/src/package/model.rs
@@ -4,7 +4,7 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::{str::FromStr, time::SystemTime};
-use warg_crypto::hash::{DynHash, HashAlgorithm};
+use warg_crypto::hash::{AnyHash, HashAlgorithm};
 use warg_crypto::signing;
 
 /// A package record is a collection of entries published together by the same author
@@ -21,7 +21,7 @@ pub struct PackageRecord {
 }
 
 impl crate::Record for PackageRecord {
-    fn contents(&self) -> HashSet<&DynHash> {
+    fn contents(&self) -> HashSet<&AnyHash> {
         self.entries
             .iter()
             .filter_map(PackageEntry::content)
@@ -91,7 +91,7 @@ pub enum PackageEntry {
     },
     /// Release a version of a package.
     /// The version must not have been released yet.
-    Release { version: Version, content: DynHash },
+    Release { version: Version, content: AnyHash },
     /// Yank a version of a package.
     /// The version must have been released and not yanked.
     Yank { version: Version },
@@ -110,7 +110,7 @@ impl PackageEntry {
     /// Gets the content associated with the entry.
     ///
     /// Returns `None` if the entry does not have content.
-    pub fn content(&self) -> Option<&DynHash> {
+    pub fn content(&self) -> Option<&AnyHash> {
         match self {
             Self::Release { content, .. } => Some(content),
             _ => None,

--- a/crates/protocol/src/package/validate.rs
+++ b/crates/protocol/src/package/validate.rs
@@ -6,7 +6,7 @@ use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use std::time::SystemTime;
 use thiserror::Error;
-use warg_crypto::hash::{DynHash, HashAlgorithm, Sha256};
+use warg_crypto::hash::{AnyHash, HashAlgorithm, Sha256};
 use warg_crypto::{signing, Signable};
 
 #[derive(Error, Debug)]
@@ -76,7 +76,7 @@ pub enum ReleaseState {
     /// The release is currently available.
     Released {
         /// The content digest associated with the release.
-        content: DynHash,
+        content: AnyHash,
     },
     /// The release has been yanked.
     Yanked {
@@ -114,7 +114,7 @@ impl Release {
     /// Gets the content associated with the release.
     ///
     /// Returns `None` if the release has been yanked.
-    pub fn content(&self) -> Option<&DynHash> {
+    pub fn content(&self) -> Option<&AnyHash> {
         match &self.state {
             ReleaseState::Released { content } => Some(content),
             ReleaseState::Yanked { .. } => None,
@@ -447,7 +447,7 @@ impl Validator {
         signer_key_id: &signing::KeyID,
         timestamp: SystemTime,
         version: &Version,
-        content: &DynHash,
+        content: &AnyHash,
     ) -> Result<(), ValidationError> {
         match self.releases.entry(version.clone()) {
             Entry::Occupied(e) => {

--- a/crates/protocol/src/proto_envelope.rs
+++ b/crates/protocol/src/proto_envelope.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{base64::Base64, serde_as};
 use std::fmt;
 use thiserror::Error;
-use warg_crypto::{hash::DynHashError, signing, Decode, Signable};
+use warg_crypto::{hash::AnyHashError, signing, Decode, Signable};
 
 /// The envelope struct is used to keep around the original
 /// bytes that the content was serialized into in case
@@ -107,7 +107,7 @@ pub enum ParseEnvelopeError {
     Contents(#[from] Error),
 
     #[error("failed to parse envelope key id")]
-    KeyID(#[from] DynHashError),
+    KeyID(#[from] AnyHashError),
 
     #[error("failed to parse envelope signature")]
     Signature(#[from] signing::SignatureParseError),

--- a/crates/protocol/src/registry.rs
+++ b/crates/protocol/src/registry.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::{operator::OperatorRecord, package::PackageRecord, ProtoEnvelope};
 use serde::{Deserialize, Serialize};
-use warg_crypto::hash::{DynHash, Hash, HashAlgorithm, SupportedDigest};
+use warg_crypto::hash::{AnyHash, Hash, HashAlgorithm, SupportedDigest};
 use warg_crypto::{prefix, ByteVisitor, Signable, VisitBytes};
 
 use warg_crypto::prefix::VisitPrefixEncode;
@@ -10,9 +10,9 @@ use warg_crypto::prefix::VisitPrefixEncode;
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MapCheckpoint {
-    pub log_root: DynHash,
+    pub log_root: AnyHash,
     pub log_length: u32,
-    pub map_root: DynHash,
+    pub map_root: AnyHash,
 }
 
 impl Signable for MapCheckpoint {
@@ -78,7 +78,7 @@ impl VisitBytes for LogLeaf {
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct LogId(DynHash);
+pub struct LogId(AnyHash);
 
 impl LogId {
     pub fn operator_log<D: SupportedDigest>() -> Self {
@@ -106,13 +106,13 @@ impl VisitBytes for LogId {
     }
 }
 
-impl From<DynHash> for LogId {
-    fn from(value: DynHash) -> Self {
+impl From<AnyHash> for LogId {
+    fn from(value: AnyHash) -> Self {
         Self(value)
     }
 }
 
-impl From<LogId> for DynHash {
+impl From<LogId> for AnyHash {
     fn from(id: LogId) -> Self {
         id.0
     }
@@ -126,7 +126,7 @@ impl AsRef<[u8]> for LogId {
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct RecordId(DynHash);
+pub struct RecordId(AnyHash);
 
 impl RecordId {
     pub fn algorithm(&self) -> HashAlgorithm {
@@ -152,8 +152,8 @@ impl fmt::Display for RecordId {
     }
 }
 
-impl From<DynHash> for RecordId {
-    fn from(value: DynHash) -> Self {
+impl From<AnyHash> for RecordId {
+    fn from(value: AnyHash) -> Self {
         Self(value)
     }
 }

--- a/crates/server/src/api/v1/package.rs
+++ b/crates/server/src/api/v1/package.rs
@@ -20,7 +20,7 @@ use tokio::io::AsyncWriteExt;
 use warg_api::v1::package::{
     ContentSource, PackageError, PackageRecord, PackageRecordState, PublishRecordRequest,
 };
-use warg_crypto::hash::{DynHash, Sha256};
+use warg_crypto::hash::{AnyHash, Sha256};
 use warg_protocol::{
     package,
     registry::{LogId, RecordId},
@@ -64,19 +64,19 @@ impl Config {
             .with_state(self)
     }
 
-    fn content_present(&self, digest: &DynHash) -> bool {
+    fn content_present(&self, digest: &AnyHash) -> bool {
         self.content_path(digest).is_file()
     }
 
-    fn content_file_name(&self, digest: &DynHash) -> String {
+    fn content_file_name(&self, digest: &AnyHash) -> String {
         digest.to_string().replace(':', "-")
     }
 
-    fn content_path(&self, digest: &DynHash) -> PathBuf {
+    fn content_path(&self, digest: &AnyHash) -> PathBuf {
         self.files_dir.join(self.content_file_name(digest))
     }
 
-    fn content_url(&self, digest: &DynHash) -> String {
+    fn content_url(&self, digest: &AnyHash) -> String {
         format!(
             "{url}/content/{name}",
             url = self.base_url,
@@ -268,7 +268,7 @@ async fn get_record(
 #[debug_handler]
 async fn upload_content(
     State(config): State<Config>,
-    Path((log_id, record_id, digest)): Path<(LogId, RecordId, DynHash)>,
+    Path((log_id, record_id, digest)): Path<(LogId, RecordId, AnyHash)>,
     stream: BodyStream,
 ) -> Result<impl IntoResponse, PackageApiError> {
     match config
@@ -341,7 +341,7 @@ async fn upload_content(
 
 async fn process_content(
     path: &std::path::Path,
-    digest: &DynHash,
+    digest: &AnyHash,
     mut stream: BodyStream,
     policy: Option<&dyn ContentPolicy>,
 ) -> Result<(), PackageApiError> {

--- a/crates/server/src/datastore/memory.rs
+++ b/crates/server/src/datastore/memory.rs
@@ -7,7 +7,7 @@ use std::{
     sync::Arc,
 };
 use tokio::sync::RwLock;
-use warg_crypto::hash::DynHash;
+use warg_crypto::hash::AnyHash;
 use warg_protocol::{
     operator, package,
     registry::{LogId, LogLeaf, MapCheckpoint, RecordId},
@@ -46,7 +46,7 @@ enum PendingRecord {
     },
     Package {
         record: Option<ProtoEnvelope<package::PackageRecord>>,
-        missing: HashSet<DynHash>,
+        missing: HashSet<AnyHash>,
     },
 }
 
@@ -71,7 +71,7 @@ enum RecordStatus {
 struct State {
     operators: HashMap<LogId, Log<operator::Validator, operator::OperatorRecord>>,
     packages: HashMap<LogId, Log<package::Validator, package::PackageRecord>>,
-    checkpoints: IndexMap<DynHash, SerdeEnvelope<MapCheckpoint>>,
+    checkpoints: IndexMap<AnyHash, SerdeEnvelope<MapCheckpoint>>,
     records: HashMap<LogId, HashMap<RecordId, RecordStatus>>,
 }
 
@@ -213,7 +213,7 @@ impl DataStore for MemoryDataStore {
         _name: &str,
         record_id: &RecordId,
         record: &ProtoEnvelope<package::PackageRecord>,
-        missing: &HashSet<&DynHash>,
+        missing: &HashSet<&AnyHash>,
     ) -> Result<(), DataStoreError> {
         // Ensure the set of missing hashes is a subset of the record contents.
         debug_assert!({
@@ -315,7 +315,7 @@ impl DataStore for MemoryDataStore {
         &self,
         log_id: &LogId,
         record_id: &RecordId,
-        digest: &DynHash,
+        digest: &AnyHash,
     ) -> Result<bool, DataStoreError> {
         let state = self.0.read().await;
         let log = state
@@ -343,7 +343,7 @@ impl DataStore for MemoryDataStore {
         &self,
         log_id: &LogId,
         record_id: &RecordId,
-        digest: &DynHash,
+        digest: &AnyHash,
     ) -> Result<bool, DataStoreError> {
         let mut state = self.0.write().await;
         let log = state
@@ -375,7 +375,7 @@ impl DataStore for MemoryDataStore {
 
     async fn store_checkpoint(
         &self,
-        checkpoint_id: &DynHash,
+        checkpoint_id: &AnyHash,
         checkpoint: SerdeEnvelope<MapCheckpoint>,
         participants: &[LogLeaf],
     ) -> Result<(), DataStoreError> {
@@ -421,7 +421,7 @@ impl DataStore for MemoryDataStore {
     async fn get_operator_records(
         &self,
         log_id: &LogId,
-        root: &DynHash,
+        root: &AnyHash,
         since: Option<&RecordId>,
         limit: u16,
     ) -> Result<Vec<ProtoEnvelope<operator::OperatorRecord>>, DataStoreError> {
@@ -451,7 +451,7 @@ impl DataStore for MemoryDataStore {
     async fn get_package_records(
         &self,
         log_id: &LogId,
-        root: &DynHash,
+        root: &AnyHash,
         since: Option<&RecordId>,
         limit: u16,
     ) -> Result<Vec<ProtoEnvelope<package::PackageRecord>>, DataStoreError> {

--- a/crates/server/src/datastore/postgres/models.rs
+++ b/crates/server/src/datastore/postgres/models.rs
@@ -11,7 +11,7 @@ use diesel_json::Json;
 use serde::Serialize;
 use std::{fmt::Display, io::Write, str::FromStr};
 use warg_crypto::{
-    hash::DynHash,
+    hash::AnyHash,
     signing::{KeyID, Signature},
 };
 use warg_protocol::registry::{LogId, RecordId};
@@ -80,10 +80,10 @@ pub struct NewRecord<'a> {
 #[derive(Insertable)]
 #[diesel(table_name = checkpoints)]
 pub struct NewCheckpoint<'a> {
-    pub checkpoint_id: TextRef<'a, DynHash>,
-    pub log_root: TextRef<'a, DynHash>,
+    pub checkpoint_id: TextRef<'a, AnyHash>,
+    pub log_root: TextRef<'a, AnyHash>,
     pub log_length: i64,
-    pub map_root: TextRef<'a, DynHash>,
+    pub map_root: TextRef<'a, AnyHash>,
     pub key_id: TextRef<'a, KeyID>,
     pub signature: TextRef<'a, Signature>,
 }
@@ -92,10 +92,10 @@ pub struct NewCheckpoint<'a> {
 #[diesel(table_name = checkpoints)]
 pub struct Checkpoint {
     pub id: i32,
-    pub checkpoint_id: ParsedText<DynHash>,
-    pub log_root: ParsedText<DynHash>,
+    pub checkpoint_id: ParsedText<AnyHash>,
+    pub log_root: ParsedText<AnyHash>,
     pub log_length: i64,
-    pub map_root: ParsedText<DynHash>,
+    pub map_root: ParsedText<AnyHash>,
     pub key_id: Text<KeyID>,
     pub signature: ParsedText<Signature>,
     pub created_at: DateTime<Utc>,
@@ -115,9 +115,9 @@ pub struct RecordContent {
 #[derive(Queryable, Selectable)]
 #[diesel(table_name = checkpoints)]
 pub struct CheckpointData {
-    pub log_root: ParsedText<DynHash>,
+    pub log_root: ParsedText<AnyHash>,
     pub log_length: i64,
-    pub map_root: ParsedText<DynHash>,
+    pub map_root: ParsedText<AnyHash>,
     pub key_id: Text<KeyID>,
     pub signature: ParsedText<Signature>,
 }
@@ -126,6 +126,6 @@ pub struct CheckpointData {
 #[diesel(table_name = contents)]
 pub struct NewContent<'a> {
     pub record_id: i32,
-    pub digest: TextRef<'a, DynHash>,
+    pub digest: TextRef<'a, AnyHash>,
     pub missing: bool,
 }

--- a/crates/server/src/policy/content/mod.rs
+++ b/crates/server/src/policy/content/mod.rs
@@ -1,6 +1,6 @@
 //! Module for server content policy implementations.
 use thiserror::Error;
-use warg_crypto::hash::DynHash;
+use warg_crypto::hash::AnyHash;
 
 mod wasm;
 
@@ -28,7 +28,7 @@ pub trait ContentPolicy: Send + Sync {
     /// to check the content as it is received.
     fn new_stream_policy(
         &self,
-        digest: &DynHash,
+        digest: &AnyHash,
     ) -> ContentPolicyResult<Box<dyn ContentStreamPolicy>>;
 }
 
@@ -71,7 +71,7 @@ impl ContentPolicyCollection {
 impl ContentPolicy for ContentPolicyCollection {
     fn new_stream_policy(
         &self,
-        digest: &DynHash,
+        digest: &AnyHash,
     ) -> ContentPolicyResult<Box<dyn ContentStreamPolicy>> {
         Ok(Box::new(ContentStreamPolicyCollection {
             policies: self

--- a/crates/server/src/policy/content/wasm.rs
+++ b/crates/server/src/policy/content/wasm.rs
@@ -1,5 +1,5 @@
 use super::{ContentPolicy, ContentPolicyError, ContentPolicyResult, ContentStreamPolicy};
-use warg_crypto::hash::DynHash;
+use warg_crypto::hash::AnyHash;
 use wasmparser::{
     Chunk, Encoding, FuncValidatorAllocations, Parser, ValidPayload, Validator, WasmFeatures,
 };
@@ -54,7 +54,7 @@ impl Default for WasmContentPolicy {
 impl ContentPolicy for WasmContentPolicy {
     fn new_stream_policy(
         &self,
-        _digest: &DynHash,
+        _digest: &AnyHash,
     ) -> ContentPolicyResult<Box<dyn ContentStreamPolicy>> {
         Ok(Box::new(WasmContentStreamPolicy {
             buffer: Vec::new(),

--- a/crates/server/src/services/core.rs
+++ b/crates/server/src/services/core.rs
@@ -22,7 +22,7 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 use warg_crypto::{
-    hash::{DynHash, Hash, HashAlgorithm, Sha256},
+    hash::{AnyHash, Hash, HashAlgorithm, Sha256},
     signing::PrivateKey,
 };
 use warg_protocol::{
@@ -265,7 +265,7 @@ impl CoreService {
         data.map_data.insert(data.map.clone());
 
         let checkpoint = data.log.checkpoint();
-        let log_root: DynHash = checkpoint.root().into();
+        let log_root: AnyHash = checkpoint.root().into();
         let log_length = checkpoint.length() as u32;
 
         let checkpoint = MapCheckpoint {

--- a/crates/server/src/services/transparency/log.rs
+++ b/crates/server/src/services/transparency/log.rs
@@ -1,7 +1,7 @@
 use tokio::sync::mpsc::{self, Receiver};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use warg_crypto::hash::{DynHash, Sha256};
+use warg_crypto::hash::{AnyHash, Sha256};
 use warg_protocol::registry::LogLeaf;
 use warg_transparency::log::{LogBuilder, StackLog};
 
@@ -22,7 +22,7 @@ pub struct Output {
 #[derive(Debug)]
 pub struct Summary {
     pub leaf: LogLeaf,
-    pub log_root: DynHash,
+    pub log_root: AnyHash,
     pub log_length: u32,
 }
 
@@ -44,7 +44,7 @@ pub fn spawn(input: Input) -> Output {
                         log.push(&leaf);
 
                         let checkpoint = log.checkpoint();
-                        let log_root: DynHash = checkpoint.root().into();
+                        let log_root: AnyHash = checkpoint.root().into();
                         let log_length = checkpoint.length() as u32;
 
                         log_tx.send(leaf.clone()).await.unwrap();

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -2,7 +2,7 @@ use super::CommonOptions;
 use anyhow::Result;
 use clap::Args;
 use warg_client::storage::{PackageInfo, RegistryStorage};
-use warg_crypto::hash::DynHash;
+use warg_crypto::hash::AnyHash;
 use warg_protocol::Version;
 
 /// Display client storage information.
@@ -54,7 +54,7 @@ impl InfoCommand {
         });
     }
 
-    fn print_release(version: &Version, content: &DynHash) {
+    fn print_release(version: &Version, content: &AnyHash) {
         println!("    {version} ({content})");
     }
 }

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -11,7 +11,7 @@ use warg_client::{
     storage::{ContentStorage as _, PublishEntry, PublishInfo, RegistryStorage as _},
     FileSystemClient,
 };
-use warg_crypto::hash::DynHash;
+use warg_crypto::hash::AnyHash;
 use warg_protocol::{registry::RecordId, Version};
 
 const DEFAULT_WAIT_INTERVAL: Duration = Duration::from_secs(1);
@@ -438,7 +438,7 @@ pub struct PublishWaitCommand {
 
     /// The identifier of the package record to wait for completion.
     #[clap(value_name = "RECORD")]
-    pub record_id: DynHash,
+    pub record_id: AnyHash,
 }
 
 impl PublishWaitCommand {


### PR DESCRIPTION
Avoids the possible confusion associating with the `dyn` Rust keyword.