### PR TITLE
Implement authorization by publishing key id.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3952,6 +3952,7 @@ dependencies = [
  "thiserror",
  "warg-crypto",
  "warg-transparency",
+ "wasmparser 0.107.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3384,6 +3384,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "testresult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e045f5cf9ad69772c1c9652f5567a75df88bbb5a1310a64e53cab140c5c459"
+
+[[package]]
 name = "thiserror"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3851,12 +3857,16 @@ dependencies = [
  "keyring",
  "p256",
  "rand_core",
+ "reqwest",
  "rpassword",
+ "serde_json",
+ "testresult",
  "thiserror",
  "tokio",
  "tokio-util",
  "tracing-subscriber",
  "url",
+ "warg-api",
  "warg-client",
  "warg-crypto",
  "warg-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,14 @@ wasmtime = "9.0"
 wasmtime-wasi = "9.0"
 
 [dev-dependencies]
+reqwest = { workspace = true }
+serde_json = { workspace = true }
 warg-server = { workspace = true }
+warg-api = { workspace = true }
 wat = "1.0.66"
 wit-component = "0.11.0"
 wit-parser = "0.8.0"
+testresult = "0.3.0"
 
 [features]
 default = []

--- a/crates/api/src/v1/package.rs
+++ b/crates/api/src/v1/package.rs
@@ -6,7 +6,7 @@ use std::{borrow::Cow, collections::HashMap};
 use thiserror::Error;
 use warg_crypto::hash::AnyHash;
 use warg_protocol::{
-    registry::{LogId, MapCheckpoint, RecordId},
+    registry::{LogId, MapCheckpoint, PackageId, RecordId},
     ProtoEnvelopeBody, SerdeEnvelope,
 };
 
@@ -25,8 +25,8 @@ pub enum ContentSource {
 #[derive(Serialize, Deserialize)]
 #[serde(rename = "camelCase")]
 pub struct PublishRecordRequest<'a> {
-    /// The name of the package being published.
-    pub name: Cow<'a, str>,
+    /// The id of the package being published.
+    pub id: Cow<'a, PackageId>,
     /// The publish record to add to the package log.
     pub record: Cow<'a, ProtoEnvelopeBody>,
     /// The complete set of content sources for the record.
@@ -111,8 +111,8 @@ pub enum PackageError {
     /// The record is not currently sourcing content.
     #[error("the record is not currently sourcing content")]
     RecordNotSourcing,
-    /// The publish operation was not authorized by the registry.
-    #[error("registry did not authorize the request to publish: {0}")]
+    /// The operation was not authorized by the registry.
+    #[error("unauthorized operation: {0}")]
     Unauthorized(String),
     /// The operation was not supported by the registry.
     #[error("the requested operation is not supported: {0}")]

--- a/crates/client/src/api.rs
+++ b/crates/client/src/api.rs
@@ -214,8 +214,8 @@ impl Client {
             .join(&paths::publish_package_record(log_id))
             .unwrap();
         tracing::debug!(
-            "appending record to package `{name}` at `{url}`",
-            name = request.name
+            "appending record to package `{id}` at `{url}`",
+            id = request.id
         );
 
         let response = self.client.post(url).json(&request).send().await?;

--- a/crates/client/src/storage.rs
+++ b/crates/client/src/storage.rs
@@ -13,7 +13,7 @@ use warg_crypto::{
 use warg_protocol::{
     operator,
     package::{self, PackageRecord, PACKAGE_RECORD_VERSION},
-    registry::{MapCheckpoint, RecordId},
+    registry::{MapCheckpoint, PackageId, RecordId},
     ProtoEnvelope, SerdeEnvelope, Version,
 };
 
@@ -49,7 +49,7 @@ pub trait RegistryStorage: Send + Sync {
     /// Loads the package information from the storage.
     ///
     /// Returns `Ok(None)` if the information is not present.
-    async fn load_package(&self, package: &str) -> Result<Option<PackageInfo>>;
+    async fn load_package(&self, package: &PackageId) -> Result<Option<PackageInfo>>;
 
     /// Stores the package information in the storage.
     async fn store_package(&self, info: &PackageInfo) -> Result<()>;
@@ -112,8 +112,8 @@ pub struct OperatorInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PackageInfo {
-    /// The name of the package.
-    pub name: String,
+    /// The id of the package to publish.
+    pub id: PackageId,
     /// The last known checkpoint of the package.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub checkpoint: Option<SerdeEnvelope<MapCheckpoint>>,
@@ -123,10 +123,10 @@ pub struct PackageInfo {
 }
 
 impl PackageInfo {
-    /// Creates a new package info for the given package name and url.
-    pub fn new(name: impl Into<String>) -> Self {
+    /// Creates a new package info for the given package id.
+    pub fn new(id: impl Into<PackageId>) -> Self {
         Self {
-            name: name.into(),
+            id: id.into(),
             checkpoint: None,
             state: package::Validator::default(),
         }
@@ -152,8 +152,8 @@ pub enum PublishEntry {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PublishInfo {
-    /// The name of the package being published.
-    pub package: String,
+    /// The id of the package being published.
+    pub id: PackageId,
     /// The last known head of the package log to use.
     ///
     /// If `None` and the package is not being initialized,

--- a/crates/client/src/storage/fs.rs
+++ b/crates/client/src/storage/fs.rs
@@ -19,7 +19,7 @@ use tokio_util::io::ReaderStream;
 use walkdir::WalkDir;
 use warg_crypto::hash::{AnyHash, Digest, Hash, Sha256};
 use warg_protocol::{
-    registry::{LogId, MapCheckpoint},
+    registry::{LogId, MapCheckpoint, PackageId},
     SerdeEnvelope,
 };
 
@@ -69,9 +69,9 @@ impl FileSystemRegistryStorage {
         self.base_dir.join("operator.log")
     }
 
-    fn package_path(&self, name: &str) -> PathBuf {
+    fn package_path(&self, id: &PackageId) -> PathBuf {
         self.base_dir.join(
-            LogId::package_log::<Sha256>(name)
+            LogId::package_log::<Sha256>(id)
                 .to_string()
                 .replace(':', "/"),
         )
@@ -133,12 +133,12 @@ impl RegistryStorage for FileSystemRegistryStorage {
         store(&self.operator_path(), info).await
     }
 
-    async fn load_package(&self, package: &str) -> Result<Option<PackageInfo>> {
+    async fn load_package(&self, package: &PackageId) -> Result<Option<PackageInfo>> {
         Ok(load(&self.package_path(package)).await?)
     }
 
     async fn store_package(&self, info: &PackageInfo) -> Result<()> {
-        store(&self.package_path(&info.name), info).await
+        store(&self.package_path(&info.id), info).await
     }
 
     async fn load_publish(&self) -> Result<Option<PublishInfo>> {

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = { workspace = true }
 [dependencies]
 warg-crypto = { workspace = true }
 warg-transparency = { workspace = true }
+wasmparser = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }

--- a/crates/protocol/src/operator/mod.rs
+++ b/crates/protocol/src/operator/mod.rs
@@ -52,7 +52,7 @@ impl TryFrom<protobuf::OperatorRecord> for model::OperatorRecord {
 }
 
 #[derive(Error, Debug)]
-#[error("Empty or invalid timestamp in record")]
+#[error("empty or invalid timestamp in record")]
 struct InvalidTimestampError;
 
 impl TryFrom<protobuf::OperatorEntry> for model::OperatorEntry {

--- a/crates/protocol/src/package/mod.rs
+++ b/crates/protocol/src/package/mod.rs
@@ -52,7 +52,7 @@ impl TryFrom<protobuf::PackageRecord> for model::PackageRecord {
 }
 
 #[derive(Error, Debug)]
-#[error("Empty or invalid timestamp in record")]
+#[error("empty or invalid timestamp in record")]
 struct InvalidTimestampError;
 
 impl TryFrom<protobuf::PackageEntry> for model::PackageEntry {

--- a/crates/protocol/src/registry.rs
+++ b/crates/protocol/src/registry.rs
@@ -84,7 +84,7 @@ impl VisitBytes for LogLeaf {
 ///
 /// A valid component model identifier is the format `<namespace>:<name>`,
 /// where both parts are also valid WIT identifiers (i.e. kebab-cased).
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct PackageId {
     id: String,
     colon: usize,

--- a/crates/protocol/src/registry.rs
+++ b/crates/protocol/src/registry.rs
@@ -1,11 +1,11 @@
-use std::fmt;
-
 use crate::{operator::OperatorRecord, package::PackageRecord, ProtoEnvelope};
+use anyhow::bail;
 use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
 use warg_crypto::hash::{AnyHash, Hash, HashAlgorithm, SupportedDigest};
-use warg_crypto::{prefix, ByteVisitor, Signable, VisitBytes};
-
 use warg_crypto::prefix::VisitPrefixEncode;
+use warg_crypto::{prefix, ByteVisitor, Signable, VisitBytes};
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -76,6 +76,114 @@ impl VisitBytes for LogLeaf {
     }
 }
 
+fn is_kebab_case(s: &str) -> bool {
+    let mut lower = false;
+    let mut upper = false;
+    for c in s.chars() {
+        match c {
+            'a'..='z' if !lower && !upper => lower = true,
+            'A'..='Z' if !lower && !upper => upper = true,
+            'a'..='z' if lower => continue,
+            'A'..='Z' if upper => continue,
+            '0'..='9' if lower || upper => continue,
+            '-' if lower || upper => {
+                lower = false;
+                upper = false;
+                continue;
+            }
+            _ => return false,
+        }
+    }
+
+    !s.is_empty() && !s.ends_with('-')
+}
+
+/// Represents a valid package identifier in the registry.
+///
+/// Valid package identifiers conform to the component model specification
+/// for identifiers.
+///
+/// A valid component model identifier is the format `<namespace>:<name>`,
+/// where both parts are also valid WIT identifiers (i.e. kebab-cased).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PackageId {
+    id: String,
+    colon: usize,
+}
+
+impl PackageId {
+    /// Creates a package identifier from the given string.
+    ///
+    /// Returns an error if the given string is not a valid package identifier.
+    pub fn new(id: impl Into<String>) -> anyhow::Result<Self> {
+        let id = id.into();
+
+        if let Some(colon) = id.find(':') {
+            if is_kebab_case(&id[..colon]) && is_kebab_case(&id[colon + 1..]) {
+                return Ok(Self { id, colon });
+            }
+        }
+
+        bail!("invalid package identifier `{id}`: expected format is `<namespace>:<name>`")
+    }
+
+    /// Gets the namespace part of the package identifier.
+    pub fn namespace(&self) -> &str {
+        &self.id[..self.colon]
+    }
+
+    /// Gets the name part of the package identifier.
+    pub fn name(&self) -> &str {
+        &self.id[self.colon + 1..]
+    }
+}
+
+impl AsRef<str> for PackageId {
+    fn as_ref(&self) -> &str {
+        &self.id
+    }
+}
+
+impl FromStr for PackageId {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
+    }
+}
+
+impl fmt::Display for PackageId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{id}", id = self.id)
+    }
+}
+
+impl prefix::VisitPrefixEncode for PackageId {
+    fn visit_pe<BV: ?Sized + ByteVisitor>(&self, visitor: &mut prefix::PrefixEncodeVisitor<BV>) {
+        visitor.visit_str_raw("WARG-PACKAGE-ID-V0");
+        visitor.visit_str(&self.id);
+    }
+}
+
+impl VisitBytes for PackageId {
+    fn visit<BV: ?Sized + ByteVisitor>(&self, visitor: &mut BV) {
+        self.visit_bv(visitor);
+    }
+}
+
+impl Serialize for PackageId {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.id)
+    }
+}
+
+impl<'de> Deserialize<'de> for PackageId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let id = String::deserialize(deserializer)?;
+        PackageId::new(id).map_err(serde::de::Error::custom)
+    }
+}
+
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct LogId(AnyHash);
@@ -87,9 +195,9 @@ impl LogId {
         Self(hash.into())
     }
 
-    pub fn package_log<D: SupportedDigest>(name: &str) -> Self {
+    pub fn package_log<D: SupportedDigest>(id: &PackageId) -> Self {
         let prefix: &[u8] = b"WARG-PACKAGE-LOG-ID-V0:".as_slice();
-        let hash: Hash<D> = Hash::of((prefix, name));
+        let hash: Hash<D> = Hash::of((prefix, id));
         Self(hash.into())
     }
 }

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -1,6 +1,10 @@
 use crate::{policy::content::ContentPolicy, services::CoreService};
 use axum::{body::Body, http::Request, Router};
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+    sync::Arc,
+};
 use tower::ServiceBuilder;
 use tower_http::{
     cors::{Any, CorsLayer},
@@ -9,6 +13,7 @@ use tower_http::{
     LatencyUnit,
 };
 use tracing::{Level, Span};
+use warg_crypto::signing::KeyID;
 
 pub mod v1;
 
@@ -19,11 +24,19 @@ pub fn create_router(
     temp_dir: PathBuf,
     files_dir: PathBuf,
     content_policy: Option<Arc<dyn ContentPolicy>>,
+    authorized_keys: Option<HashMap<String, HashSet<KeyID>>>,
 ) -> Router {
     Router::new()
         .nest(
             "/v1",
-            v1::create_router(base_url, core, temp_dir, files_dir.clone(), content_policy),
+            v1::create_router(
+                base_url,
+                core,
+                temp_dir,
+                files_dir.clone(),
+                content_policy,
+                authorized_keys,
+            ),
         )
         .nest_service("/content", ServeDir::new(files_dir))
         .layer(

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -1,10 +1,9 @@
-use crate::{policy::content::ContentPolicy, services::CoreService};
-use axum::{body::Body, http::Request, Router};
-use std::{
-    collections::{HashMap, HashSet},
-    path::PathBuf,
-    sync::Arc,
+use crate::{
+    policy::{content::ContentPolicy, record::RecordPolicy},
+    services::CoreService,
 };
+use axum::{body::Body, http::Request, Router};
+use std::{path::PathBuf, sync::Arc};
 use tower::ServiceBuilder;
 use tower_http::{
     cors::{Any, CorsLayer},
@@ -13,7 +12,6 @@ use tower_http::{
     LatencyUnit,
 };
 use tracing::{Level, Span};
-use warg_crypto::signing::KeyID;
 
 pub mod v1;
 
@@ -24,7 +22,7 @@ pub fn create_router(
     temp_dir: PathBuf,
     files_dir: PathBuf,
     content_policy: Option<Arc<dyn ContentPolicy>>,
-    authorized_keys: Option<HashMap<String, HashSet<KeyID>>>,
+    record_policy: Option<Arc<dyn RecordPolicy>>,
 ) -> Router {
     Router::new()
         .nest(
@@ -35,7 +33,7 @@ pub fn create_router(
                 temp_dir,
                 files_dir.clone(),
                 content_policy,
-                authorized_keys,
+                record_policy,
             ),
         )
         .nest_service("/content", ServeDir::new(files_dir))

--- a/crates/server/src/api/v1/mod.rs
+++ b/crates/server/src/api/v1/mod.rs
@@ -1,4 +1,7 @@
-use crate::{policy::content::ContentPolicy, services::CoreService};
+use crate::{
+    policy::{content::ContentPolicy, record::RecordPolicy},
+    services::CoreService,
+};
 use anyhow::Result;
 use axum::{
     extract::{
@@ -10,12 +13,7 @@ use axum::{
     Router,
 };
 use serde::{Serialize, Serializer};
-use std::{
-    collections::{HashMap, HashSet},
-    path::PathBuf,
-    sync::Arc,
-};
-use warg_crypto::signing::KeyID;
+use std::{path::PathBuf, sync::Arc};
 
 pub mod fetch;
 pub mod package;
@@ -96,7 +94,7 @@ pub fn create_router(
     temp_dir: PathBuf,
     files_dir: PathBuf,
     content_policy: Option<Arc<dyn ContentPolicy>>,
-    authorized_keys: Option<HashMap<String, HashSet<KeyID>>>,
+    record_policy: Option<Arc<dyn RecordPolicy>>,
 ) -> Router {
     let proof_config = proof::Config::new(core.log_data().clone(), core.map_data().clone());
     let package_config = package::Config::new(
@@ -105,7 +103,7 @@ pub fn create_router(
         files_dir,
         temp_dir,
         content_policy,
-        authorized_keys,
+        record_policy,
     );
     let fetch_config = fetch::Config::new(core);
 

--- a/crates/server/src/api/v1/mod.rs
+++ b/crates/server/src/api/v1/mod.rs
@@ -10,7 +10,12 @@ use axum::{
     Router,
 };
 use serde::{Serialize, Serializer};
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+    sync::Arc,
+};
+use warg_crypto::signing::KeyID;
 
 pub mod fetch;
 pub mod package;
@@ -91,10 +96,17 @@ pub fn create_router(
     temp_dir: PathBuf,
     files_dir: PathBuf,
     content_policy: Option<Arc<dyn ContentPolicy>>,
+    authorized_keys: Option<HashMap<String, HashSet<KeyID>>>,
 ) -> Router {
     let proof_config = proof::Config::new(core.log_data().clone(), core.map_data().clone());
-    let package_config =
-        package::Config::new(core.clone(), base_url, files_dir, temp_dir, content_policy);
+    let package_config = package::Config::new(
+        core.clone(),
+        base_url,
+        files_dir,
+        temp_dir,
+        content_policy,
+        authorized_keys,
+    );
     let fetch_config = fetch::Config::new(core);
 
     Router::new()

--- a/crates/server/src/datastore/memory.rs
+++ b/crates/server/src/datastore/memory.rs
@@ -7,9 +7,10 @@ use std::{
     sync::Arc,
 };
 use tokio::sync::RwLock;
-use warg_crypto::hash::AnyHash;
+use warg_crypto::{hash::AnyHash, Signable};
 use warg_protocol::{
-    operator, package,
+    operator,
+    package::{self, PackageEntry},
     registry::{LogId, LogLeaf, MapCheckpoint, RecordId},
     ProtoEnvelope, SerdeEnvelope,
 };
@@ -576,5 +577,28 @@ impl DataStore for MemoryDataStore {
             envelope,
             checkpoint,
         })
+    }
+
+    async fn verify_package_record_signature(
+        &self,
+        log_id: &LogId,
+        record: &ProtoEnvelope<package::PackageRecord>,
+    ) -> Result<(), DataStoreError> {
+        let state = self.0.read().await;
+        let key = match state
+            .packages
+            .get(log_id)
+            .and_then(|log| log.validator.public_key(record.key_id()))
+        {
+            Some(key) => Some(key),
+            None => match record.as_ref().entries.first() {
+                Some(PackageEntry::Init { key, .. }) => Some(key),
+                _ => return Err(DataStoreError::UnknownKey(record.key_id().clone())),
+            },
+        }
+        .ok_or_else(|| DataStoreError::UnknownKey(record.key_id().clone()))?;
+
+        package::PackageRecord::verify(key, record.content_bytes(), record.signature())
+            .map_err(|_| DataStoreError::SignatureVerificationFailed)
     }
 }

--- a/crates/server/src/datastore/memory.rs
+++ b/crates/server/src/datastore/memory.rs
@@ -11,7 +11,7 @@ use warg_crypto::{hash::AnyHash, Signable};
 use warg_protocol::{
     operator,
     package::{self, PackageEntry},
-    registry::{LogId, LogLeaf, MapCheckpoint, RecordId},
+    registry::{LogId, LogLeaf, MapCheckpoint, PackageId, RecordId},
     ProtoEnvelope, SerdeEnvelope,
 };
 
@@ -211,7 +211,7 @@ impl DataStore for MemoryDataStore {
     async fn store_package_record(
         &self,
         log_id: &LogId,
-        _name: &str,
+        _package_id: &PackageId,
         record_id: &RecordId,
         record: &ProtoEnvelope<package::PackageRecord>,
         missing: &HashSet<&AnyHash>,

--- a/crates/server/src/datastore/mod.rs
+++ b/crates/server/src/datastore/mod.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 use warg_crypto::{hash::AnyHash, signing::KeyID};
 use warg_protocol::{
     operator, package,
-    registry::{LogId, LogLeaf, MapCheckpoint, RecordId},
+    registry::{LogId, LogLeaf, MapCheckpoint, PackageId, RecordId},
     ProtoEnvelope, SerdeEnvelope,
 };
 
@@ -153,7 +153,7 @@ pub trait DataStore: Send + Sync {
     async fn store_package_record(
         &self,
         log_id: &LogId,
-        name: &str,
+        package_id: &PackageId,
         record_id: &RecordId,
         record: &ProtoEnvelope<package::PackageRecord>,
         missing: &HashSet<&AnyHash>,

--- a/crates/server/src/datastore/mod.rs
+++ b/crates/server/src/datastore/mod.rs
@@ -1,7 +1,7 @@
 use futures::Stream;
 use std::{collections::HashSet, pin::Pin};
 use thiserror::Error;
-use warg_crypto::hash::AnyHash;
+use warg_crypto::{hash::AnyHash, signing::KeyID};
 use warg_protocol::{
     operator, package,
     registry::{LogId, LogLeaf, MapCheckpoint, RecordId},
@@ -44,6 +44,12 @@ pub enum DataStoreError {
 
     #[error("the package record was invalid: {0}")]
     PackageValidationFailed(#[from] package::ValidationError),
+
+    #[error("unknown key id `{0}`")]
+    UnknownKey(KeyID),
+
+    #[error("record signature verification failed")]
+    SignatureVerificationFailed,
 
     #[error("the record was rejected: {0}")]
     Rejection(String),
@@ -241,4 +247,16 @@ pub trait DataStore: Send + Sync {
         log_id: &LogId,
         record_id: &RecordId,
     ) -> Result<Record<package::PackageRecord>, DataStoreError>;
+
+    /// Verifies the signature of a package record.
+    ///
+    /// This is different from `validate_package_record` in that
+    /// only the signature on the envelope is verified.
+    ///
+    /// It does not attempt to validate the record itself.
+    async fn verify_package_record_signature(
+        &self,
+        log_id: &LogId,
+        record: &ProtoEnvelope<package::PackageRecord>,
+    ) -> Result<(), DataStoreError>;
 }

--- a/crates/server/src/datastore/postgres/mod.rs
+++ b/crates/server/src/datastore/postgres/mod.rs
@@ -17,7 +17,7 @@ use warg_crypto::{hash::AnyHash, Decode, Signable};
 use warg_protocol::{
     operator,
     package::{self, PackageEntry},
-    registry::{LogId, LogLeaf, MapCheckpoint, RecordId},
+    registry::{LogId, LogLeaf, MapCheckpoint, PackageId, RecordId},
     ProtoEnvelope, Record as _, SerdeEnvelope, Validator,
 };
 
@@ -452,7 +452,7 @@ impl DataStore for PostgresDataStore {
     async fn store_package_record(
         &self,
         log_id: &LogId,
-        name: &str,
+        package_id: &PackageId,
         record_id: &RecordId,
         record: &ProtoEnvelope<package::PackageRecord>,
         missing: &HashSet<&AnyHash>,
@@ -461,7 +461,7 @@ impl DataStore for PostgresDataStore {
         insert_record::<package::Validator>(
             conn.as_mut(),
             log_id,
-            Some(name),
+            Some(package_id.as_ref()),
             record_id,
             record,
             missing,

--- a/crates/server/src/datastore/postgres/mod.rs
+++ b/crates/server/src/datastore/postgres/mod.rs
@@ -13,9 +13,10 @@ use diesel_async::{
 use diesel_json::Json;
 use futures::{Stream, StreamExt};
 use std::{collections::HashSet, pin::Pin};
-use warg_crypto::{hash::AnyHash, Decode};
+use warg_crypto::{hash::AnyHash, Decode, Signable};
 use warg_protocol::{
-    operator, package,
+    operator,
+    package::{self, PackageEntry},
     registry::{LogId, LogLeaf, MapCheckpoint, RecordId},
     ProtoEnvelope, Record as _, SerdeEnvelope, Validator,
 };
@@ -726,5 +727,34 @@ impl DataStore for PostgresDataStore {
     ) -> Result<Record<package::PackageRecord>, DataStoreError> {
         let mut conn = self.0.get().await?;
         get_record::<package::Validator>(conn.as_mut(), log_id, record_id).await
+    }
+
+    async fn verify_package_record_signature(
+        &self,
+        log_id: &LogId,
+        record: &ProtoEnvelope<package::PackageRecord>,
+    ) -> Result<(), DataStoreError> {
+        let mut conn = self.0.get().await?;
+
+        let validator = schema::logs::table
+            .select(schema::logs::validator)
+            .filter(schema::logs::log_id.eq(TextRef(log_id)))
+            .first::<Json<package::Validator>>(&mut conn)
+            .await
+            .optional()?;
+
+        let key = match validator
+            .as_ref()
+            .and_then(|v| v.public_key(record.key_id()))
+        {
+            Some(key) => key,
+            None => match record.as_ref().entries.get(0) {
+                Some(PackageEntry::Init { key, .. }) => key,
+                _ => return Err(DataStoreError::UnknownKey(record.key_id().clone())),
+            },
+        };
+
+        package::PackageRecord::verify(key, record.content_bytes(), record.signature())
+            .map_err(|_| DataStoreError::SignatureVerificationFailed)
     }
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -23,28 +23,6 @@ pub mod services;
 const DEFAULT_BIND_ADDRESS: &str = "127.0.0.1:8090";
 const DEFAULT_CHECKPOINT_INTERVAL: Duration = Duration::from_secs(5);
 
-fn is_kebab_case(s: &str) -> bool {
-    let mut lower = false;
-    let mut upper = false;
-    for c in s.chars() {
-        match c {
-            'a'..='z' if !lower && !upper => lower = true,
-            'A'..='Z' if !lower && !upper => upper = true,
-            'a'..='z' if lower => continue,
-            'A'..='Z' if upper => continue,
-            '0'..='9' if lower || upper => continue,
-            '-' if lower || upper => {
-                lower = false;
-                upper = false;
-                continue;
-            }
-            _ => return false,
-        }
-    }
-
-    !s.is_empty() && !s.ends_with('-')
-}
-
 /// The server configuration.
 pub struct Config {
     operator_key: PrivateKey,

--- a/crates/server/src/policy/content/mod.rs
+++ b/crates/server/src/policy/content/mod.rs
@@ -6,7 +6,7 @@ mod wasm;
 
 pub use wasm::*;
 
-/// Represents an error
+/// Represents a content policy error.
 #[derive(Debug, Error)]
 pub enum ContentPolicyError {
     /// The policy rejected the content with the given message.

--- a/crates/server/src/policy/mod.rs
+++ b/crates/server/src/policy/mod.rs
@@ -1,3 +1,4 @@
 //! Module for server policy implementations.
 
 pub mod content;
+pub mod record;

--- a/crates/server/src/policy/record/authorization.rs
+++ b/crates/server/src/policy/record/authorization.rs
@@ -1,9 +1,9 @@
 use super::{RecordPolicy, RecordPolicyError, RecordPolicyResult};
-use crate::is_kebab_case;
 use anyhow::{bail, Result};
 use std::collections::{HashMap, HashSet};
 use warg_crypto::signing::KeyID;
 use warg_protocol::{package::PackageRecord, registry::PackageId, ProtoEnvelope};
+use wasmparser::names::KebabStr;
 
 /// A policy that ensures a published record is authorized by
 /// the key signing the record.
@@ -23,7 +23,7 @@ impl AuthorizedKeyPolicy {
     /// Sets an authorized key for a particular namespace.
     pub fn with_authorized_key(mut self, namespace: impl Into<String>, key: KeyID) -> Result<Self> {
         let namespace = namespace.into();
-        if !is_kebab_case(&namespace) {
+        if KebabStr::new(&namespace).is_none() {
             bail!("namespace `{namespace}` is not a legal kebab-case identifier");
         }
 

--- a/crates/server/src/policy/record/authorization.rs
+++ b/crates/server/src/policy/record/authorization.rs
@@ -1,0 +1,55 @@
+use super::{RecordPolicy, RecordPolicyError, RecordPolicyResult};
+use crate::is_kebab_case;
+use anyhow::{bail, Result};
+use std::collections::{HashMap, HashSet};
+use warg_crypto::signing::KeyID;
+use warg_protocol::{package::PackageRecord, registry::PackageId, ProtoEnvelope};
+
+/// A policy that ensures a published record is authorized by
+/// the key signing the record.
+#[derive(Default)]
+pub struct AuthorizedKeyPolicy {
+    namespaces: HashMap<String, HashSet<KeyID>>,
+}
+
+impl AuthorizedKeyPolicy {
+    /// Creates a new authorized key policy.
+    ///
+    /// By default, no keys are authorized.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets an authorized key for a particular namespace.
+    pub fn with_authorized_key(mut self, namespace: impl Into<String>, key: KeyID) -> Result<Self> {
+        let namespace = namespace.into();
+        if !is_kebab_case(&namespace) {
+            bail!("namespace `{namespace}` is not a legal kebab-case identifier");
+        }
+
+        self.namespaces.entry(namespace).or_default().insert(key);
+        Ok(self)
+    }
+}
+
+impl RecordPolicy for AuthorizedKeyPolicy {
+    fn check(
+        &self,
+        id: &PackageId,
+        record: &ProtoEnvelope<PackageRecord>,
+    ) -> RecordPolicyResult<()> {
+        if !self
+            .namespaces
+            .get(id.namespace())
+            .map(|keys| keys.contains(record.key_id()))
+            .unwrap_or(false)
+        {
+            return Err(RecordPolicyError::Unauthorized(format!(
+                "key id `{key}` is not authorized to publish to package `{id}`",
+                key = record.key_id()
+            )));
+        }
+
+        Ok(())
+    }
+}

--- a/crates/server/src/policy/record/mod.rs
+++ b/crates/server/src/policy/record/mod.rs
@@ -1,0 +1,68 @@
+//! Module for server record policy implementations.
+use thiserror::Error;
+use warg_protocol::{package::PackageRecord, registry::PackageId, ProtoEnvelope};
+
+mod authorization;
+pub use authorization::*;
+
+/// Represents a record policy error.
+#[derive(Debug, Error)]
+pub enum RecordPolicyError {
+    /// A special rejection that indicates the record is not
+    /// authorized to be published.
+    ///
+    /// Unauthorized records will never be stored.
+    #[error("unauthorized operation:: {0}")]
+    Unauthorized(String),
+    /// The policy rejected the record with the given message.
+    #[error("record was rejected by policy: {0}")]
+    Rejection(String),
+}
+
+/// The result type returned by record policies.
+pub type RecordPolicyResult<T> = Result<T, RecordPolicyError>;
+
+/// A trait implemented by record policies.
+pub trait RecordPolicy: Send + Sync {
+    /// Checks the record against the policy.
+    fn check(
+        &self,
+        id: &PackageId,
+        record: &ProtoEnvelope<PackageRecord>,
+    ) -> RecordPolicyResult<()>;
+}
+
+/// Represents a collection of record policies.
+///
+/// Record policies are checked in order of their addition
+/// to the collection.
+#[derive(Default)]
+pub struct RecordPolicyCollection {
+    policies: Vec<Box<dyn RecordPolicy>>,
+}
+
+impl RecordPolicyCollection {
+    /// Creates a new record policy collection.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Pushes a new record policy into the collection.
+    pub fn push(&mut self, policy: impl RecordPolicy + 'static) {
+        self.policies.push(Box::new(policy));
+    }
+}
+
+impl RecordPolicy for RecordPolicyCollection {
+    fn check(
+        &self,
+        id: &PackageId,
+        record: &ProtoEnvelope<PackageRecord>,
+    ) -> RecordPolicyResult<()> {
+        for policy in &self.policies {
+            policy.check(id, record)?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/server/src/services/core.rs
+++ b/crates/server/src/services/core.rs
@@ -133,8 +133,6 @@ impl CoreService {
                         Some(SubmitPackageRecord {
                             log_id, record_id
                         }) => {
-                            // TODO: perform all policy checks on the record here
-
                             // Validate the package record
                             match task_core.store.validate_package_record(&log_id, &record_id).await {
                                 Ok(()) => {

--- a/src/bin/warg.rs
+++ b/src/bin/warg.rs
@@ -63,13 +63,11 @@ fn describe_client_error(e: &ClientError) {
         ClientError::NoDefaultUrl => {
             eprintln!("error: {e}; use the `config` subcommand to set a default URL");
         }
-        ClientError::PackageValidationFailed { package, inner } => {
-            eprintln!("error: the log for package `{package}` is invalid: {inner}")
+        ClientError::PackageValidationFailed { id, inner } => {
+            eprintln!("error: the log for package `{id}` is invalid: {inner}")
         }
-        ClientError::PackageLogEmpty { package } => {
-            eprintln!(
-                "error: the log for package `{package}` is empty (the registry could be lying)"
-            );
+        ClientError::PackageLogEmpty { id } => {
+            eprintln!("error: the log for package `{id}` is empty (the registry could be lying)");
             eprintln!("see issue https://github.com/bytecodealliance/registry/issues/66");
         }
         _ => eprintln!("error: {e}"),

--- a/src/commands/download.rs
+++ b/src/commands/download.rs
@@ -1,7 +1,7 @@
 use super::CommonOptions;
 use anyhow::{anyhow, Result};
 use clap::Args;
-use warg_protocol::VersionReq;
+use warg_protocol::{registry::PackageId, VersionReq};
 
 /// Download a warg registry package.
 #[derive(Args)]
@@ -10,9 +10,9 @@ pub struct DownloadCommand {
     /// The common command options.
     #[clap(flatten)]
     pub common: CommonOptions,
-    /// The name of the package to download.
+    /// The identifier of the package to download.
     #[clap(value_name = "PACKAGE")]
-    pub package: String,
+    pub id: PackageId,
     #[clap(long, short, value_name = "VERSION")]
     /// The version requirement of the package to download; defaults to `*`.
     pub version: Option<VersionReq>,
@@ -24,25 +24,22 @@ impl DownloadCommand {
         let config = self.common.read_config()?;
         let client = self.common.create_client(&config)?;
 
-        println!("downloading package `{package}`...", package = self.package);
+        println!("downloading package `{id}`...", id = self.id);
 
         let res = client
-            .download(
-                &self.package,
-                self.version.as_ref().unwrap_or(&VersionReq::STAR),
-            )
+            .download(&self.id, self.version.as_ref().unwrap_or(&VersionReq::STAR))
             .await?
             .ok_or_else(|| {
                 anyhow!(
-                    "a version of package `{package}` that satisfies `{version}` was not found",
-                    package = self.package,
+                    "a version of package `{id}` that satisfies `{version}` was not found",
+                    id = self.id,
                     version = self.version.as_ref().unwrap_or(&VersionReq::STAR)
                 )
             })?;
 
         println!(
-            "downloaded version {version} of package `{package}` ({digest})",
-            package = self.package,
+            "downloaded version {version} of package `{id}` ({digest})",
+            id = self.id,
             version = res.version,
             digest = res.digest
         );

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use clap::Args;
 use warg_client::storage::{PackageInfo, RegistryStorage};
 use warg_crypto::hash::AnyHash;
-use warg_protocol::Version;
+use warg_protocol::{registry::PackageId, Version};
 
 /// Display client storage information.
 #[derive(Args)]
@@ -14,7 +14,7 @@ pub struct InfoCommand {
 
     /// Only show information for the specified package.
     #[clap(value_name = "PACKAGE")]
-    pub package: Option<String>,
+    pub package: Option<PackageId>,
 }
 
 impl InfoCommand {
@@ -45,7 +45,7 @@ impl InfoCommand {
     }
 
     fn print_package_info(info: &PackageInfo) {
-        println!("  name: {name}", name = info.name);
+        println!("  id: {id}", id = info.id);
         println!("  versions:");
         info.state.releases().for_each(|r| {
             if let Some(content) = r.content() {

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -5,6 +5,7 @@ use warg_client::{
     storage::{ContentStorage, PublishEntry, PublishInfo, RegistryStorage},
     Config, FileSystemClient, StorageLockResult,
 };
+use warg_protocol::registry::PackageId;
 
 pub mod support;
 
@@ -18,7 +19,7 @@ fn create_client(config: &Config) -> Result<FileSystemClient> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn client_incrementally_fetches() -> Result<()> {
     const RELEASE_COUNT: usize = 300;
-    const PACKAGE_NAME: &str = "test:package";
+    const PACKAGE_ID: &str = "test:package";
 
     let (_server, config) = spawn_server(&root().await?, None, None).await?;
 
@@ -38,11 +39,12 @@ async fn client_incrementally_fetches() -> Result<()> {
 
     // Here we don't wait for a single publish operation to complete, except for the last one
     // If the last one is accepted, it implies that all the previous ones were accepted as well
+    let id = PackageId::new(PACKAGE_ID)?;
     let mut head = client
         .publish_with_info(
             &signing_key,
             PublishInfo {
-                package: PACKAGE_NAME.to_string(),
+                id: id.clone(),
                 head: None,
                 entries: vec![PublishEntry::Init],
             },
@@ -54,7 +56,7 @@ async fn client_incrementally_fetches() -> Result<()> {
             .publish_with_info(
                 &signing_key,
                 PublishInfo {
-                    package: PACKAGE_NAME.to_string(),
+                    id: id.clone(),
                     head: Some(head),
                     entries: vec![PublishEntry::Release {
                         version: format!("0.{i}.0").parse().unwrap(),
@@ -66,7 +68,7 @@ async fn client_incrementally_fetches() -> Result<()> {
     }
 
     client
-        .wait_for_publish(PACKAGE_NAME, &head, Duration::from_millis(100))
+        .wait_for_publish(&id, &head, Duration::from_millis(100))
         .await?;
 
     drop(client);
@@ -79,12 +81,12 @@ async fn client_incrementally_fetches() -> Result<()> {
     let client = create_client(&config)?;
 
     // Fetch the package log
-    client.upsert(&[PACKAGE_NAME]).await?;
+    client.upsert([&id]).await?;
 
     // Ensure the package log exists and has releases with all with the same digest
     let package = client
         .registry()
-        .load_package(PACKAGE_NAME)
+        .load_package(&id)
         .await?
         .context("package does not exist in client storage")?;
 

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -20,7 +20,7 @@ async fn client_incrementally_fetches() -> Result<()> {
     const RELEASE_COUNT: usize = 300;
     const PACKAGE_NAME: &str = "test:package";
 
-    let (_server, config) = spawn_server(&root().await?, None).await?;
+    let (_server, config) = spawn_server(&root().await?, None, None).await?;
 
     let client = create_client(&config)?;
     let signing_key = support::test_signing_key().parse().unwrap();

--- a/tests/memory/mod.rs
+++ b/tests/memory/mod.rs
@@ -1,0 +1,83 @@
+//! Tests for the in-memory storage backend.
+
+use super::{support::*, *};
+use anyhow::Result;
+use warg_client::api;
+use warg_crypto::signing::PrivateKey;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn it_starts_with_initial_checkpoint() -> Result<()> {
+    let (_server, config) = spawn_server(&root().await?, None, None).await?;
+    test_initial_checkpoint(&config).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn it_publishes_a_component() -> Result<()> {
+    let (_server, config) = spawn_server(&root().await?, None, None).await?;
+    test_component_publishing(&config).await?;
+
+    // There should be two log entries in the registry
+    let client = api::Client::new(config.default_url.as_ref().unwrap())?;
+    let checkpoint = client.latest_checkpoint().await?;
+    assert_eq!(
+        checkpoint.as_ref().log_length,
+        2,
+        "expected two log entries (initial + component)"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn it_publishes_a_wit_package() -> Result<()> {
+    let (_server, config) = spawn_server(&root().await?, None, None).await?;
+    test_wit_publishing(&config).await?;
+
+    // There should be two log entries in the registry
+    let client = api::Client::new(config.default_url.as_ref().unwrap())?;
+    let checkpoint = client.latest_checkpoint().await?;
+    assert_eq!(
+        checkpoint.as_ref().log_length,
+        2,
+        "expected two log entries (initial + wit)"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn it_rejects_non_wasm_content() -> Result<()> {
+    let (_server, config) = spawn_server(&root().await?, None, None).await?;
+    test_wasm_content_policy(&config).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn it_rejects_unauthorized_signing_key() -> Result<()> {
+    let (_server, config) = spawn_server(
+        &root().await?,
+        None,
+        Some(vec![(
+            "test".to_string(),
+            test_signing_key()
+                .parse::<PrivateKey>()
+                .unwrap()
+                .public_key()
+                .fingerprint(),
+        )]),
+    )
+    .await?;
+
+    test_unauthorized_signing_key(&config).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn it_rejects_unknown_signing_key() -> Result<()> {
+    let (_server, config) = spawn_server(&root().await?, None, None).await?;
+    test_unknown_signing_key(&config).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn it_rejects_invalid_signature() -> Result<()> {
+    let (_server, config) = spawn_server(&root().await?, None, None).await?;
+    test_invalid_signature(&config).await
+}

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -55,9 +55,9 @@ async fn it_works_with_postgres() -> TestResult {
     test_invalid_signature(&config).await?;
 
     let mut packages = vec![
-        "test:component",
-        "test:wit-package",
-        "test:unauthorized-key",
+        PackageId::new("test:component")?,
+        PackageId::new("test:wit-package")?,
+        PackageId::new("test:unauthorized-key")?,
     ];
 
     // There should be two log entries in the registry
@@ -77,7 +77,7 @@ async fn it_works_with_postgres() -> TestResult {
 
     test_unknown_signing_key(&config).await?;
 
-    packages.push("test:unknown-key");
+    packages.push(PackageId::new("test:unknown-key")?);
 
     let client = api::Client::new(config.default_url.as_ref().unwrap())?;
     let checkpoint = client.latest_checkpoint().await?;
@@ -93,12 +93,12 @@ async fn it_works_with_postgres() -> TestResult {
     fs::remove_dir_all(root.join("registries"))?;
 
     let client = create_client(&config)?;
-    client.upsert(&packages).await?;
+    client.upsert(packages.iter()).await?;
 
     // Finally, after a restart, ensure the packages can be downloaded
     for package in packages {
         client
-            .download(package, &"0.1.0".parse()?)
+            .download(&package, &"0.1.0".parse()?)
             .await?
             .context("failed to resolve package")?;
     }

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -1,8 +1,9 @@
-use std::path::Path;
+//! Tests for the PostgreSQL storage backend.
 
+use super::{support::*, *};
 use anyhow::{Context, Result};
-use futures::Future;
-use warg_client::{api, Config};
+use testresult::TestResult;
+use warg_client::api;
 use warg_server::datastore::{DataStore, PostgresDataStore};
 
 fn data_store() -> Result<Box<dyn DataStore>> {
@@ -10,14 +11,6 @@ fn data_store() -> Result<Box<dyn DataStore>> {
         std::env::var("WARG_DATABASE_URL")
             .context("failed to get `WARG_DATABASE_URL` environment variable")?,
     )?))
-}
-
-async fn run<F, T>(root: &Path, callback: impl FnOnce(Config) -> F) -> Result<T>
-where
-    F: Future<Output = Result<T>>,
-{
-    let (_server, config) = super::support::spawn_server(root, Some(data_store()?)).await?;
-    callback(config).await
 }
 
 /// This test assumes the database is empty on each run.
@@ -34,81 +27,81 @@ where
 /// the checkpointing service is moved to a separate process, we can extract this
 /// out to multiple tests.
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test() -> Result<()> {
-    let root = super::root().await?;
-
-    // Each of these is run with their own server instance to ensure restart works
-
-    // Start by validating the initial checkpoint
-    run(&root, |config| async {
-        super::validate_initial_checkpoint(config).await
-    })
+async fn it_works_with_postgres() -> TestResult {
+    let root = root().await?;
+    let (server, config) = spawn_server(
+        &root,
+        Some(data_store()?),
+        Some(vec![(
+            "test".to_string(),
+            test_signing_key()
+                .parse::<PrivateKey>()
+                .unwrap()
+                .public_key()
+                .fingerprint(),
+        )]),
+    )
     .await?;
 
-    // Publish and validate a component package
-    let digest = run(&root, |config| async move {
-        let client = super::create_client(&config)?;
-        let digest = super::publish_component_package(&client).await?;
-        super::validate_component_package(&config, &client, &digest).await?;
+    // This should be the same set of tests as in `tests/memory/mod.rs`
+    test_initial_checkpoint(&config).await?;
+    test_component_publishing(&config).await?;
+    test_wit_publishing(&config).await?;
+    test_wasm_content_policy(&config).await?;
+    test_unauthorized_signing_key(&config).await?;
+    // This is tested below where a different server is used that
+    // allows any signing key
+    //test_unknown_signing_key(&config).await?;
+    test_invalid_signature(&config).await?;
 
-        // There should be two log entries in the registry
-        let client = api::Client::new(config.default_url.as_ref().unwrap())?;
-        let checkpoint = client.latest_checkpoint().await?;
-        assert_eq!(checkpoint.as_ref().log_length, 2);
+    let mut packages = vec![
+        "test:component",
+        "test:wit-package",
+        "test:unauthorized-key",
+    ];
 
-        Ok(digest)
-    })
-    .await?;
+    // There should be two log entries in the registry
+    let client = api::Client::new(config.default_url.as_ref().unwrap())?;
+    let checkpoint = client.latest_checkpoint().await?;
+    assert_eq!(
+        checkpoint.as_ref().log_length,
+        packages.len() as u32 + 1, /* initial checkpoint */
+        "expected {len} packages plus the initial checkpoint",
+        len = packages.len()
+    );
 
-    // Validate the component package is still present after a restart
-    run(&root, |config| async move {
-        let client = super::create_client(&config)?;
-        super::validate_component_package(&config, &client, &digest).await?;
+    drop(server);
 
-        // There should be two log entries in the registry
-        let client = api::Client::new(config.default_url.as_ref().unwrap())?;
-        let checkpoint = client.latest_checkpoint().await?;
-        assert_eq!(checkpoint.as_ref().log_length, 2);
+    // Restart the server and ensure the data is still there
+    let (_server, config) = spawn_server(&root, Some(data_store()?), None).await?;
 
-        Ok(())
-    })
-    .await?;
+    test_unknown_signing_key(&config).await?;
 
-    // Publish and validate a wit package
-    let digest = run(&root, |config| async move {
-        let client = super::create_client(&config)?;
-        let digest = super::publish_wit_package(&client).await?;
-        super::validate_wit_package(&config, &client, &digest).await?;
+    packages.push("test:unknown-key");
 
-        // There should be three log entries in the registry
-        let client = api::Client::new(config.default_url.as_ref().unwrap())?;
-        let checkpoint = client.latest_checkpoint().await?;
-        assert_eq!(checkpoint.as_ref().log_length, 3);
+    let client = api::Client::new(config.default_url.as_ref().unwrap())?;
+    let checkpoint = client.latest_checkpoint().await?;
+    assert_eq!(
+        checkpoint.as_ref().log_length,
+        packages.len() as u32 + 1, /* initial checkpoint */
+        "expected {len} packages plus the initial checkpoint",
+        len = packages.len()
+    );
 
-        Ok(digest)
-    })
-    .await?;
+    // Delete the client cache to force a complete download of all packages below
+    fs::remove_dir_all(root.join("content"))?;
+    fs::remove_dir_all(root.join("registries"))?;
 
-    // Validate the wit package is still present after a restart
-    run(&root, |config| async move {
-        let client = super::create_client(&config)?;
-        super::validate_wit_package(&config, &client, &digest).await?;
+    let client = create_client(&config)?;
+    client.upsert(&packages).await?;
 
-        // There should be three log entries in the registry
-        let client = api::Client::new(config.default_url.as_ref().unwrap())?;
-        let checkpoint = client.latest_checkpoint().await?;
-        assert_eq!(checkpoint.as_ref().log_length, 3);
-
-        Ok(())
-    })
-    .await?;
-
-    // Validate content policy
-    run(&root, |config| async move {
-        let client = super::create_client(&config)?;
-        super::validate_content_policy(&client).await
-    })
-    .await?;
+    // Finally, after a restart, ensure the packages can be downloaded
+    for package in packages {
+        client
+            .download(package, &"0.1.0".parse()?)
+            .await?
+            .context("failed to resolve package")?;
+    }
 
     Ok(())
 }

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,23 +1,31 @@
 use self::support::*;
-use anyhow::{bail, Context, Result};
-use std::{fs, str::FromStr, time::Duration};
-use warg_client::{api, ClientError, Config, FileSystemClient, StorageLockResult};
-use warg_crypto::{hash::AnyHash, signing::PrivateKey, Encode, Signable};
+use anyhow::{Context, Result};
+use rand_core::OsRng;
+use reqwest::StatusCode;
+use std::{
+    borrow::Cow,
+    fs,
+    str::FromStr,
+    time::{Duration, SystemTime},
+};
+use url::Url;
+use warg_api::v1::{package::PublishRecordRequest, paths};
+use warg_client::{api, ClientError, Config};
+use warg_crypto::{hash::Sha256, signing::PrivateKey, Encode, Signable};
+use warg_protocol::{
+    package::{PackageEntry, PackageRecord, PACKAGE_RECORD_VERSION},
+    registry::LogId,
+    ProtoEnvelope, ProtoEnvelopeBody,
+};
 use wit_component::DecodedWasm;
 
 mod support;
 
+mod memory;
 #[cfg(feature = "postgres")]
 mod postgres;
 
-fn create_client(config: &Config) -> Result<FileSystemClient> {
-    match FileSystemClient::try_new_with_config(None, config)? {
-        StorageLockResult::Acquired(client) => Ok(client),
-        _ => bail!("failed to acquire storage lock"),
-    }
-}
-
-async fn validate_initial_checkpoint(config: Config) -> Result<()> {
+async fn test_initial_checkpoint(config: &Config) -> Result<()> {
     let client = api::Client::new(config.default_url.as_ref().unwrap())?;
 
     let checkpoint = client.latest_checkpoint().await?;
@@ -44,23 +52,31 @@ async fn validate_initial_checkpoint(config: Config) -> Result<()> {
     Ok(())
 }
 
-async fn publish_component_package(client: &FileSystemClient) -> Result<AnyHash> {
-    publish_component(client, "component:foo", "0.1.0", "(component)", true).await
-}
+async fn test_component_publishing(config: &Config) -> Result<()> {
+    const PACKAGE_NAME: &str = "test:component";
+    const PACKAGE_VERSION: &str = "0.1.0";
 
-async fn validate_component_package(
-    config: &Config,
-    client: &FileSystemClient,
-    expected_digest: &AnyHash,
-) -> Result<()> {
+    let client = create_client(config)?;
+    let signing_key = test_signing_key().parse().unwrap();
+    let digest = publish_component(
+        &client,
+        PACKAGE_NAME,
+        PACKAGE_VERSION,
+        "(component)",
+        true,
+        &signing_key,
+    )
+    .await?;
+
     // Assert that the package can be downloaded
-    client.upsert(&["component:foo"]).await?;
+    client.upsert(&[PACKAGE_NAME]).await?;
     let download = client
-        .download("component:foo", &"0.1.0".parse()?)
+        .download(PACKAGE_NAME, &PACKAGE_VERSION.parse()?)
         .await?
         .context("failed to resolve package")?;
-    assert_eq!(download.digest, *expected_digest);
-    assert_eq!(download.version, "0.1.0".parse()?);
+
+    assert_eq!(download.digest, digest);
+    assert_eq!(download.version, PACKAGE_VERSION.parse()?);
     assert_eq!(
         download.path,
         config
@@ -79,37 +95,38 @@ async fn validate_component_package(
 
     // Assert that a different version can't be downloaded
     assert!(client
-        .download("component:foo", &"0.2.0".parse()?)
+        .download(PACKAGE_NAME, &"0.2.0".parse()?)
         .await?
         .is_none());
 
     Ok(())
 }
 
-async fn publish_wit_package(client: &FileSystemClient) -> Result<AnyHash> {
-    publish_wit(
-        client,
-        "wit:foo",
-        "0.1.0",
-        "package wit:foo\nworld foo {}",
-        true,
-    )
-    .await
-}
+async fn test_wit_publishing(config: &Config) -> Result<()> {
+    const PACKAGE_NAME: &str = "test:wit-package";
+    const PACKAGE_VERSION: &str = "0.1.0";
 
-async fn validate_wit_package(
-    config: &Config,
-    client: &FileSystemClient,
-    expected_digest: &AnyHash,
-) -> Result<()> {
+    let client = create_client(config)?;
+    let signing_key = test_signing_key().parse().unwrap();
+    let digest = publish_wit(
+        &client,
+        PACKAGE_NAME,
+        PACKAGE_VERSION,
+        &format!("package {PACKAGE_NAME}\nworld foo {{}}"),
+        true,
+        &signing_key,
+    )
+    .await?;
+
     // Assert that the package can be downloaded
-    client.upsert(&["wit:foo"]).await?;
+    client.upsert(&[PACKAGE_NAME]).await?;
     let download = client
-        .download("wit:foo", &"0.1.0".parse()?)
+        .download(PACKAGE_NAME, &PACKAGE_VERSION.parse()?)
         .await?
         .context("failed to resolve package")?;
-    assert_eq!(download.digest, *expected_digest);
-    assert_eq!(download.version, "0.1.0".parse()?);
+
+    assert_eq!(download.digest, digest);
+    assert_eq!(download.version, PACKAGE_VERSION.parse()?);
     assert_eq!(
         download.path,
         config
@@ -120,30 +137,40 @@ async fn validate_wit_package(
             .join(download.digest.to_string().strip_prefix("sha256:").unwrap())
     );
 
-    // Assert it is a valid wit package
-    match wit_component::decode(&fs::read(download.path).context("failed to read WIT package")?)? {
+    // Assert that it is a valid wit package
+    match wit_component::decode(&fs::read(download.path).context("failed to read component")?)? {
         DecodedWasm::WitPackage(..) => {}
-        _ => panic!("expected WIT package"),
+        _ => panic!("expected wit package"),
     }
 
     // Assert that a different version can't be downloaded
     assert!(client
-        .download("wit:foo", &"0.2.0".parse()?)
+        .download(PACKAGE_NAME, &"0.2.0".parse()?)
         .await?
         .is_none());
 
     Ok(())
 }
 
-async fn validate_content_policy(client: &FileSystemClient) -> Result<()> {
-    const PACKAGE_NAME: &str = "bad:content";
+async fn test_wasm_content_policy(config: &Config) -> Result<()> {
+    const PACKAGE_NAME: &str = "test:bad-content";
+    const PACKAGE_VERSION: &str = "0.1.0";
 
     // Publish empty content to the server
     // This should be rejected by policy because it is not valid WebAssembly
-    match publish(client, PACKAGE_NAME, "0.1.0", Vec::new(), true)
-        .await
-        .expect_err("expected publish to fail")
-        .downcast::<ClientError>()
+    let client = create_client(config)?;
+    let signing_key = test_signing_key().parse().unwrap();
+    match publish(
+        &client,
+        PACKAGE_NAME,
+        PACKAGE_VERSION,
+        Vec::new(),
+        true,
+        &signing_key,
+    )
+    .await
+    .expect_err("expected publish to fail")
+    .downcast::<ClientError>()
     {
         Ok(ClientError::PublishRejected {
             package,
@@ -183,48 +210,140 @@ async fn validate_content_policy(client: &FileSystemClient) -> Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn it_starts_with_initial_checkpoint() -> Result<()> {
-    let (_server, config) = spawn_server(&root().await?, None).await?;
-    validate_initial_checkpoint(config).await?;
+async fn test_unauthorized_signing_key(config: &Config) -> Result<()> {
+    const PACKAGE_NAME: &str = "test:unauthorized-key";
+    const PACKAGE_VERSION: &str = "0.1.0";
+
+    // Start by publishing a new component package
+    let client = create_client(config)?;
+    let signing_key = test_signing_key().parse().unwrap();
+    publish_component(
+        &client,
+        PACKAGE_NAME,
+        PACKAGE_VERSION,
+        "(component)",
+        true,
+        &signing_key,
+    )
+    .await?;
+
+    // Next, we're going to publish a new record signed by a different key
+    let signing_key = PrivateKey::from(p256::ecdsa::SigningKey::random(&mut OsRng));
+
+    let message = format!(
+        "{:#}",
+        publish_component(
+            &client,
+            PACKAGE_NAME,
+            "0.2.0",
+            "(component)",
+            false,
+            &signing_key,
+        )
+        .await
+        .expect_err("expected publish to fail")
+    );
+
+    assert!(
+        message.contains("not authorized to publish to package `test:unauthorized-key`"),
+        "unexpected error message: {message}"
+    );
+
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn it_publishes_a_component() -> Result<()> {
-    let (_server, config) = spawn_server(&root().await?, None).await?;
-    let client = create_client(&config)?;
+async fn test_unknown_signing_key(config: &Config) -> Result<()> {
+    const PACKAGE_NAME: &str = "test:unknown-key";
+    const PACKAGE_VERSION: &str = "0.1.0";
 
-    let digest = publish_component_package(&client).await?;
-    validate_component_package(&config, &client, &digest).await?;
+    // Start by publishing a new component package
+    let client = create_client(config)?;
+    let signing_key = test_signing_key().parse().unwrap();
+    publish_component(
+        &client,
+        PACKAGE_NAME,
+        PACKAGE_VERSION,
+        "(component)",
+        true,
+        &signing_key,
+    )
+    .await?;
 
-    // There should be two log entries in the registry
-    let client = api::Client::new(config.default_url.as_ref().unwrap())?;
-    let checkpoint = client.latest_checkpoint().await?;
-    assert_eq!(checkpoint.as_ref().log_length, 2);
+    // Next, we're going to publish a new record signed by a different key
+    // The new key is not currently known to the package log.
+    let signing_key = PrivateKey::from(p256::ecdsa::SigningKey::random(&mut OsRng));
+
+    let message = format!(
+        "{:#}",
+        publish_component(
+            &client,
+            PACKAGE_NAME,
+            "0.2.0",
+            "(component)",
+            false,
+            &signing_key,
+        )
+        .await
+        .expect_err("expected publish to fail")
+    );
+
+    assert!(
+        message.contains("unknown key id"),
+        "unexpected error message: {message}"
+    );
 
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn it_publishes_a_wit_package() -> Result<()> {
-    let (_server, config) = spawn_server(&root().await?, None).await?;
-    let client = create_client(&config)?;
+async fn test_invalid_signature(config: &Config) -> Result<()> {
+    // Use a reqwest client directly here as we're going to be sending an invalid signature
+    let log_id = LogId::package_log::<Sha256>("test:invalid-signature");
+    let url = Url::parse(config.default_url.as_ref().unwrap())?
+        .join(&paths::publish_package_record(&log_id))
+        .unwrap();
 
-    let digest = publish_wit_package(&client).await?;
-    validate_wit_package(&config, &client, &digest).await?;
+    let signing_key = test_signing_key().parse().unwrap();
+    let record = ProtoEnvelope::signed_contents(
+        &signing_key,
+        PackageRecord {
+            prev: None,
+            version: PACKAGE_RECORD_VERSION,
+            timestamp: SystemTime::now(),
+            entries: vec![PackageEntry::Init {
+                hash_algorithm: warg_crypto::hash::HashAlgorithm::Sha256,
+                key: signing_key.public_key(),
+            }],
+        },
+    )?;
 
-    // There should be two log entries in the registry
-    let client = api::Client::new(config.default_url.as_ref().unwrap())?;
-    let checkpoint = client.latest_checkpoint().await?;
-    assert_eq!(checkpoint.as_ref().log_length, 2);
+    let body = PublishRecordRequest {
+        name: "test:invalid-signature".into(),
+        record: Cow::Owned(ProtoEnvelopeBody::from(record)),
+        content_sources: Default::default(),
+    };
+
+    // Update the signature to one that does not match the contents
+    let mut body = serde_json::to_value(&body).unwrap();
+    body["record"]["signature"] = serde_json::Value::String("ecdsa-p256:MEUCIQCzWZBW6ux9LecP66Y+hjmLZTP/hZVz7puzlPTXcRT2wwIgQZO7nxP0nugtw18MwHZ26ROFWcJmgCtKOguK031Y1D0=".to_string());
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(url)
+        .json(&serde_json::to_value(&body).unwrap())
+        .send()
+        .await?;
+
+    let status = response.status();
+    let body = response.text().await?;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "unexpected response from server: {status}\n{body}",
+    );
+    assert!(
+        body.contains("record signature verification failed"),
+        "unexpected response body: {body}"
+    );
 
     Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn it_rejects_non_wasm_content() -> Result<()> {
-    let (_server, config) = spawn_server(&root().await?, None).await?;
-    let client = create_client(&config)?;
-    validate_content_policy(&client).await
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -105,7 +105,7 @@ pub async fn spawn_server(
     if let Some(authorized_keys) = authorized_keys {
         let mut policy = AuthorizedKeyPolicy::new();
         for (namespace, key) in authorized_keys {
-            policy = policy.with_authorized_key(namespace, key)?;
+            policy = policy.with_namespace_key(namespace, key)?;
         }
 
         config = config.with_record_policy(policy);


### PR DESCRIPTION
This PR implements authorization of publishing operations by the key id used to sign the record being published.

By default, the server `Config` denies all keys, and keys can be specified per-namespace with the `with_authorized_key` method.

Authorization can also be disabled (allow any key id to claim a package name) with the `with_no_authorization` method.

A consequence of this change is that package names are now restricted to valid package names in a component model ID (e.g. `wasi:http`).

The tests have also been refactored to better share the test implementations between the in-memory and postgres data stores.

In the future, the authorization scheme could be further refined to specific package names rather than entire namespaces.