### PR TITLE
rename `root` field to `checkpoint_id` for the API call to fetch logs

### DIFF
--- a/crates/api/src/v1/fetch.rs
+++ b/crates/api/src/v1/fetch.rs
@@ -14,8 +14,8 @@ use warg_protocol::{
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct FetchLogsRequest<'a> {
-    /// The root checkpoint hash of the registry.
-    pub root: Cow<'a, AnyHash>,
+    /// The root checkpoint ID hash of the registry.
+    pub checkpoint_id: Cow<'a, AnyHash>,
     /// The limit for the number of operator and package records to fetch.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<u16>,

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -349,8 +349,8 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
         checkpoint: &SerdeEnvelope<MapCheckpoint>,
         packages: impl IntoIterator<Item = &mut PackageInfo>,
     ) -> Result<(), ClientError> {
-        let root: AnyHash = Hash::<Sha256>::of(checkpoint.as_ref()).into();
-        tracing::info!("updating to checkpoint `{root}`");
+        let checkpoint_id: AnyHash = Hash::<Sha256>::of(checkpoint.as_ref()).into();
+        tracing::info!("updating to checkpoint `{checkpoint_id}`");
 
         let mut operator = self.registry.load_operator().await?.unwrap_or_default();
 
@@ -382,7 +382,7 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
             let response: FetchLogsResponse = self
                 .api
                 .fetch_logs(FetchLogsRequest {
-                    root: Cow::Borrowed(&root),
+                    checkpoint_id: Cow::Borrowed(&checkpoint_id),
                     operator: operator
                         .state
                         .head()

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -496,11 +496,11 @@ components:
       description: A request to fetch logs from the registry.
       additionalProperties: false
       required:
-        - checkpoint
+        - checkpoint_id
       properties:
-        checkpoint:
+        checkpoint_id:
           $ref: "#/components/schemas/AnyHash"
-          description: The registry checkpoint hash to fetch from.
+          description: The registry checkpoint ID hash to fetch from.
         limit:
           type: integer
           description: The limit of operator and packages records to return for the fetch request.

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -496,9 +496,9 @@ components:
       description: A request to fetch logs from the registry.
       additionalProperties: false
       required:
-        - checkpoint_id
+        - checkpointId
       properties:
-        checkpoint_id:
+        checkpointId:
           $ref: "#/components/schemas/AnyHash"
           description: The registry checkpoint ID hash to fetch from.
         limit:

--- a/crates/server/src/api/v1/fetch.rs
+++ b/crates/server/src/api/v1/fetch.rs
@@ -91,7 +91,7 @@ async fn fetch_logs(
         .store()
         .get_operator_records(
             &LogId::operator_log::<Sha256>(),
-            &body.root,
+            &body.checkpoint_id,
             body.operator.as_deref(),
             limit,
         )
@@ -108,7 +108,7 @@ async fn fetch_logs(
         let records: Vec<ProtoEnvelopeBody> = config
             .core_service
             .store()
-            .get_package_records(&id, &body.root, since.as_ref(), limit)
+            .get_package_records(&id, &body.checkpoint_id, since.as_ref(), limit)
             .await?
             .into_iter()
             .map(Into::into)

--- a/crates/server/src/datastore/memory.rs
+++ b/crates/server/src/datastore/memory.rs
@@ -424,7 +424,7 @@ impl DataStore for MemoryDataStore {
     async fn get_operator_records(
         &self,
         log_id: &LogId,
-        root: &AnyHash,
+        checkpoint_id: &AnyHash,
         since: Option<&RecordId>,
         limit: u16,
     ) -> Result<Vec<ProtoEnvelope<operator::OperatorRecord>>, DataStoreError> {
@@ -435,7 +435,7 @@ impl DataStore for MemoryDataStore {
             .get(log_id)
             .ok_or_else(|| DataStoreError::LogNotFound(log_id.clone()))?;
 
-        if let Some(checkpoint_index) = state.checkpoints.get_index_of(root) {
+        if let Some(checkpoint_index) = state.checkpoints.get_index_of(checkpoint_id) {
             let start = match since {
                 Some(since) => match &state.records[log_id][since] {
                     RecordStatus::Validated(record) => record.index + 1,
@@ -447,14 +447,14 @@ impl DataStore for MemoryDataStore {
             let end = get_records_before_checkpoint(&log.checkpoint_indices, checkpoint_index);
             Ok(log.entries[start..std::cmp::min(end, start + limit as usize)].to_vec())
         } else {
-            Err(DataStoreError::CheckpointNotFound(root.clone()))
+            Err(DataStoreError::CheckpointNotFound(checkpoint_id.clone()))
         }
     }
 
     async fn get_package_records(
         &self,
         log_id: &LogId,
-        root: &AnyHash,
+        checkpoint_id: &AnyHash,
         since: Option<&RecordId>,
         limit: u16,
     ) -> Result<Vec<ProtoEnvelope<package::PackageRecord>>, DataStoreError> {
@@ -465,7 +465,7 @@ impl DataStore for MemoryDataStore {
             .get(log_id)
             .ok_or_else(|| DataStoreError::LogNotFound(log_id.clone()))?;
 
-        if let Some(checkpoint_index) = state.checkpoints.get_index_of(root) {
+        if let Some(checkpoint_index) = state.checkpoints.get_index_of(checkpoint_id) {
             let start = match since {
                 Some(since) => match &state.records[log_id][since] {
                     RecordStatus::Validated(record) => record.index + 1,
@@ -477,7 +477,7 @@ impl DataStore for MemoryDataStore {
             let end = get_records_before_checkpoint(&log.checkpoint_indices, checkpoint_index);
             Ok(log.entries[start..std::cmp::min(end, start + limit as usize)].to_vec())
         } else {
-            Err(DataStoreError::CheckpointNotFound(root.clone()))
+            Err(DataStoreError::CheckpointNotFound(checkpoint_id.clone()))
         }
     }
 

--- a/crates/server/src/datastore/mod.rs
+++ b/crates/server/src/datastore/mod.rs
@@ -216,20 +216,20 @@ pub trait DataStore: Send + Sync {
     /// Gets the latest checkpoint.
     async fn get_latest_checkpoint(&self) -> Result<SerdeEnvelope<MapCheckpoint>, DataStoreError>;
 
-    /// Gets the operator records for the given registry root.
+    /// Gets the operator records for the given registry checkpoint ID hash.
     async fn get_operator_records(
         &self,
         log_id: &LogId,
-        root: &AnyHash,
+        checkpoint_id: &AnyHash,
         since: Option<&RecordId>,
         limit: u16,
     ) -> Result<Vec<ProtoEnvelope<operator::OperatorRecord>>, DataStoreError>;
 
-    /// Gets the package records for the given registry root.
+    /// Gets the package records for the given registry checkpoint ID hash.
     async fn get_package_records(
         &self,
         log_id: &LogId,
-        root: &AnyHash,
+        checkpoint_id: &AnyHash,
         since: Option<&RecordId>,
         limit: u16,
     ) -> Result<Vec<ProtoEnvelope<package::PackageRecord>>, DataStoreError>;

--- a/crates/server/src/datastore/postgres/mod.rs
+++ b/crates/server/src/datastore/postgres/mod.rs
@@ -31,17 +31,17 @@ mod schema;
 async fn get_records<R: Decode>(
     conn: &mut AsyncPgConnection,
     log_id: i32,
-    root: &AnyHash,
+    checkpoint_id: &AnyHash,
     since: Option<&RecordId>,
     limit: i64,
 ) -> Result<Vec<ProtoEnvelope<R>>, DataStoreError> {
     let checkpoint_id = schema::checkpoints::table
         .select(schema::checkpoints::id)
-        .filter(schema::checkpoints::checkpoint_id.eq(TextRef(root)))
+        .filter(schema::checkpoints::checkpoint_id.eq(TextRef(checkpoint_id)))
         .first::<i32>(conn)
         .await
         .optional()?
-        .ok_or_else(|| DataStoreError::CheckpointNotFound(root.clone()))?;
+        .ok_or_else(|| DataStoreError::CheckpointNotFound(checkpoint_id.clone()))?;
 
     let mut query = schema::records::table
         .into_boxed()
@@ -709,7 +709,7 @@ impl DataStore for PostgresDataStore {
     async fn get_operator_records(
         &self,
         log_id: &LogId,
-        root: &AnyHash,
+        checkpoint_id: &AnyHash,
         since: Option<&RecordId>,
         limit: u16,
     ) -> Result<Vec<ProtoEnvelope<operator::OperatorRecord>>, DataStoreError> {
@@ -722,13 +722,13 @@ impl DataStore for PostgresDataStore {
             .optional()?
             .ok_or_else(|| DataStoreError::LogNotFound(log_id.clone()))?;
 
-        get_records(&mut conn, log_id, root, since, limit as i64).await
+        get_records(&mut conn, log_id, checkpoint_id, since, limit as i64).await
     }
 
     async fn get_package_records(
         &self,
         log_id: &LogId,
-        root: &AnyHash,
+        checkpoint_id: &AnyHash,
         since: Option<&RecordId>,
         limit: u16,
     ) -> Result<Vec<ProtoEnvelope<package::PackageRecord>>, DataStoreError> {
@@ -741,7 +741,7 @@ impl DataStore for PostgresDataStore {
             .optional()?
             .ok_or_else(|| DataStoreError::LogNotFound(log_id.clone()))?;
 
-        get_records(&mut conn, log_id, root, since, limit as i64).await
+        get_records(&mut conn, log_id, checkpoint_id, since, limit as i64).await
     }
 
     async fn get_operator_record(


### PR DESCRIPTION
`checkpoint_id` is probably more clear and consistent than `root` or `checkpoint`. Breaking change while they are still easy.

I don't feel strongly about this. This PR would be an "either or", comparing against: https://github.com/bytecodealliance/registry/pull/161