### PR TITLE
client: Fix Client::update on empty registry storage

### DIFF
--- a/crates/client/src/storage/fs.rs
+++ b/crates/client/src/storage/fs.rs
@@ -97,6 +97,10 @@ impl RegistryStorage for FileSystemRegistryStorage {
         let mut packages = Vec::new();
 
         let packages_dir = self.base_dir.join(PACKAGE_LOGS_DIR);
+        if !packages_dir.exists() {
+            return Ok(vec![]);
+        }
+
         for entry in WalkDir::new(&packages_dir) {
             let entry = entry.with_context(|| {
                 anyhow!(

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -80,6 +80,9 @@ async fn client_incrementally_fetches() -> Result<()> {
     // Recreate the client with the same config
     let client = create_client(&config)?;
 
+    // Regression test: update on empty registry storage
+    client.update().await?;
+
     // Fetch the package log
     client.upsert([&id]).await?;
 


### PR DESCRIPTION
Fixing `warg update` in #158 introduced a regression when local registry storage is empty.