### PR TITLE
Replace record checkpoint field with registry log index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4132,6 +4132,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "tracing",
  "tracing-subscriber",
  "url",
  "warg-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 futures = { workspace = true }
+tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 async-trait = { workspace = true }
 bytes = { workspace = true }

--- a/crates/api/src/v1/package.rs
+++ b/crates/api/src/v1/package.rs
@@ -6,8 +6,8 @@ use std::{borrow::Cow, collections::HashMap};
 use thiserror::Error;
 use warg_crypto::hash::AnyHash;
 use warg_protocol::{
-    registry::{LogId, MapCheckpoint, PackageId, RecordId},
-    ProtoEnvelopeBody, SerdeEnvelope,
+    registry::{LogId, PackageId, RecordId},
+    ProtoEnvelopeBody,
 };
 
 /// Represents the supported kinds of content sources.
@@ -45,16 +45,6 @@ pub struct PackageRecord {
 }
 
 impl PackageRecord {
-    /// Gets the checkpoint of the record.
-    ///
-    /// Returns `None` if the record hasn't been published yet.
-    pub fn checkpoint(&self) -> Option<&SerdeEnvelope<MapCheckpoint>> {
-        match &self.state {
-            PackageRecordState::Published { checkpoint, .. } => Some(checkpoint),
-            _ => None,
-        }
-    }
-
     /// Gets the missing content digests of the record.
     pub fn missing_content(&self) -> &[AnyHash] {
         match &self.state {
@@ -89,10 +79,10 @@ pub enum PackageRecordState {
     },
     /// The package record was successfully published to the log.
     Published {
-        /// The checkpoint that the record was included in.
-        checkpoint: SerdeEnvelope<MapCheckpoint>,
         /// The envelope of the package record.
         record: ProtoEnvelopeBody,
+        /// The index of the record in the registry log.
+        registry_log_index: u32,
         /// The content sources of the record.
         content_sources: HashMap<AnyHash, Vec<ContentSource>>,
     },

--- a/crates/crypto/src/hash/static.rs
+++ b/crates/crypto/src/hash/static.rs
@@ -9,7 +9,7 @@ use crate::{ByteVisitor, VisitBytes};
 
 use super::{Output, SupportedDigest};
 
-#[derive(PartialOrd, Ord)]
+#[derive(Default, PartialOrd, Ord)]
 pub struct Hash<D: SupportedDigest> {
     pub(crate) digest: Output<D>,
 }

--- a/crates/protocol/src/serde_envelope.rs
+++ b/crates/protocol/src/serde_envelope.rs
@@ -45,6 +45,10 @@ impl<Contents> SerdeEnvelope<Contents> {
         })
     }
 
+    pub fn into_contents(self) -> Contents {
+        self.contents
+    }
+
     pub fn key_id(&self) -> &signing::KeyID {
         &self.key_id
     }

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -746,9 +746,9 @@ components:
           description: The state of the package record.
           enum: [published]
           example: published
-        checkpoint:
-          "$ref": "#/components/schemas/SignedMapCheckpoint"
-          description: The checkpoint of the record.
+        registryLogIndex:
+          type: number
+          description: The index of the record in the registry log.
         record:
           "$ref": "#/components/schemas/EnvelopeBody"
           description: The package record.

--- a/crates/server/src/api/v1/package.rs
+++ b/crates/server/src/api/v1/package.rs
@@ -285,11 +285,13 @@ async fn get_record(
                 })
                 .collect();
 
+            let registry_log_index = record.registry_log_index.unwrap().try_into().unwrap();
+
             Ok(Json(PackageRecord {
                 id: record_id,
                 state: PackageRecordState::Published {
                     record: record.envelope.into(),
-                    checkpoint: record.checkpoint.unwrap(),
+                    registry_log_index,
                     content_sources,
                 },
             }))

--- a/crates/server/src/datastore/memory.rs
+++ b/crates/server/src/datastore/memory.rs
@@ -1,4 +1,4 @@
-use super::{DataStore, DataStoreError, InitialLeaf};
+use super::{DataStore, DataStoreError};
 use futures::Stream;
 use indexmap::IndexMap;
 use std::{
@@ -15,10 +15,14 @@ use warg_protocol::{
     ProtoEnvelope, SerdeEnvelope,
 };
 
+struct Entry<R> {
+    registry_index: u64,
+    record_content: ProtoEnvelope<R>,
+}
+
 struct Log<V, R> {
     validator: V,
-    entries: Vec<ProtoEnvelope<R>>,
-    checkpoint_indices: Vec<usize>,
+    entries: Vec<Entry<R>>,
 }
 
 impl<V, R> Default for Log<V, R>
@@ -29,7 +33,6 @@ where
         Self {
             validator: V::default(),
             entries: Vec::new(),
-            checkpoint_indices: Vec::new(),
         }
     }
 }
