### PR TITLE
server: Add /debug/packages endpoint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,9 @@
 {
     "rust-analyzer.check.command": "clippy",
-    "rust-analyzer.cargo.features": ["postgres"],
+    "rust-analyzer.cargo.features": [
+        "debug",
+        "postgres",
+    ],
     "protoc": {
         "options": [
             "--proto_path=${workspaceFolder}/proto",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -38,4 +38,5 @@ chrono = { workspace = true, optional = true }
 
 [features]
 default = []
+debug = []
 postgres = ["diesel", "diesel-async", "diesel_json", "diesel_migrations", "diesel-derive-enum", "serde_json", "chrono"]

--- a/crates/server/src/api/debug/mod.rs
+++ b/crates/server/src/api/debug/mod.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+
+use axum::{
+    debug_handler, extract::State, http::StatusCode, response::IntoResponse, routing::get, Router,
+};
+use warg_protocol::registry::PackageId;
+
+use crate::{api::v1::Json, services::CoreService};
+
+#[derive(Clone)]
+pub struct Config {
+    core_service: Arc<CoreService>,
+}
+
+impl Config {
+    pub fn new(core_service: Arc<CoreService>) -> Self {
+        Self { core_service }
+    }
+
+    pub fn into_router(self) -> Router {
+        Router::new()
+            .route("/packages", get(list_package_names))
+            .with_state(self)
+    }
+}
+
+#[debug_handler]
+async fn list_package_names(
+    State(config): State<Config>,
+) -> anyhow::Result<Json<Vec<PackageId>>, DebugError> {
+    let ids = config.core_service.store().debug_list_package_ids().await?;
+    Ok(Json(ids))
+}
+
+struct DebugError(String);
+
+impl From<anyhow::Error> for DebugError {
+    fn from(err: anyhow::Error) -> Self {
+        Self(format!("{err:#?}"))
+    }
+}
+
+impl IntoResponse for DebugError {
+    fn into_response(self) -> axum::response::Response {
+        (StatusCode::INTERNAL_SERVER_ERROR, self.0).into_response()
+    }
+}

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -16,6 +16,9 @@ use url::Url;
 
 pub mod v1;
 
+#[cfg(feature = "debug")]
+pub mod debug;
+
 /// Creates the router for the API.
 pub fn create_router(
     content_base_url: Url,
@@ -25,7 +28,10 @@ pub fn create_router(
     content_policy: Option<Arc<dyn ContentPolicy>>,
     record_policy: Option<Arc<dyn RecordPolicy>>,
 ) -> Router {
-    Router::new()
+    let router = Router::new();
+    #[cfg(feature = "debug")]
+    let router = router.nest("/debug", debug::Config::new(core.clone()).into_router());
+    router
         .nest(
             "/v1",
             v1::create_router(

--- a/crates/server/src/api/v1/mod.rs
+++ b/crates/server/src/api/v1/mod.rs
@@ -25,7 +25,7 @@ pub mod proof;
 /// This extractor returns an API error on rejection.
 #[derive(FromRequest)]
 #[from_request(via(axum::Json), rejection(Error))]
-pub struct Json<T>(T);
+pub struct Json<T>(pub T);
 
 impl<T> IntoResponse for Json<T>
 where

--- a/crates/server/src/datastore/memory.rs
+++ b/crates/server/src/datastore/memory.rs
@@ -604,6 +604,7 @@ impl DataStore for MemoryDataStore {
             .map_err(|_| DataStoreError::SignatureVerificationFailed)
     }
 
+    #[cfg(feature = "debug")]
     async fn debug_list_package_ids(&self) -> anyhow::Result<Vec<PackageId>> {
         let state = self.0.read().await;
         Ok(state.package_ids.iter().cloned().collect())

--- a/crates/server/src/datastore/mod.rs
+++ b/crates/server/src/datastore/mod.rs
@@ -259,4 +259,10 @@ pub trait DataStore: Send + Sync {
         log_id: &LogId,
         record: &ProtoEnvelope<package::PackageRecord>,
     ) -> Result<(), DataStoreError>;
+
+    // Returns a list of package names, for debugging only.
+    #[doc(hidden)]
+    async fn debug_list_package_ids(&self) -> anyhow::Result<Vec<PackageId>> {
+        anyhow::bail!("not implemented")
+    }
 }

--- a/crates/server/src/datastore/mod.rs
+++ b/crates/server/src/datastore/mod.rs
@@ -261,6 +261,7 @@ pub trait DataStore: Send + Sync {
     ) -> Result<(), DataStoreError>;
 
     // Returns a list of package names, for debugging only.
+    #[cfg(feature = "debug")]
     #[doc(hidden)]
     async fn debug_list_package_ids(&self) -> anyhow::Result<Vec<PackageId>> {
         anyhow::bail!("not implemented")

--- a/crates/server/src/datastore/postgres/mod.rs
+++ b/crates/server/src/datastore/postgres/mod.rs
@@ -790,4 +790,17 @@ impl DataStore for PostgresDataStore {
         package::PackageRecord::verify(key, record.content_bytes(), record.signature())
             .map_err(|_| DataStoreError::SignatureVerificationFailed)
     }
+
+    async fn debug_list_package_ids(&self) -> anyhow::Result<Vec<PackageId>> {
+        let mut conn = self.0.get().await?;
+        let names = schema::logs::table
+            .select(schema::logs::name)
+            .load::<Option<String>>(&mut conn)
+            .await?
+            .into_iter()
+            .flatten()
+            .filter_map(|name| name.parse().ok())
+            .collect();
+        Ok(names)
+    }
 }

--- a/crates/server/src/datastore/postgres/mod.rs
+++ b/crates/server/src/datastore/postgres/mod.rs
@@ -791,6 +791,7 @@ impl DataStore for PostgresDataStore {
             .map_err(|_| DataStoreError::SignatureVerificationFailed)
     }
 
+    #[cfg(feature = "debug")]
     async fn debug_list_package_ids(&self) -> anyhow::Result<Vec<PackageId>> {
         let mut conn = self.0.get().await?;
         let names = schema::logs::table


### PR DESCRIPTION
This introduces a 'debug' feature to warg-server, which toggles on /debug/-prefixed APIs. The first such api is /debug/packages, which uses a new (optional) DataStore::debug_list_package_ids.

Reorganized some generic API code from `warg_server::api::v1` up to `warg_server::api` to be shared with the new `warg_server::api::debug` module.