### PR TITLE
Add timestamp to checkpoints

### DIFF
--- a/crates/api/src/v1/proof.rs
+++ b/crates/api/src/v1/proof.rs
@@ -6,7 +6,7 @@ use serde_with::{base64::Base64, serde_as};
 use std::borrow::Cow;
 use thiserror::Error;
 use warg_crypto::hash::AnyHash;
-use warg_protocol::registry::{LogId, LogLeaf, MapCheckpoint};
+use warg_protocol::registry::{Checkpoint, LogId, LogLeaf};
 
 /// Represents a consistency proof request.
 #[derive(Serialize, Deserialize)]
@@ -33,7 +33,7 @@ pub struct ConsistencyResponse {
 #[serde(rename_all = "camelCase")]
 pub struct InclusionRequest<'a> {
     /// The checkpoint to check for inclusion.
-    pub checkpoint: Cow<'a, MapCheckpoint>,
+    pub checkpoint: Cow<'a, Checkpoint>,
     /// The log leafs to check for inclusion.
     pub leafs: Cow<'a, [LogLeaf]>,
 }

--- a/crates/client/src/api.rs
+++ b/crates/client/src/api.rs
@@ -18,7 +18,7 @@ use warg_api::v1::{
 };
 use warg_crypto::hash::{AnyHash, HashError, Sha256};
 use warg_protocol::{
-    registry::{LogId, LogLeaf, MapCheckpoint, MapLeaf, RecordId},
+    registry::{Checkpoint, LogId, LogLeaf, MapLeaf, RecordId, TimestampedCheckpoint},
     SerdeEnvelope,
 };
 use warg_transparency::{
@@ -143,7 +143,9 @@ impl Client {
     }
 
     /// Gets the latest checkpoint from the registry.
-    pub async fn latest_checkpoint(&self) -> Result<SerdeEnvelope<MapCheckpoint>, ClientError> {
+    pub async fn latest_checkpoint(
+        &self,
+    ) -> Result<SerdeEnvelope<TimestampedCheckpoint>, ClientError> {
         let url = self.url.join(paths::fetch_checkpoint());
         tracing::debug!("getting latest checkpoint at `{url}`");
         into_result::<_, FetchError>(reqwest::get(url).await?).await
@@ -333,7 +335,7 @@ impl Client {
 
     fn validate_inclusion_response(
         response: InclusionResponse,
-        checkpoint: &MapCheckpoint,
+        checkpoint: &Checkpoint,
         leafs: &[LogLeaf],
     ) -> Result<(), ClientError> {
         let log_proof_bundle: LogProofBundle<Sha256, LogLeaf> =

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -25,7 +25,7 @@ use warg_crypto::{
 };
 use warg_protocol::{
     operator, package,
-    registry::{LogId, LogLeaf, MapCheckpoint, PackageId, RecordId},
+    registry::{LogId, LogLeaf, PackageId, RecordId, TimestampedCheckpoint},
     ProtoEnvelope, SerdeEnvelope, Version, VersionReq,
 };
 
@@ -350,10 +350,11 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
 
     async fn update_checkpoint<'a>(
         &self,
-        checkpoint: &SerdeEnvelope<MapCheckpoint>,
+        ts_checkpoint: &SerdeEnvelope<TimestampedCheckpoint>,
         packages: impl IntoIterator<Item = &mut PackageInfo>,
     ) -> Result<(), ClientError> {
-        let checkpoint_id: AnyHash = Hash::<Sha256>::of(checkpoint.as_ref()).into();
+        let checkpoint = &ts_checkpoint.as_ref().checkpoint;
+        let checkpoint_id: AnyHash = Hash::<Sha256>::of(checkpoint).into();
         tracing::info!("updating to checkpoint `{checkpoint_id}`");
 
         let mut operator = self.registry.load_operator().await?.unwrap_or_default();
@@ -464,7 +465,7 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
         if !leafs.is_empty() {
             self.api
                 .prove_inclusion(InclusionRequest {
-                    checkpoint: Cow::Borrowed(checkpoint.as_ref()),
+                    checkpoint: Cow::Borrowed(checkpoint),
                     leafs: Cow::Borrowed(&leafs),
                 })
                 .await?;
@@ -473,8 +474,8 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
         if let Some(from) = self.registry.load_checkpoint().await? {
             self.api
                 .prove_log_consistency(ConsistencyRequest {
-                    from: Cow::Borrowed(&from.as_ref().log_root),
-                    to: Cow::Borrowed(&checkpoint.as_ref().log_root),
+                    from: Cow::Borrowed(&from.as_ref().checkpoint.log_root),
+                    to: Cow::Borrowed(&ts_checkpoint.as_ref().checkpoint.log_root),
                 })
                 .await?;
         }
@@ -486,7 +487,7 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
             self.registry.store_package(package).await?;
         }
 
-        self.registry.store_checkpoint(checkpoint).await?;
+        self.registry.store_checkpoint(ts_checkpoint).await?;
 
         Ok(())
     }

--- a/crates/client/src/storage.rs
+++ b/crates/client/src/storage.rs
@@ -13,7 +13,7 @@ use warg_crypto::{
 use warg_protocol::{
     operator,
     package::{self, PackageRecord, PACKAGE_RECORD_VERSION},
-    registry::{MapCheckpoint, PackageId, RecordId},
+    registry::{Checkpoint, PackageId, RecordId, TimestampedCheckpoint},
     ProtoEnvelope, SerdeEnvelope, Version,
 };
 
@@ -30,10 +30,13 @@ pub use fs::*;
 #[async_trait]
 pub trait RegistryStorage: Send + Sync {
     /// Loads most recent checkpoint
-    async fn load_checkpoint(&self) -> Result<Option<SerdeEnvelope<MapCheckpoint>>>;
+    async fn load_checkpoint(&self) -> Result<Option<SerdeEnvelope<TimestampedCheckpoint>>>;
 
     /// Stores most recent checkpoint
-    async fn store_checkpoint(&self, checkpoint: &SerdeEnvelope<MapCheckpoint>) -> Result<()>;
+    async fn store_checkpoint(
+        &self,
+        ts_checkpoint: &SerdeEnvelope<TimestampedCheckpoint>,
+    ) -> Result<()>;
 
     /// Loads the operator information from the storage.
     ///
@@ -116,7 +119,7 @@ pub struct PackageInfo {
     pub id: PackageId,
     /// The last known checkpoint of the package.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub checkpoint: Option<SerdeEnvelope<MapCheckpoint>>,
+    pub checkpoint: Option<Checkpoint>,
     /// The current package log state
     #[serde(default)]
     pub state: package::LogState,

--- a/crates/client/src/storage/fs.rs
+++ b/crates/client/src/storage/fs.rs
@@ -19,7 +19,7 @@ use tokio_util::io::ReaderStream;
 use walkdir::WalkDir;
 use warg_crypto::hash::{AnyHash, Digest, Hash, Sha256};
 use warg_protocol::{
-    registry::{LogId, MapCheckpoint, PackageId},
+    registry::{LogId, PackageId, TimestampedCheckpoint},
     SerdeEnvelope,
 };
 
@@ -85,12 +85,15 @@ impl FileSystemRegistryStorage {
 
 #[async_trait]
 impl RegistryStorage for FileSystemRegistryStorage {
-    async fn load_checkpoint(&self) -> Result<Option<SerdeEnvelope<MapCheckpoint>>> {
+    async fn load_checkpoint(&self) -> Result<Option<SerdeEnvelope<TimestampedCheckpoint>>> {
         load(&self.base_dir.join("checkpoint")).await
     }
 
-    async fn store_checkpoint(&self, checkpoint: &SerdeEnvelope<MapCheckpoint>) -> Result<()> {
-        store(&self.base_dir.join("checkpoint"), checkpoint).await
+    async fn store_checkpoint(
+        &self,
+        ts_checkpoint: &SerdeEnvelope<TimestampedCheckpoint>,
+    ) -> Result<()> {
+        store(&self.base_dir.join("checkpoint"), ts_checkpoint).await
     }
 
     async fn load_packages(&self) -> Result<Vec<PackageInfo>> {

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -102,7 +102,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SignedMapCheckpoint"
+                $ref: "#/components/schemas/SignedCheckpoint"
         default:
           description: An error occurred when processing the request.
           content:
@@ -650,7 +650,7 @@ components:
         - leafs
       properties:
         checkpoint:
-          $ref: "#/components/schemas/MapCheckpoint"
+          $ref: "#/components/schemas/Checkpoint"
           description: The checkpoint to prove the inclusion for.
         leafs:
           type: array
@@ -752,13 +752,13 @@ components:
         contentSources:
           "$ref": "#/components/schemas/ContentSourceMap"
           description: The content sources for the package record.
-    MapCheckpoint:
+    Checkpoint:
       type: object
       description: |
         A registry checkpoint.
 
         Checkpoints are hashed by concatenating the following:
-          * A prefix of the byte string `WARG-MAP-CHECKPOINT-V0`
+          * A prefix of the byte string `WARG-CHECKPOINT-V0`
           * The LEB128-encoded `logLength`
           * The LEB128-length-prefixed `logRoot`
           * The LEB128-length-prefixed `mapRoot`
@@ -779,7 +779,31 @@ components:
         mapRoot:
           $ref: "#/components/schemas/AnyHash"
           description: The map root hash of the checkpoint.
-    SignedMapCheckpoint:
+    TimestampedCheckpoint:
+      description: |
+        A timestamped registry checkpoint.
+
+        Checkpoints are hashed by concatenating the following:
+          * A prefix of the byte string `WARG-TIMESTAMPED-CHECKPOINT-V0`
+          * The LEB128-encoded `logLength`
+          * The LEB128-length-prefixed `logRoot`
+          * The LEB128-length-prefixed `mapRoot`
+          * The LEB128-encoded `timestamp`
+      allOf:
+        - $ref: "#/components/schemas/Checkpoint"
+        - type: object
+          additionalProperties: false
+          required:
+            - timestamp
+          properties:
+            timestamp:
+              type: integer
+              description: |
+                The time that the checkpoint was generated, in seconds since
+                the Unix epoch.
+              minimum: 1
+              example: 1692035502
+    SignedCheckpoint:
       description: A signed registry checkpoint.
       allOf:
         - type: object
@@ -787,7 +811,7 @@ components:
             - contents
           properties:
             contents:
-              $ref: "#/components/schemas/MapCheckpoint"
+              $ref: "#/components/schemas/TimestampedCheckpoint"
         - $ref: "#/components/schemas/Signature"
     EnvelopeBody:
       description: A signed envelope body.

--- a/crates/server/src/api/debug/mod.rs
+++ b/crates/server/src/api/debug/mod.rs
@@ -92,7 +92,7 @@ async fn get_package_info(
         .get_latest_checkpoint()
         .await
         .context("get_latest_checkpoint")?;
-    let checkpoint_id = Hash::<Sha256>::of(checkpoint.as_ref()).into();
+    let checkpoint_id = Hash::<Sha256>::of(&checkpoint.as_ref().checkpoint).into();
 
     let log_id = LogId::package_log::<Sha256>(&package_id);
     let records = store

--- a/crates/server/src/api/v1/fetch.rs
+++ b/crates/server/src/api/v1/fetch.rs
@@ -12,7 +12,7 @@ use axum::{
 use std::collections::HashMap;
 use warg_api::v1::fetch::{FetchError, FetchLogsRequest, FetchLogsResponse};
 use warg_crypto::hash::Sha256;
-use warg_protocol::registry::{LogId, MapCheckpoint};
+use warg_protocol::registry::{LogId, TimestampedCheckpoint};
 use warg_protocol::{ProtoEnvelopeBody, SerdeEnvelope};
 
 const DEFAULT_RECORDS_LIMIT: u16 = 100;
@@ -126,7 +126,7 @@ async fn fetch_logs(
 #[debug_handler]
 async fn fetch_checkpoint(
     State(config): State<Config>,
-) -> Result<Json<SerdeEnvelope<MapCheckpoint>>, FetchApiError> {
+) -> Result<Json<SerdeEnvelope<TimestampedCheckpoint>>, FetchApiError> {
     Ok(Json(
         config.core_service.store().get_latest_checkpoint().await?,
     ))

--- a/crates/server/src/datastore/mod.rs
+++ b/crates/server/src/datastore/mod.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 use warg_crypto::{hash::AnyHash, signing::KeyID};
 use warg_protocol::{
     operator, package,
-    registry::{LogId, LogLeaf, MapCheckpoint, PackageId, RecordId},
+    registry::{LogId, LogLeaf, PackageId, RecordId, TimestampedCheckpoint},
     ProtoEnvelope, SerdeEnvelope,
 };
 
@@ -102,7 +102,7 @@ pub trait DataStore: Send + Sync {
     async fn get_all_checkpoints(
         &self,
     ) -> Result<
-        Pin<Box<dyn Stream<Item = Result<MapCheckpoint, DataStoreError>> + Send>>,
+        Pin<Box<dyn Stream<Item = Result<TimestampedCheckpoint, DataStoreError>> + Send>>,
         DataStoreError,
     >;
 
@@ -207,11 +207,13 @@ pub trait DataStore: Send + Sync {
     async fn store_checkpoint(
         &self,
         checkpoint_id: &AnyHash,
-        checkpoint: SerdeEnvelope<MapCheckpoint>,
+        ts_checkpoint: SerdeEnvelope<TimestampedCheckpoint>,
     ) -> Result<(), DataStoreError>;
 
     /// Gets the latest checkpoint.
-    async fn get_latest_checkpoint(&self) -> Result<SerdeEnvelope<MapCheckpoint>, DataStoreError>;
+    async fn get_latest_checkpoint(
+        &self,
+    ) -> Result<SerdeEnvelope<TimestampedCheckpoint>, DataStoreError>;
 
     /// Gets the operator records for the given registry checkpoint ID hash.
     async fn get_operator_records(

--- a/crates/server/src/datastore/postgres/migrations/2023-08-11-183810_add_checkpoints_timestamp/down.sql
+++ b/crates/server/src/datastore/postgres/migrations/2023-08-11-183810_add_checkpoints_timestamp/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE checkpoints
+  DROP COLUMN timestamp;

--- a/crates/server/src/datastore/postgres/migrations/2023-08-11-183810_add_checkpoints_timestamp/up.sql
+++ b/crates/server/src/datastore/postgres/migrations/2023-08-11-183810_add_checkpoints_timestamp/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE checkpoints
+  ADD COLUMN timestamp BIGINT NOT NULL DEFAULT 0;

--- a/crates/server/src/datastore/postgres/models.rs
+++ b/crates/server/src/datastore/postgres/models.rs
@@ -86,11 +86,12 @@ pub struct NewCheckpoint<'a> {
     pub map_root: TextRef<'a, AnyHash>,
     pub key_id: TextRef<'a, KeyID>,
     pub signature: TextRef<'a, Signature>,
+    pub timestamp: i64,
 }
 
 #[derive(Queryable)]
 #[diesel(table_name = checkpoints)]
-pub struct Checkpoint {
+pub struct CheckpointData {
     pub id: i32,
     pub checkpoint_id: ParsedText<AnyHash>,
     pub log_root: ParsedText<AnyHash>,
@@ -100,6 +101,7 @@ pub struct Checkpoint {
     pub signature: ParsedText<Signature>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub timestamp: i64,
 }
 
 /// Selects only the record content and status
@@ -110,17 +112,6 @@ pub struct RecordContent {
     pub registry_log_index: Option<i64>,
     pub reason: Option<String>,
     pub content: Vec<u8>,
-}
-
-/// Selects only the relevant checkpoint data from the checkpoints table.
-#[derive(Queryable, Selectable)]
-#[diesel(table_name = checkpoints)]
-pub struct CheckpointData {
-    pub log_root: ParsedText<AnyHash>,
-    pub log_length: i64,
-    pub map_root: ParsedText<AnyHash>,
-    pub key_id: Text<KeyID>,
-    pub signature: ParsedText<Signature>,
 }
 
 #[derive(Insertable)]

--- a/crates/server/src/datastore/postgres/schema.rs
+++ b/crates/server/src/datastore/postgres/schema.rs
@@ -17,6 +17,7 @@ diesel::table! {
         signature -> Text,
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
+        timestamp -> Int8,
     }
 }
 

--- a/tests/memory/mod.rs
+++ b/tests/memory/mod.rs
@@ -17,9 +17,9 @@ async fn it_publishes_a_component() -> Result<()> {
 
     // There should be two log entries in the registry
     let client = api::Client::new(config.default_url.as_ref().unwrap())?;
-    let checkpoint = client.latest_checkpoint().await?;
+    let ts_checkpoint = client.latest_checkpoint().await?;
     assert_eq!(
-        checkpoint.as_ref().log_length,
+        ts_checkpoint.as_ref().checkpoint.log_length,
         2,
         "expected two log entries (initial + component)"
     );
@@ -34,9 +34,9 @@ async fn it_yanks_a_package() -> Result<()> {
 
     // There should be three entries in the registry
     let client = api::Client::new(config.default_url.as_ref().unwrap())?;
-    let checkpoint = client.latest_checkpoint().await?;
+    let ts_checkpoint = client.latest_checkpoint().await?;
     assert_eq!(
-        checkpoint.as_ref().log_length,
+        ts_checkpoint.as_ref().checkpoint.log_length,
         3,
         "expected three log entries (initial + release + yank)"
     );
@@ -51,9 +51,9 @@ async fn it_publishes_a_wit_package() -> Result<()> {
 
     // There should be two log entries in the registry
     let client = api::Client::new(config.default_url.as_ref().unwrap())?;
-    let checkpoint = client.latest_checkpoint().await?;
+    let ts_checkpoint = client.latest_checkpoint().await?;
     assert_eq!(
-        checkpoint.as_ref().log_length,
+        ts_checkpoint.as_ref().checkpoint.log_length,
         2,
         "expected two log entries (initial + wit)"
     );

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -62,9 +62,9 @@ async fn it_works_with_postgres() -> TestResult {
 
     // There should be two log entries in the registry
     let client = api::Client::new(config.default_url.as_ref().unwrap())?;
-    let checkpoint = client.latest_checkpoint().await?;
+    let ts_checkpoint = client.latest_checkpoint().await?;
     assert_eq!(
-        checkpoint.as_ref().log_length,
+        ts_checkpoint.as_ref().checkpoint.log_length,
         packages.len() as u32 + 2, /* publishes + initial checkpoint + yank */
         "expected {len} packages plus the initial checkpoint and yank",
         len = packages.len()
@@ -80,9 +80,9 @@ async fn it_works_with_postgres() -> TestResult {
     packages.push(PackageId::new("test:unknown-key")?);
 
     let client = api::Client::new(config.default_url.as_ref().unwrap())?;
-    let checkpoint = client.latest_checkpoint().await?;
+    let ts_checkpoint = client.latest_checkpoint().await?;
     assert_eq!(
-        checkpoint.as_ref().log_length,
+        ts_checkpoint.as_ref().checkpoint.log_length,
         packages.len() as u32 + 2, /* publishes + initial checkpoint + yank*/
         "expected {len} packages plus the initial checkpoint and yank",
         len = packages.len()

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -35,25 +35,26 @@ mod postgres;
 async fn test_initial_checkpoint(config: &Config) -> Result<()> {
     let client = api::Client::new(config.default_url.as_ref().unwrap())?;
 
-    let checkpoint = client.latest_checkpoint().await?;
+    let ts_checkpoint = client.latest_checkpoint().await?;
+    let checkpoint = &ts_checkpoint.as_ref().checkpoint;
 
     // There should be only a single log entry (the initial operator log entry)
     // As the log leaf differs every time because it contains a timestamp,
     // the log root and map root can't be compared to a baseline value.
-    assert_eq!(checkpoint.as_ref().log_length, 1);
+    assert_eq!(checkpoint.log_length, 1);
 
     // Ensure the response was signed with the operator key
     let operator_key = test_operator_key();
     assert_eq!(
-        checkpoint.key_id().to_string(),
+        ts_checkpoint.key_id().to_string(),
         operator_key.public_key().fingerprint().to_string()
     );
 
     // Ensure the signature matches the response
-    warg_protocol::registry::MapCheckpoint::verify(
+    warg_protocol::registry::TimestampedCheckpoint::verify(
         &operator_key.public_key(),
-        &checkpoint.as_ref().encode(),
-        checkpoint.signature(),
+        &ts_checkpoint.as_ref().encode(),
+        ts_checkpoint.signature(),
     )?;
 
     Ok(())

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -27,7 +27,6 @@ use wit_component::DecodedWasm;
 
 mod support;
 
-#[cfg(not(feature = "postgres"))]
 mod memory;
 #[cfg(feature = "postgres")]
 mod postgres;


### PR DESCRIPTION
- Add a new TimestampedCheckpoint type, which adds a unix timestamp to the basic checkpoint data.
- Update DataStores to store TimestampedCheckpoints.
- Update CoreService to generate new TimestampedCheckpoint periodically, even if the underlying checkpoint hasn't changed.

This also renames `MapCheckpoint` to just `Checkpoint`. `MapCheckpoint` was slightly misleading since it covers both the verifiable map *and* log.