@@ -37,8 +40,8 @@ where
 struct Record {
     /// Index in the log's entries.
     index: usize,
-    /// Index in the checkpoints map.
-    checkpoint_index: Option<usize>,
+    /// Index in the registry's log.
+    registry_index: u64,
 }
 
 enum PendingRecord {
@@ -77,13 +80,6 @@ struct State {
     records: HashMap<LogId, HashMap<RecordId, RecordStatus>>,
 }
 
-fn get_records_before_checkpoint(indices: &[usize], checkpoint_index: usize) -> usize {
-    indices
-        .iter()
-        .filter(|index| **index <= checkpoint_index)
-        .count()
-}
-
 /// Represents an in-memory data store.
 ///
 /// Data is not persisted between restarts of the server.
@@ -106,12 +102,19 @@ impl Default for MemoryDataStore {
 
 #[axum::async_trait]
 impl DataStore for MemoryDataStore {
-    async fn get_initial_leaves(
+    async fn get_all_checkpoints(
         &self,
     ) -> Result<
-        Pin<Box<dyn Stream<Item = Result<InitialLeaf, DataStoreError>> + Send>>,
+        Pin<Box<dyn Stream<Item = Result<MapCheckpoint, DataStoreError>> + Send>>,
         DataStoreError,
     > {
+        Ok(Box::pin(futures::stream::empty()))
+    }
+
+    async fn get_all_validated_records(
+        &self,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<LogLeaf, DataStoreError>> + Send>>, DataStoreError>
+    {
         Ok(Box::pin(futures::stream::empty()))
     }
 
@@ -161,10 +164,11 @@ impl DataStore for MemoryDataStore {
         Ok(())
     }
 
-    async fn validate_operator_record(
+    async fn commit_operator_record(
         &self,
         log_id: &LogId,
         record_id: &RecordId,
+        registry_log_index: u64,
     ) -> Result<(), DataStoreError> {
         let mut state = self.0.write().await;
 
@@ -189,10 +193,13 @@ impl DataStore for MemoryDataStore {
                 {
                     Ok(_) => {
                         let index = log.entries.len();
-                        log.entries.push(record);
+                        log.entries.push(Entry {
+                            registry_index: registry_log_index,
+                            record_content: record,
+                        });
                         *status = RecordStatus::Validated(Record {
                             index,
-                            checkpoint_index: None,
+                            registry_index: registry_log_index,
                         });
                         Ok(())
                     }
@@ -266,10 +273,11 @@ impl DataStore for MemoryDataStore {
         Ok(())
     }
 
-    async fn validate_package_record(
+    async fn commit_package_record(
         &self,
         log_id: &LogId,
         record_id: &RecordId,
+        registry_log_index: u64,
     ) -> Result<(), DataStoreError> {
         let mut state = self.0.write().await;
 
@@ -294,10 +302,13 @@ impl DataStore for MemoryDataStore {
                 {
                     Ok(_) => {
                         let index = log.entries.len();
-                        log.entries.push(record);
+                        log.entries.push(Entry {
+                            registry_index: registry_log_index,
+                            record_content: record,
+                        });
                         *status = RecordStatus::Validated(Record {
                             index,
-                            checkpoint_index: None,
+                            registry_index: registry_log_index,
                         });
                         Ok(())
                     }
@@ -380,37 +391,13 @@ impl DataStore for MemoryDataStore {
         &self,
         checkpoint_id: &AnyHash,
         checkpoint: SerdeEnvelope<MapCheckpoint>,
-        participants: &[LogLeaf],
     ) -> Result<(), DataStoreError> {
         let mut state = self.0.write().await;
 
-        let (index, prev) = state
+        let (_, prev) = state
             .checkpoints
             .insert_full(checkpoint_id.clone(), checkpoint);
         assert!(prev.is_none());
-
-        for leaf in participants {
-            if let Some(log) = state.operators.get_mut(&leaf.log_id) {
-                log.checkpoint_indices.push(index);
-            } else if let Some(log) = state.packages.get_mut(&leaf.log_id) {
-                log.checkpoint_indices.push(index);
-            } else {
-                unreachable!("log not found");
-            }
-
-            match state
-                .records
-                .get_mut(&leaf.log_id)
-                .unwrap()
-                .get_mut(&leaf.record_id)
-                .unwrap()
-            {
-                RecordStatus::Validated(record) => {
-                    record.checkpoint_index = Some(index);
-                }
-                _ => unreachable!(),
-            }
-        }
 
         Ok(())
     }
@@ -435,20 +422,27 @@ impl DataStore for MemoryDataStore {
             .get(log_id)
             .ok_or_else(|| DataStoreError::LogNotFound(log_id.clone()))?;
 
-        if let Some(checkpoint_index) = state.checkpoints.get_index_of(checkpoint_id) {
-            let start = match since {
-                Some(since) => match &state.records[log_id][since] {
-                    RecordStatus::Validated(record) => record.index + 1,
-                    _ => unreachable!(),
-                },
-                None => 0,
-            };
+        let Some(checkpoint) = state.checkpoints.get(checkpoint_id) else {
+            return Err(DataStoreError::CheckpointNotFound(checkpoint_id.clone()));
+        };
 
-            let end = get_records_before_checkpoint(&log.checkpoint_indices, checkpoint_index);
-            Ok(log.entries[start..std::cmp::min(end, start + limit as usize)].to_vec())
-        } else {
-            Err(DataStoreError::CheckpointNotFound(checkpoint_id.clone()))
-        }
+        let start_log_idx = match since {
+            Some(since) => match &state.records[log_id][since] {
+                RecordStatus::Validated(record) => record.index + 1,
+                _ => unreachable!(),
+            },
+            None => 0,
+        };
+        let end_registry_idx = checkpoint.as_ref().log_length as u64;
+
+        Ok(log
+            .entries
+            .iter()
+            .skip(start_log_idx)
+            .take_while(|entry| entry.registry_index < end_registry_idx)
+            .map(|entry| entry.record_content.clone())
+            .take(limit as usize)
+            .collect())
     }
 
     async fn get_package_records(
@@ -465,20 +459,27 @@ impl DataStore for MemoryDataStore {
             .get(log_id)
             .ok_or_else(|| DataStoreError::LogNotFound(log_id.clone()))?;
 
-        if let Some(checkpoint_index) = state.checkpoints.get_index_of(checkpoint_id) {
-            let start = match since {
-                Some(since) => match &state.records[log_id][since] {
-                    RecordStatus::Validated(record) => record.index + 1,
-                    _ => unreachable!(),
-                },
-                None => 0,
-            };
+        let Some(checkpoint) = state.checkpoints.get(checkpoint_id) else {
+            return Err(DataStoreError::CheckpointNotFound(checkpoint_id.clone()));
+        };
 
-            let end = get_records_before_checkpoint(&log.checkpoint_indices, checkpoint_index);
-            Ok(log.entries[start..std::cmp::min(end, start + limit as usize)].to_vec())
-        } else {
-            Err(DataStoreError::CheckpointNotFound(checkpoint_id.clone()))
-        }
+        let start_log_idx = match since {
+            Some(since) => match &state.records[log_id][since] {
+                RecordStatus::Validated(record) => record.index + 1,
+                _ => unreachable!(),
+            },
+            None => 0,
+        };
+        let end_registry_idx = checkpoint.as_ref().log_length as u64;
+
+        Ok(log
+            .entries
+            .iter()
+            .skip(start_log_idx)
+            .take_while(|entry| entry.registry_index < end_registry_idx)
+            .map(|entry| entry.record_content.clone())
+            .take(limit as usize)
+            .collect())
     }
 
     async fn get_operator_record(
@@ -494,7 +495,7 @@ impl DataStore for MemoryDataStore {
             .get(record_id)
             .ok_or_else(|| DataStoreError::RecordNotFound(record_id.clone()))?;
 
-        let (status, envelope, checkpoint) = match status {
+        let (status, envelope, registry_log_index) = match status {
             RecordStatus::Pending(PendingRecord::Operator { record, .. }) => {
                 (super::RecordStatus::Pending, record.clone().unwrap(), None)
             }
@@ -509,16 +510,20 @@ impl DataStore for MemoryDataStore {
                     .get(log_id)
                     .ok_or_else(|| DataStoreError::LogNotFound(log_id.clone()))?;
 
-                let checkpoint = r.checkpoint_index.map(|i| state.checkpoints[i].clone());
+                let published_length = state
+                    .checkpoints
+                    .last()
+                    .map(|(_, c)| c.as_ref().log_length)
+                    .unwrap_or_default() as u64;
 
                 (
-                    if checkpoint.is_some() {
+                    if r.registry_index < published_length {
                         super::RecordStatus::Published
                     } else {
                         super::RecordStatus::Validated
                     },
-                    log.entries[r.index].clone(),
-                    checkpoint,
+                    log.entries[r.index].record_content.clone(),
+                    Some(r.registry_index),
                 )
             }
             _ => return Err(DataStoreError::RecordNotFound(record_id.clone())),
@@ -527,7 +532,7 @@ impl DataStore for MemoryDataStore {
         Ok(super::Record {
             status,
             envelope,
-            checkpoint,
+            registry_log_index,
         })
     }
 
@@ -544,7 +549,7 @@ impl DataStore for MemoryDataStore {
             .get(record_id)
             .ok_or_else(|| DataStoreError::RecordNotFound(record_id.clone()))?;
 
-        let (status, envelope, checkpoint) = match status {
+        let (status, envelope, registry_log_index) = match status {
             RecordStatus::Pending(PendingRecord::Package { record, .. }) => {
                 (super::RecordStatus::Pending, record.clone().unwrap(), None)
             }
@@ -559,16 +564,20 @@ impl DataStore for MemoryDataStore {
                     .get(log_id)
                     .ok_or_else(|| DataStoreError::LogNotFound(log_id.clone()))?;
 
-                let checkpoint = r.checkpoint_index.map(|i| state.checkpoints[i].clone());
+                let published_length = state
+                    .checkpoints
+                    .last()
+                    .map(|(_, c)| c.as_ref().log_length)
+                    .unwrap_or_default() as u64;
 
                 (
-                    if checkpoint.is_some() {
+                    if r.registry_index < published_length {
                         super::RecordStatus::Published
                     } else {
                         super::RecordStatus::Validated
                     },
-                    log.entries[r.index].clone(),
-                    checkpoint,
+                    log.entries[r.index].record_content.clone(),
+                    Some(r.registry_index),
                 )
             }
             _ => return Err(DataStoreError::RecordNotFound(record_id.clone())),
@@ -577,7 +586,7 @@ impl DataStore for MemoryDataStore {
         Ok(super::Record {
             status,
             envelope,
-            checkpoint,
+            registry_log_index,
         })
     }
 

--- a/crates/server/src/datastore/postgres/migrations/2023-04-11-013700_initial_db/up.sql
+++ b/crates/server/src/datastore/postgres/migrations/2023-04-11-013700_initial_db/up.sql
@@ -33,7 +33,7 @@ CREATE TABLE records (
   id SERIAL PRIMARY KEY,
   log_id INTEGER NOT NULL REFERENCES logs(id),
   record_id TEXT NOT NULL UNIQUE,
-  checkpoint_id INTEGER REFERENCES checkpoints(id),
+  registry_log_index BIGINT UNIQUE,
   content BYTEA NOT NULL,
   status record_status NOT NULL DEFAULT 'pending',
   reason TEXT,

--- a/crates/server/src/datastore/postgres/models.rs
+++ b/crates/server/src/datastore/postgres/models.rs
@@ -107,6 +107,7 @@ pub struct Checkpoint {
 #[diesel(table_name = records)]
 pub struct RecordContent {
     pub status: RecordStatus,
+    pub registry_log_index: Option<i64>,
     pub reason: Option<String>,
     pub content: Vec<u8>,
 }

--- a/crates/server/src/datastore/postgres/schema.rs
+++ b/crates/server/src/datastore/postgres/schema.rs
@@ -50,7 +50,7 @@ diesel::table! {
         id -> Int4,
         log_id -> Int4,
         record_id -> Text,
-        checkpoint_id -> Nullable<Int4>,
+        registry_log_index -> Nullable<Int8>,
         content -> Bytea,
         status -> RecordStatus,
         reason -> Nullable<Text>,
@@ -60,7 +60,6 @@ diesel::table! {
 }
 
 diesel::joinable!(contents -> records (record_id));
-diesel::joinable!(records -> checkpoints (checkpoint_id));
 diesel::joinable!(records -> logs (log_id));
 
 diesel::allow_tables_to_appear_in_same_query!(checkpoints, contents, logs, records,);

--- a/crates/transparency/src/log/vec_log.rs
+++ b/crates/transparency/src/log/vec_log.rs
@@ -34,6 +34,11 @@ where
     D: SupportedDigest,
     V: VisitBytes,
 {
+    /// Returns the number of entries in the log.
+    pub fn length(&self) -> usize {
+        self.length
+    }
+
     fn get_digest(&self, node: Node) -> Hash<D> {
         self.tree[node.index()].clone()
     }

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -29,8 +29,6 @@ fn data_store() -> Result<Box<dyn DataStore>> {
 /// out to multiple tests.
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn it_works_with_postgres() -> TestResult {
-    tracing_subscriber::fmt().with_test_writer().init();
-
     let root = root().await?;
     let (server, config) = spawn_server(
         &root,

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -7,6 +7,7 @@ use std::{
 };
 use tokio::{fs, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
+use tracing::subscriber::DefaultGuard;
 use url::Url;
 use warg_client::{
     storage::{ContentStorage, PublishEntry, PublishInfo},
@@ -44,13 +45,14 @@ pub fn create_client(config: &warg_client::Config) -> Result<FileSystemClient> {
 pub struct ServerInstance {
     task: Option<JoinHandle<()>>,
     shutdown: CancellationToken,
+    _subscriber_guard: DefaultGuard,
 }
 
 impl Drop for ServerInstance {
     fn drop(&mut self) {
         futures::executor::block_on(async move {
             self.shutdown.cancel();
-            self.task.take().unwrap().await.ok();
+            self.task.take().unwrap().await.unwrap();
         });
     }
 }
@@ -92,6 +94,15 @@ pub async fn root() -> Result<PathBuf> {
     Ok(path)
 }
 
+/// Sets up logging for the current thread, active until the returned guard is dropped.
+fn thread_test_logging() -> DefaultGuard {
+    let subscriber = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_test_writer()
+        .finish();
+    tracing::subscriber::set_default(subscriber)
+}
+
 /// Spawns a server as a background task.
 pub async fn spawn_server(
     root: &Path,
@@ -99,6 +110,8 @@ pub async fn spawn_server(
     data_store: Option<Box<dyn DataStore>>,
     authorized_keys: Option<Vec<(String, KeyID)>>,
 ) -> Result<(ServerInstance, warg_client::Config)> {
+    let _subscriber_guard = thread_test_logging();
+
     let shutdown = CancellationToken::new();
     let mut config = Config::new(test_operator_key(), root.join("server"))
         .with_addr(([127, 0, 0, 1], 0))
@@ -126,14 +139,17 @@ pub async fn spawn_server(
     let server = Server::new(config).initialize().await?;
 
     let addr = server.local_addr()?;
+    tracing::debug!("Test server running at {addr}");
 
     let task = tokio::spawn(async move {
+        let _subscriber_guard = thread_test_logging();
         server.serve().await.unwrap();
     });
 
     let instance = ServerInstance {
         task: Some(task),
         shutdown,
+        _subscriber_guard,
     };
 
     let config = warg_client::Config {

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -123,11 +123,12 @@ pub async fn spawn_server(
         config = config.with_boxed_data_store(store);
     }
 
-    let mut server = Server::new(config);
-    let addr = server.bind()?;
+    let server = Server::new(config).initialize().await?;
+
+    let addr = server.local_addr()?;
 
     let task = tokio::spawn(async move {
-        server.run().await.unwrap();
+        server.serve().await.unwrap();
     });
 
     let instance = ServerInstance {


### PR DESCRIPTION
Prior to this commit, every published record is associated with the first checkpoint created after the record was added to the registry log. While this does aid clients in verifying the inclusion of a record, it is more information than necessary and forces the registry to hold on to all checkpoints indefinitely. It also requires additional bookkeeping just to track this partially-unnecessary information.

This removes that per-record checkpoint and instead associates each record with its index in the registry log. This is still enough information to aid inclusion proofs and reduces the overall complexity of the server.