### PR TITLE
added registry index for fetched records and updated proof endpoints to use the log length and registry index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /content
 /target
 *.swp
+*.swo

--- a/crates/api/src/v1/fetch.rs
+++ b/crates/api/src/v1/fetch.rs
@@ -144,9 +144,11 @@ impl<'de> Deserialize<'de> for FetchError {
         D: serde::Deserializer<'de>,
     {
         match RawError::<String>::deserialize(deserializer)? {
-            RawError::CheckpointNotFound { status: _, ty: _, id } => {
-                Ok(Self::CheckpointNotFound(id))
-            },
+            RawError::CheckpointNotFound {
+                status: _,
+                ty: _,
+                id,
+            } => Ok(Self::CheckpointNotFound(id)),
             RawError::NotFound { status: _, ty, id } => match ty {
                 EntityType::Log => Ok(Self::LogNotFound(
                     id.parse::<AnyHash>()
@@ -166,9 +168,9 @@ impl<'de> Deserialize<'de> for FetchError {
                         .into(),
                 )),
                 _ => Err(serde::de::Error::invalid_value(
-                                Unexpected::Str(&id),
-                                &"a valid log length",
-                            )),
+                    Unexpected::Str(&id),
+                    &"a valid log length",
+                )),
             },
             RawError::Message { status, message } => Ok(Self::Message {
                 status,

--- a/crates/api/src/v1/fetch.rs
+++ b/crates/api/src/v1/fetch.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 use warg_crypto::hash::AnyHash;
 use warg_protocol::{
     registry::{LogId, RecordId},
-    ProtoEnvelopeBody,
+    PublishedProtoEnvelopeBody,
 };
 
 /// Represents a fetch logs request.
@@ -36,10 +36,10 @@ pub struct FetchLogsResponse {
     pub more: bool,
     /// The operator records appended since the last known operator record.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub operator: Vec<ProtoEnvelopeBody>,
+    pub operator: Vec<PublishedProtoEnvelopeBody>,
     /// The package records appended since last known package record ids.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub packages: HashMap<LogId, Vec<ProtoEnvelopeBody>>,
+    pub packages: HashMap<LogId, Vec<PublishedProtoEnvelopeBody>>,
 }
 
 /// Represents a fetch API error.

--- a/crates/api/src/v1/fetch.rs
+++ b/crates/api/src/v1/fetch.rs
@@ -144,11 +144,7 @@ impl<'de> Deserialize<'de> for FetchError {
         D: serde::Deserializer<'de>,
     {
         match RawError::<String>::deserialize(deserializer)? {
-            RawError::CheckpointNotFound {
-                status: _,
-                ty: _,
-                id,
-            } => Ok(Self::CheckpointNotFound(id)),
+            RawError::CheckpointNotFound { id, .. } => Ok(Self::CheckpointNotFound(id)),
             RawError::NotFound { status: _, ty, id } => match ty {
                 EntityType::Log => Ok(Self::LogNotFound(
                     id.parse::<AnyHash>()

--- a/crates/api/src/v1/package.rs
+++ b/crates/api/src/v1/package.rs
@@ -105,10 +105,10 @@ pub enum PackageRecordState {
     Published {
         /// The envelope of the package record.
         record: ProtoEnvelopeBody,
-        /// The index of the record in the registry log.
-        registry_log_index: u32,
         /// The content sources of the record.
         content_sources: HashMap<AnyHash, Vec<ContentSource>>,
+        /// The published index of the record in the registry log.
+        index: u32,
     },
 }
 

--- a/crates/api/src/v1/package.rs
+++ b/crates/api/src/v1/package.rs
@@ -6,7 +6,7 @@ use std::{borrow::Cow, collections::HashMap};
 use thiserror::Error;
 use warg_crypto::hash::AnyHash;
 use warg_protocol::{
-    registry::{LogId, PackageId, RecordId},
+    registry::{LogId, PackageId, RecordId, RegistryIndex},
     ProtoEnvelopeBody,
 };
 
@@ -108,7 +108,7 @@ pub enum PackageRecordState {
         /// The content sources of the record.
         content_sources: HashMap<AnyHash, Vec<ContentSource>>,
         /// The published index of the record in the registry log.
-        index: u32,
+        registry_index: RegistryIndex,
     },
 }
 

--- a/crates/api/src/v1/proof.rs
+++ b/crates/api/src/v1/proof.rs
@@ -6,16 +6,16 @@ use serde_with::{base64::Base64, serde_as};
 use std::borrow::Cow;
 use thiserror::Error;
 use warg_crypto::hash::AnyHash;
-use warg_protocol::registry::{LogId, RegistryIndex};
+use warg_protocol::registry::{LogId, RegistryLen, RegistryIndex};
 
 /// Represents a consistency proof request.
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConsistencyRequest {
     /// The starting log length to check for consistency.
-    pub from: RegistryIndex,
+    pub from: RegistryLen,
     /// The ending log length to check for consistency.
-    pub to: RegistryIndex,
+    pub to: RegistryLen,
 }
 
 /// Represents a consistency proof response.
@@ -33,7 +33,7 @@ pub struct ConsistencyResponse {
 #[serde(rename_all = "camelCase")]
 pub struct InclusionRequest {
     /// The log length to check for inclusion.
-    pub log_length: RegistryIndex,
+    pub log_length: RegistryLen,
     /// The log leaf indexes in the registry log to check for inclusion.
     pub leafs: Vec<RegistryIndex>,
 }
@@ -57,9 +57,9 @@ pub struct InclusionResponse {
 pub enum ProofError {
     /// The checkpoint could not be found for the provided log length.
     #[error("checkpoint not found for log length {0}")]
-    CheckpointNotFound(RegistryIndex),
+    CheckpointNotFound(RegistryLen),
     /// The provided log leaf was not found.
-    #[error("log leaf `{0}` exceeds the registry log length")]
+    #[error("log leaf `{0}` not found")]
     LeafNotFound(RegistryIndex),
     /// Failed to prove inclusion of a package.
     #[error("failed to prove inclusion of package log `{0}`")]

--- a/crates/api/src/v1/proof.rs
+++ b/crates/api/src/v1/proof.rs
@@ -6,16 +6,16 @@ use serde_with::{base64::Base64, serde_as};
 use std::borrow::Cow;
 use thiserror::Error;
 use warg_crypto::hash::AnyHash;
-use warg_protocol::registry::{LogId};
+use warg_protocol::registry::{LogId, LogIndex};
 
 /// Represents a consistency proof request.
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConsistencyRequest {
     /// The starting log length to check for consistency.
-    pub from: u32,
+    pub from: LogIndex,
     /// The ending log length to check for consistency.
-    pub to: u32,
+    pub to: LogIndex,
 }
 
 /// Represents a consistency proof response.
@@ -33,9 +33,9 @@ pub struct ConsistencyResponse {
 #[serde(rename_all = "camelCase")]
 pub struct InclusionRequest {
     /// The log length to check for inclusion.
-    pub log_length: u32,
+    pub log_length: LogIndex,
     /// The log leaf indexes in the registry log to check for inclusion.
-    pub leafs: Vec<u32>,
+    pub leafs: Vec<LogIndex>,
 }
 
 /// Represents an inclusion proof response.
@@ -57,10 +57,10 @@ pub struct InclusionResponse {
 pub enum ProofError {
     /// The checkpoint could not be found for the provided log length.
     #[error("checkpoint not found for log length {0}")]
-    CheckpointNotFound(u32),
+    CheckpointNotFound(LogIndex),
     /// The provided log leaf was not found.
     #[error("log leaf `{0}` exceeds the registry log length")]
-    LeafNotFound(u32),
+    LeafNotFound(LogIndex),
     /// Failed to prove inclusion of a package.
     #[error("failed to prove inclusion of package log `{0}`")]
     PackageLogNotIncluded(LogId),
@@ -128,7 +128,7 @@ enum RawError<'a>
         status: Status<404>,
         #[serde(rename = "type")]
         ty: EntityType,
-        id: u32,
+        id: LogIndex,
     },
     BundleError {
         status: Status<422>,

--- a/crates/api/src/v1/proof.rs
+++ b/crates/api/src/v1/proof.rs
@@ -1,12 +1,12 @@
 //! Types relating to the proof API.
 
 use crate::Status;
-use serde::{de::Unexpected, Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer};
 use serde_with::{base64::Base64, serde_as};
 use std::borrow::Cow;
 use thiserror::Error;
 use warg_crypto::hash::AnyHash;
-use warg_protocol::registry::{Checkpoint, LogId, LogLeaf};
+use warg_protocol::registry::{LogId};
 
 /// Represents a consistency proof request.
 #[derive(Serialize, Deserialize)]
@@ -31,11 +31,11 @@ pub struct ConsistencyResponse {
 /// Represents an inclusion proof request.
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct InclusionRequest<'a> {
-    /// The checkpoint to check for inclusion.
-    pub checkpoint: Cow<'a, Checkpoint>,
-    /// The log leafs to check for inclusion.
-    pub leafs: Cow<'a, [LogLeaf]>,
+pub struct InclusionRequest {
+    /// The log length to check for inclusion.
+    pub log_length: u32,
+    /// The log leaf indexes in the registry log to check for inclusion.
+    pub leafs: Vec<u32>,
 }
 
 /// Represents an inclusion proof response.
@@ -55,12 +55,12 @@ pub struct InclusionResponse {
 #[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum ProofError {
-    /// The provided log root was not found.
-    #[error("log root `{0}` was not found")]
-    RootNotFound(AnyHash),
+    /// The checkpoint could not be found for the provided log length.
+    #[error("checkpoint not found for log length {0}")]
+    CheckpointNotFound(u32),
     /// The provided log leaf was not found.
-    #[error("log leaf `{}:{}` was not found", .0.log_id, .0.record_id)]
-    LeafNotFound(LogLeaf),
+    #[error("log leaf `{0}` exceeds the registry log length")]
+    LeafNotFound(u32),
     /// Failed to prove inclusion of a package.
     #[error("failed to prove inclusion of package log `{0}`")]
     PackageLogNotIncluded(LogId),
@@ -89,7 +89,7 @@ impl ProofError {
     /// Returns the HTTP status code of the error.
     pub fn status(&self) -> u16 {
         match self {
-            Self::RootNotFound(_) | Self::LeafNotFound(_) => 404,
+            Self::CheckpointNotFound(_) | Self::LeafNotFound(_) => 404,
             Self::BundleFailure(_)
             | Self::PackageLogNotIncluded(_)
             | Self::IncorrectProof { .. } => 422,
@@ -101,7 +101,7 @@ impl ProofError {
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 enum EntityType {
-    LogRoot,
+    LogLength,
     Leaf,
 }
 
@@ -122,16 +122,13 @@ enum BundleError<'a> {
 
 #[derive(Serialize, Deserialize)]
 #[serde(untagged, rename_all = "camelCase")]
-enum RawError<'a, T>
-where
-    T: Clone + ToOwned,
-    <T as ToOwned>::Owned: Serialize + for<'b> Deserialize<'b>,
+enum RawError<'a>
 {
     NotFound {
         status: Status<404>,
         #[serde(rename = "type")]
         ty: EntityType,
-        id: Cow<'a, T>,
+        id: u32,
     },
     BundleError {
         status: Status<422>,
@@ -147,26 +144,26 @@ where
 impl Serialize for ProofError {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match self {
-            Self::RootNotFound(root) => RawError::NotFound {
+            Self::CheckpointNotFound(log_length) => RawError::NotFound {
                 status: Status::<404>,
-                ty: EntityType::LogRoot,
-                id: Cow::Borrowed(root),
+                ty: EntityType::LogLength,
+                id: *log_length,
             }
             .serialize(serializer),
-            Self::LeafNotFound(leaf) => RawError::NotFound::<String> {
+            Self::LeafNotFound(leaf_index) => RawError::NotFound {
                 status: Status::<404>,
                 ty: EntityType::Leaf,
-                id: Cow::Owned(format!("{}|{}", leaf.log_id, leaf.record_id)),
+                id: *leaf_index,
             }
             .serialize(serializer),
-            Self::PackageLogNotIncluded(log_id) => RawError::BundleError::<()> {
+            Self::PackageLogNotIncluded(log_id) => RawError::BundleError {
                 status: Status::<422>,
                 error: BundleError::PackageNotIncluded {
                     log_id: Cow::Borrowed(log_id),
                 },
             }
             .serialize(serializer),
-            Self::IncorrectProof { root, found } => RawError::BundleError::<()> {
+            Self::IncorrectProof { root, found } => RawError::BundleError {
                 status: Status::<422>,
                 error: BundleError::IncorrectProof {
                     root: Cow::Borrowed(root),
@@ -174,14 +171,14 @@ impl Serialize for ProofError {
                 },
             }
             .serialize(serializer),
-            Self::BundleFailure(message) => RawError::BundleError::<()> {
+            Self::BundleFailure(message) => RawError::BundleError {
                 status: Status::<422>,
                 error: BundleError::Failure {
                     message: Cow::Borrowed(message),
                 },
             }
             .serialize(serializer),
-            Self::Message { status, message } => RawError::Message::<()> {
+            Self::Message { status, message } => RawError::Message {
                 status: *status,
                 message: Cow::Borrowed(message),
             }
@@ -195,47 +192,12 @@ impl<'de> Deserialize<'de> for ProofError {
     where
         D: serde::Deserializer<'de>,
     {
-        match RawError::<String>::deserialize(deserializer)? {
+        match RawError::deserialize(deserializer)? {
             RawError::NotFound { status: _, ty, id } => match ty {
-                EntityType::LogRoot => {
-                    Ok(Self::RootNotFound(id.parse::<AnyHash>().map_err(|_| {
-                        serde::de::Error::invalid_value(
-                            Unexpected::Str(&id),
-                            &"a valid checkpoint id",
-                        )
-                    })?))
+                EntityType::LogLength => {
+                    Ok(Self::CheckpointNotFound(id))
                 }
-                EntityType::Leaf => Ok(Self::LeafNotFound(
-                    id.split_once('|')
-                        .map(|(log_id, record_id)| {
-                            Ok(LogLeaf {
-                                log_id: log_id
-                                    .parse::<AnyHash>()
-                                    .map_err(|_| {
-                                        serde::de::Error::invalid_value(
-                                            Unexpected::Str(log_id),
-                                            &"a valid log id",
-                                        )
-                                    })?
-                                    .into(),
-                                record_id: record_id
-                                    .parse::<AnyHash>()
-                                    .map_err(|_| {
-                                        serde::de::Error::invalid_value(
-                                            Unexpected::Str(record_id),
-                                            &"a valid record id",
-                                        )
-                                    })?
-                                    .into(),
-                            })
-                        })
-                        .ok_or_else(|| {
-                            serde::de::Error::invalid_value(
-                                Unexpected::Str(&id),
-                                &"a valid leaf id",
-                            )
-                        })??,
-                )),
+                EntityType::Leaf => Ok(Self::LeafNotFound(id)),
             },
             RawError::BundleError { status: _, error } => match error {
                 BundleError::PackageNotIncluded { log_id } => {

--- a/crates/api/src/v1/proof.rs
+++ b/crates/api/src/v1/proof.rs
@@ -6,7 +6,7 @@ use serde_with::{base64::Base64, serde_as};
 use std::borrow::Cow;
 use thiserror::Error;
 use warg_crypto::hash::AnyHash;
-use warg_protocol::registry::{LogId, RegistryLen, RegistryIndex};
+use warg_protocol::registry::{LogId, RegistryIndex, RegistryLen};
 
 /// Represents a consistency proof request.
 #[derive(Serialize, Deserialize)]

--- a/crates/api/src/v1/proof.rs
+++ b/crates/api/src/v1/proof.rs
@@ -122,8 +122,7 @@ enum BundleError<'a> {
 
 #[derive(Serialize, Deserialize)]
 #[serde(untagged, rename_all = "camelCase")]
-enum RawError<'a>
-{
+enum RawError<'a> {
     NotFound {
         status: Status<404>,
         #[serde(rename = "type")]
@@ -194,9 +193,7 @@ impl<'de> Deserialize<'de> for ProofError {
     {
         match RawError::deserialize(deserializer)? {
             RawError::NotFound { status: _, ty, id } => match ty {
-                EntityType::LogLength => {
-                    Ok(Self::CheckpointNotFound(id))
-                }
+                EntityType::LogLength => Ok(Self::CheckpointNotFound(id)),
                 EntityType::Leaf => Ok(Self::LeafNotFound(id)),
             },
             RawError::BundleError { status: _, error } => match error {

--- a/crates/api/src/v1/proof.rs
+++ b/crates/api/src/v1/proof.rs
@@ -6,16 +6,16 @@ use serde_with::{base64::Base64, serde_as};
 use std::borrow::Cow;
 use thiserror::Error;
 use warg_crypto::hash::AnyHash;
-use warg_protocol::registry::{LogId, LogIndex};
+use warg_protocol::registry::{LogId, RegistryIndex};
 
 /// Represents a consistency proof request.
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConsistencyRequest {
     /// The starting log length to check for consistency.
-    pub from: LogIndex,
+    pub from: RegistryIndex,
     /// The ending log length to check for consistency.
-    pub to: LogIndex,
+    pub to: RegistryIndex,
 }
 
 /// Represents a consistency proof response.
@@ -33,9 +33,9 @@ pub struct ConsistencyResponse {
 #[serde(rename_all = "camelCase")]
 pub struct InclusionRequest {
     /// The log length to check for inclusion.
-    pub log_length: LogIndex,
+    pub log_length: RegistryIndex,
     /// The log leaf indexes in the registry log to check for inclusion.
-    pub leafs: Vec<LogIndex>,
+    pub leafs: Vec<RegistryIndex>,
 }
 
 /// Represents an inclusion proof response.
@@ -57,10 +57,10 @@ pub struct InclusionResponse {
 pub enum ProofError {
     /// The checkpoint could not be found for the provided log length.
     #[error("checkpoint not found for log length {0}")]
-    CheckpointNotFound(LogIndex),
+    CheckpointNotFound(RegistryIndex),
     /// The provided log leaf was not found.
     #[error("log leaf `{0}` exceeds the registry log length")]
-    LeafNotFound(LogIndex),
+    LeafNotFound(RegistryIndex),
     /// Failed to prove inclusion of a package.
     #[error("failed to prove inclusion of package log `{0}`")]
     PackageLogNotIncluded(LogId),
@@ -128,7 +128,7 @@ enum RawError<'a>
         status: Status<404>,
         #[serde(rename = "type")]
         ty: EntityType,
-        id: LogIndex,
+        id: RegistryIndex,
     },
     BundleError {
         status: Status<422>,

--- a/crates/client/src/api.rs
+++ b/crates/client/src/api.rs
@@ -237,7 +237,12 @@ impl Client {
     }
 
     /// Proves the inclusion of the given package log heads in the registry.
-    pub async fn prove_inclusion(&self, request: InclusionRequest, checkpoint: &Checkpoint, leafs: &[LogLeaf]) -> Result<(), ClientError> {
+    pub async fn prove_inclusion(
+        &self,
+        request: InclusionRequest,
+        checkpoint: &Checkpoint,
+        leafs: &[LogLeaf],
+    ) -> Result<(), ClientError> {
         let url = self.url.join(paths::prove_inclusion());
         tracing::debug!("proving checkpoint inclusion at `{url}`");
 
@@ -246,11 +251,7 @@ impl Client {
         )
         .await?;
 
-        Self::validate_inclusion_response(
-            response,
-            checkpoint,
-            leafs,
-        )
+        Self::validate_inclusion_response(response, checkpoint, leafs)
     }
 
     /// Proves consistency between two log roots.

--- a/crates/client/src/api.rs
+++ b/crates/client/src/api.rs
@@ -237,7 +237,7 @@ impl Client {
     }
 
     /// Proves the inclusion of the given package log heads in the registry.
-    pub async fn prove_inclusion(&self, request: InclusionRequest<'_>) -> Result<(), ClientError> {
+    pub async fn prove_inclusion(&self, request: InclusionRequest, checkpoint: &Checkpoint, leafs: &[LogLeaf]) -> Result<(), ClientError> {
         let url = self.url.join(paths::prove_inclusion());
         tracing::debug!("proving checkpoint inclusion at `{url}`");
 
@@ -248,8 +248,8 @@ impl Client {
 
         Self::validate_inclusion_response(
             response,
-            request.checkpoint.as_ref(),
-            request.leafs.as_ref(),
+            checkpoint,
+            leafs,
         )
     }
 

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -387,7 +387,7 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
             let response: FetchLogsResponse = self
                 .api
                 .fetch_logs(FetchLogsRequest {
-                    checkpoint_id: Cow::Borrowed(&checkpoint_id),
+                    log_length: checkpoint.log_length,
                     operator: operator
                         .state
                         .head()

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -470,10 +470,14 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
 
         if !leafs.is_empty() {
             self.api
-                .prove_inclusion(InclusionRequest {
-                    log_length: checkpoint.log_length,
-                    leafs: leaf_indices,
-                }, &checkpoint, &leafs)
+                .prove_inclusion(
+                    InclusionRequest {
+                        log_length: checkpoint.log_length,
+                        leafs: leaf_indices,
+                    },
+                    &checkpoint,
+                    &leafs,
+                )
                 .await?;
         }
 

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -409,7 +409,7 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
                     .state
                     .validate(&record.envelope)
                     .map_err(|inner| ClientError::OperatorValidationFailed { inner })?;
-                operator.latest_index = Some(record.index);
+                operator.head_registry_index = Some(record.registry_index);
             }
 
             for (log_id, records) in response.packages {
@@ -426,7 +426,7 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
                             inner,
                         }
                     })?;
-                    package.latest_index = Some(record.index);
+                    package.head_registry_index = Some(record.registry_index);
                 }
 
                 // At this point, the package log should not be empty
@@ -450,7 +450,7 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
         // Prove inclusion for the current log heads
         let mut leaf_indices = Vec::with_capacity(packages.len() + 1 /* for operator */);
         let mut leafs = Vec::with_capacity(leaf_indices.len());
-        if let Some(index) = operator.latest_index {
+        if let Some(index) = operator.head_registry_index {
             leaf_indices.push(index);
             leafs.push(LogLeaf {
                 log_id: LogId::operator_log::<Sha256>(),
@@ -459,7 +459,7 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
         }
 
         for (log_id, package) in &packages {
-            if let Some(index) = package.latest_index {
+            if let Some(index) = package.head_registry_index {
                 leaf_indices.push(index);
                 leafs.push(LogLeaf {
                     log_id: log_id.clone(),

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -26,7 +26,7 @@ use warg_crypto::{
 use warg_protocol::{
     operator, package,
     registry::{LogId, LogLeaf, PackageId, RecordId, TimestampedCheckpoint},
-    ProtoEnvelope, SerdeEnvelope, Version, VersionReq,
+    PublishedProtoEnvelope, SerdeEnvelope, Version, VersionReq,
 };
 
 pub mod api;
@@ -404,10 +404,10 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
                 })?;
 
             for record in response.operator {
-                let record: ProtoEnvelope<operator::OperatorRecord> = record.try_into()?;
+                let record: PublishedProtoEnvelope<operator::OperatorRecord> = record.try_into()?;
                 operator
                     .state
-                    .validate(&record)
+                    .validate(&record.envelope)
                     .map_err(|inner| ClientError::OperatorValidationFailed { inner })?;
             }
 
@@ -417,8 +417,9 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
                 })?;
 
                 for record in records {
-                    let record: ProtoEnvelope<package::PackageRecord> = record.try_into()?;
-                    package.state.validate(&record).map_err(|inner| {
+                    let record: PublishedProtoEnvelope<package::PackageRecord> =
+                        record.try_into()?;
+                    package.state.validate(&record.envelope).map_err(|inner| {
                         ClientError::PackageValidationFailed {
                             id: package.id.clone(),
                             inner,

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -475,7 +475,7 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
                         log_length: checkpoint.log_length,
                         leafs: leaf_indices,
                     },
-                    &checkpoint,
+                    checkpoint,
                     &leafs,
                 )
                 .await?;

--- a/crates/client/src/storage.rs
+++ b/crates/client/src/storage.rs
@@ -13,7 +13,7 @@ use warg_crypto::{
 use warg_protocol::{
     operator,
     package::{self, PackageRecord, PACKAGE_RECORD_VERSION},
-    registry::{Checkpoint, PackageId, RecordId, TimestampedCheckpoint},
+    registry::{Checkpoint, LogIndex, PackageId, RecordId, TimestampedCheckpoint},
     ProtoEnvelope, SerdeEnvelope, Version,
 };
 
@@ -111,7 +111,7 @@ pub struct OperatorInfo {
     pub state: operator::LogState,
     /// The registry log index of the most recent record
     #[serde(default)]
-    pub latest_index: Option<u32>,
+    pub latest_index: Option<LogIndex>,
 }
 
 /// Represents information about a registry package.
@@ -128,7 +128,7 @@ pub struct PackageInfo {
     pub state: package::LogState,
     /// The registry log index of the most recent record
     #[serde(default)]
-    pub latest_index: Option<u32>,
+    pub latest_index: Option<LogIndex>,
 }
 
 impl PackageInfo {

--- a/crates/client/src/storage.rs
+++ b/crates/client/src/storage.rs
@@ -13,7 +13,7 @@ use warg_crypto::{
 use warg_protocol::{
     operator,
     package::{self, PackageRecord, PACKAGE_RECORD_VERSION},
-    registry::{Checkpoint, RegistryIndex, PackageId, RecordId, TimestampedCheckpoint},
+    registry::{Checkpoint, PackageId, RecordId, RegistryIndex, TimestampedCheckpoint},
     ProtoEnvelope, SerdeEnvelope, Version,
 };
 

--- a/crates/client/src/storage.rs
+++ b/crates/client/src/storage.rs
@@ -13,7 +13,7 @@ use warg_crypto::{
 use warg_protocol::{
     operator,
     package::{self, PackageRecord, PACKAGE_RECORD_VERSION},
-    registry::{Checkpoint, LogIndex, PackageId, RecordId, TimestampedCheckpoint},
+    registry::{Checkpoint, RegistryIndex, PackageId, RecordId, TimestampedCheckpoint},
     ProtoEnvelope, SerdeEnvelope, Version,
 };
 
@@ -111,7 +111,7 @@ pub struct OperatorInfo {
     pub state: operator::LogState,
     /// The registry log index of the most recent record
     #[serde(default)]
-    pub latest_index: Option<LogIndex>,
+    pub head_registry_index: Option<RegistryIndex>,
 }
 
 /// Represents information about a registry package.
@@ -128,7 +128,7 @@ pub struct PackageInfo {
     pub state: package::LogState,
     /// The registry log index of the most recent record
     #[serde(default)]
-    pub latest_index: Option<LogIndex>,
+    pub head_registry_index: Option<RegistryIndex>,
 }
 
 impl PackageInfo {
@@ -138,7 +138,7 @@ impl PackageInfo {
             id: id.into(),
             checkpoint: None,
             state: package::LogState::default(),
-            latest_index: None,
+            head_registry_index: None,
         }
     }
 }

--- a/crates/client/src/storage.rs
+++ b/crates/client/src/storage.rs
@@ -109,6 +109,9 @@ pub struct OperatorInfo {
     /// The current operator log state
     #[serde(default)]
     pub state: operator::LogState,
+    /// The registry log index of the most recent record
+    #[serde(default)]
+    pub latest_index: Option<u32>,
 }
 
 /// Represents information about a registry package.
@@ -123,6 +126,9 @@ pub struct PackageInfo {
     /// The current package log state
     #[serde(default)]
     pub state: package::LogState,
+    /// The registry log index of the most recent record
+    #[serde(default)]
+    pub latest_index: Option<u32>,
 }
 
 impl PackageInfo {
@@ -132,6 +138,7 @@ impl PackageInfo {
             id: id.into(),
             checkpoint: None,
             state: package::LogState::default(),
+            latest_index: None,
         }
     }
 }

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -8,7 +8,9 @@ mod proto_envelope;
 pub mod registry;
 mod serde_envelope;
 
-pub use proto_envelope::{ProtoEnvelope, ProtoEnvelopeBody};
+pub use proto_envelope::{
+    ProtoEnvelope, ProtoEnvelopeBody, PublishedProtoEnvelope, PublishedProtoEnvelopeBody,
+};
 pub use semver::{Version, VersionReq};
 pub use serde_envelope::SerdeEnvelope;
 

--- a/crates/protocol/src/proto_envelope.rs
+++ b/crates/protocol/src/proto_envelope.rs
@@ -7,6 +7,7 @@ use std::fmt;
 use thiserror::Error;
 use warg_crypto::{hash::AnyHashError, signing, Decode, Signable};
 use warg_protobuf::protocol as protobuf;
+use super::registry::LogIndex;
 
 /// The ProtoEnvelope with the published registry log index.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -14,7 +15,7 @@ pub struct PublishedProtoEnvelope<Contents> {
     /// The wrapped ProtoEnvelope
     pub envelope: ProtoEnvelope<Contents>,
     /// The published registry log index for the record
-    pub index: u32,
+    pub index: LogIndex,
 }
 
 /// The envelope struct is used to keep around the original
@@ -181,7 +182,7 @@ pub struct PublishedProtoEnvelopeBody {
     #[serde(flatten)]
     pub envelope: ProtoEnvelopeBody,
     /// The index of the published record in the registry log
-    pub index: u32,
+    pub index: LogIndex,
 }
 
 impl<Content> TryFrom<PublishedProtoEnvelopeBody> for PublishedProtoEnvelope<Content>

--- a/crates/protocol/src/proto_envelope.rs
+++ b/crates/protocol/src/proto_envelope.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use thiserror::Error;
 use warg_crypto::{hash::AnyHashError, signing, Decode, Signable};
 use warg_protobuf::protocol as protobuf;
-use super::registry::LogIndex;
+use super::registry::RegistryIndex;
 
 /// The ProtoEnvelope with the published registry log index.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -15,7 +15,7 @@ pub struct PublishedProtoEnvelope<Contents> {
     /// The wrapped ProtoEnvelope
     pub envelope: ProtoEnvelope<Contents>,
     /// The published registry log index for the record
-    pub index: LogIndex,
+    pub registry_index: RegistryIndex,
 }
 
 /// The envelope struct is used to keep around the original
@@ -182,7 +182,7 @@ pub struct PublishedProtoEnvelopeBody {
     #[serde(flatten)]
     pub envelope: ProtoEnvelopeBody,
     /// The index of the published record in the registry log
-    pub index: LogIndex,
+    pub registry_index: RegistryIndex,
 }
 
 impl<Content> TryFrom<PublishedProtoEnvelopeBody> for PublishedProtoEnvelope<Content>
@@ -194,7 +194,7 @@ where
     fn try_from(value: PublishedProtoEnvelopeBody) -> Result<Self, Self::Error> {
         Ok(PublishedProtoEnvelope {
             envelope: ProtoEnvelope::<Content>::try_from(value.envelope)?,
-            index: value.index,
+            registry_index: value.registry_index,
         })
     }
 }
@@ -203,7 +203,7 @@ impl<Content> From<PublishedProtoEnvelope<Content>> for PublishedProtoEnvelopeBo
     fn from(value: PublishedProtoEnvelope<Content>) -> Self {
         PublishedProtoEnvelopeBody {
             envelope: ProtoEnvelopeBody::from(value.envelope),
-            index: value.index,
+            registry_index: value.registry_index,
         }
     }
 }
@@ -217,7 +217,7 @@ impl fmt::Debug for PublishedProtoEnvelopeBody {
             )
             .field("key_id", &self.envelope.key_id)
             .field("signature", &self.envelope.signature)
-            .field("index", &self.index)
+            .field("registry_index", &self.registry_index)
             .finish()
     }
 }

--- a/crates/protocol/src/proto_envelope.rs
+++ b/crates/protocol/src/proto_envelope.rs
@@ -1,3 +1,4 @@
+use super::registry::RegistryIndex;
 use anyhow::Error;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use prost::Message;
@@ -7,7 +8,6 @@ use std::fmt;
 use thiserror::Error;
 use warg_crypto::{hash::AnyHashError, signing, Decode, Signable};
 use warg_protobuf::protocol as protobuf;
-use super::registry::RegistryIndex;
 
 /// The ProtoEnvelope with the published registry log index.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/protocol/src/registry.rs
+++ b/crates/protocol/src/registry.rs
@@ -10,13 +10,13 @@ use warg_crypto::{prefix, ByteVisitor, Signable, VisitBytes};
 use wasmparser::names::KebabStr;
 
 /// Type alias for log index and log length
-pub type LogIndex = usize;
+pub type RegistryIndex = usize;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Checkpoint {
     pub log_root: AnyHash,
-    pub log_length: LogIndex,
+    pub log_length: RegistryIndex,
     pub map_root: AnyHash,
 }
 

--- a/crates/protocol/src/registry.rs
+++ b/crates/protocol/src/registry.rs
@@ -9,14 +9,17 @@ use warg_crypto::prefix::VisitPrefixEncode;
 use warg_crypto::{prefix, ByteVisitor, Signable, VisitBytes};
 use wasmparser::names::KebabStr;
 
-/// Type alias for log index and log length
+/// Type alias for registry log index
 pub type RegistryIndex = usize;
+
+/// Type alias for registry log length
+pub type RegistryLen = RegistryIndex;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Checkpoint {
     pub log_root: AnyHash,
-    pub log_length: RegistryIndex,
+    pub log_length: RegistryLen,
     pub map_root: AnyHash,
 }
 

--- a/crates/protocol/src/registry.rs
+++ b/crates/protocol/src/registry.rs
@@ -9,11 +9,14 @@ use warg_crypto::prefix::VisitPrefixEncode;
 use warg_crypto::{prefix, ByteVisitor, Signable, VisitBytes};
 use wasmparser::names::KebabStr;
 
+/// Type alias for log index and log length
+pub type LogIndex = usize;
+
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Checkpoint {
     pub log_root: AnyHash,
-    pub log_length: u32,
+    pub log_length: LogIndex,
     pub map_root: AnyHash,
 }
 

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -62,26 +62,9 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: false
-                required:
-                  - status
-                  - type
-                  - id
-                properties:
-                  status:
-                    type: integer
-                    description: The HTTP status code for the error.
-                    example: 404
-                  type:
-                    type: string
-                    description: The type of entity that was not found.
-                    enum: [checkpoint, log, record]
-                    example: checkpoint
-                  id:
-                    type: string
-                    description: The identifier of the entity that was not found.
-                    example: sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
+                oneOf:
+                  - "$ref": "#/components/schemas/FetchLogsIDNotFoundError"
+                  - "$ref": "#/components/schemas/FetchLogsLogLengthNotFoundError"
         default:
           description: An error occurred when processing the request.
           content:
@@ -339,8 +322,6 @@ paths:
         - proof
       description: |
         Proves the consistency of the registry between two specified checkpoints.
-
-        TODO: document the consistency proof bundle format.
       requestBody:
         content:
           application/json:
@@ -372,12 +353,11 @@ paths:
                   type:
                     type: string
                     description: The type of entity that was not found.
-                    enum: [checkpoint]
-                    example: checkpoint
+                    enum: [logLength]
+                    example: logLength
                   id:
-                    "$ref": "#/components/schemas/AnyHash"
-                    description: |
-                      The identifier of the entity that was not found.
+                    type: integer
+                    description: The identifier of the entity that was not found. 
         "422":
           description: The proof bundle could not be generated.
           content:
@@ -404,10 +384,6 @@ paths:
         - proof
       description: |
         Proves that the given log leafs are present in the given registry checkpoint.
-
-        TODO: document the log inclusion proof bundle format.
-
-        TODO: document the map inclusion proof bundle format.
       requestBody:
         content:
           application/json:
@@ -443,8 +419,7 @@ paths:
                     example: logLength
                   id:
                     type: integer
-                    description: |
-                      The identifier of the entity that was not found.
+                    description: The identifier of the entity that was not found.
         "422":
           description: The proof bundle could not be generated.
           content:
@@ -494,11 +469,13 @@ components:
       description: A request to fetch logs from the registry.
       additionalProperties: false
       required:
-        - checkpointId
+        - logLength
       properties:
-        checkpointId:
-          $ref: "#/components/schemas/AnyHash"
-          description: The registry checkpoint ID hash to fetch from.
+        logLength:
+          type: integer
+          description: The registry checkpoint log length to fetch from.
+          example: 101
+          minimum: 1
         limit:
           type: integer
           description: The limit of operator and packages records to return for the fetch request.
@@ -993,3 +970,45 @@ components:
           type: string
           description: The failure error message.
           example: bundle must contain proofs for the same root
+    FetchLogsIDNotFoundError:
+        type: object
+        additionalProperties: false
+        required:
+          - status
+          - type
+          - id
+        properties:
+          status:
+            type: integer
+            description: The HTTP status code for the error.
+            example: 404
+          type:
+            type: string
+            description: The type of entity that was not found.
+            enum: [log, record]
+            example: log
+          id:
+            type: string
+            description: The identifier of the entity that was not found.
+            example: sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
+    FetchLogsLogLengthNotFoundError:
+        type: object
+        additionalProperties: false
+        required:
+          - status
+          - type
+          - id
+        properties:
+          status:
+            type: integer
+            description: The HTTP status code for the error.
+            example: 404
+          type:
+            type: string
+            description: The type of entity that was not found.
+            enum: [logLength]
+            example: log
+          id:
+            type: integer
+            description: The log length that was not found.
+            example: 1001

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -545,7 +545,7 @@ components:
           description: The operator log records for the given checkpoint since the last known record.
           maxItems: 1000
           items:
-            $ref: "#/components/schemas/EnvelopeBody"
+            $ref: "#/components/schemas/PublishedEnvelopeBody"
         packages:
           type: object
           description: The map of package log identifier to package records.
@@ -555,19 +555,22 @@ components:
               description: The package log records for the given checkpoint since the last known record.
               maxItems: 1000
               items:
-                $ref: "#/components/schemas/EnvelopeBody"
+                $ref: "#/components/schemas/PublishedEnvelopeBody"
           example:
             ? "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730"
             : - contentBytes: "ZXhhbXBsZQ=="
                 keyId: "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730"
                 signature: "ecdsa-p256:MEUCIQCzWZBW6ux9LecP66Y+hjmLZTP/hZVz7puzlPTXcRT2wwIgQZO7nxP0nugtw18MwHZ26ROFWcJmgCtKOguK031Y1D0="
+                index: 101
               - contentBytes: "ZXhhbXBsZQ=="
                 keyId: "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730"
                 signature: "ecdsa-p256:MEUCIQCzWZBW6ux9LecP66Y+hjmLZTP/hZVz7puzlPTXcRT2wwIgQZO7nxP0nugtw18MwHZ26ROFWcJmgCtKOguK031Y1D0="
+                index: 305
             ? "sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
             : - contentBytes: "ZXhhbXBsZQ=="
                 keyId: "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730"
                 signature: "ecdsa-p256:MEUCIQCzWZBW6ux9LecP66Y+hjmLZTP/hZVz7puzlPTXcRT2wwIgQZO7nxP0nugtw18MwHZ26ROFWcJmgCtKOguK031Y1D0="
+                index: 732
     PublishPackageRecordRequest:
       type: object
       description: A request to publish a record to a package log.
@@ -747,7 +750,7 @@ components:
           description: The state of the package record.
           enum: [published]
           example: published
-        registryLogIndex:
+        index:
           type: number
           description: The index of the record in the registry log.
         record:
@@ -834,6 +837,19 @@ components:
               format: byte
               maxLength: 1048576
               example: "ZXhhbXBsZQ=="
+        - $ref: "#/components/schemas/Signature"
+    PublishedEnvelopeBody:
+      description: A signed envelope body with the published registry log index.
+      allOf:
+        - type: object
+          required:
+            - index
+          properties:
+            index:
+              type: integer
+              description: The index of the published record in the registry log.
+              example: 42
+        - $ref: "#/components/schemas/EnvelopeBody"
         - $ref: "#/components/schemas/Signature"
     Signature:
       type: object

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -654,26 +654,15 @@ components:
         - checkpoint
         - leafs
       properties:
-        checkpoint:
-          $ref: "#/components/schemas/Checkpoint"
-          description: The checkpoint to prove the inclusion for.
+        logLength:
+          type: integer
+          description: The checkpoint log length to prove the inclusion for.
         leafs:
           type: array
           maxItems: 1000
-          description: The log leafs to prove the inclusion for.
+          description: The log leaf registry log index to prove the inclusion for.
           items:
-            type: object
-            description: A log leaf.
-            required:
-              - logId
-              - recordId
-            properties:
-              logId:
-                $ref: "#/components/schemas/AnyHash"
-                description: The log identifier.
-              recordId:
-                $ref: "#/components/schemas/AnyHash"
-                description: The record identifier.
+            type: integer
     ProveInclusionResponse:
       type: object
       description: A response containing the inclusion proof bundle.

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -737,7 +737,7 @@ components:
           description: The state of the package record.
           enum: [published]
           example: published
-        index:
+        registryIndex:
           type: number
           description: The index of the record in the registry log.
         record:
@@ -832,7 +832,7 @@ components:
           required:
             - index
           properties:
-            index:
+            registryIndex:
               type: integer
               description: The index of the published record in the registry log.
               example: 42

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -729,7 +729,7 @@ components:
       description: A record that has been published to the log.
       required:
         - state
-        - checkpoint
+        - registryIndex
         - record
       properties:
         state:
@@ -738,7 +738,7 @@ components:
           enum: [published]
           example: published
         registryIndex:
-          type: number
+          type: integer
           description: The index of the record in the registry log.
         record:
           "$ref": "#/components/schemas/EnvelopeBody"

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -651,7 +651,7 @@ components:
       description: A request to prove the inclusion of log leafs in a checkpoint.
       additionalProperties: false
       required:
-        - checkpoint
+        - logLength
         - leafs
       properties:
         logLength:

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -559,16 +559,16 @@ components:
             : - contentBytes: "ZXhhbXBsZQ=="
                 keyId: "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730"
                 signature: "ecdsa-p256:MEUCIQCzWZBW6ux9LecP66Y+hjmLZTP/hZVz7puzlPTXcRT2wwIgQZO7nxP0nugtw18MwHZ26ROFWcJmgCtKOguK031Y1D0="
-                index: 101
+                registryIndex: 101
               - contentBytes: "ZXhhbXBsZQ=="
                 keyId: "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730"
                 signature: "ecdsa-p256:MEUCIQCzWZBW6ux9LecP66Y+hjmLZTP/hZVz7puzlPTXcRT2wwIgQZO7nxP0nugtw18MwHZ26ROFWcJmgCtKOguK031Y1D0="
-                index: 305
+                registryIndex: 305
             ? "sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
             : - contentBytes: "ZXhhbXBsZQ=="
                 keyId: "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730"
                 signature: "ecdsa-p256:MEUCIQCzWZBW6ux9LecP66Y+hjmLZTP/hZVz7puzlPTXcRT2wwIgQZO7nxP0nugtw18MwHZ26ROFWcJmgCtKOguK031Y1D0="
-                index: 732
+                registryIndex: 732
     PublishPackageRecordRequest:
       type: object
       description: A request to publish a record to a package log.
@@ -830,7 +830,7 @@ components:
       allOf:
         - type: object
           required:
-            - index
+            - registryIndex
           properties:
             registryIndex:
               type: integer

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -439,14 +439,12 @@ paths:
                   type:
                     type: string
                     description: The type of entity that was not found.
-                    enum: [checkpoint, leaf]
-                    example: checkpoint
+                    enum: [logLength, leaf]
+                    example: logLength
                   id:
-                    "$ref": "#/components/schemas/AnyHash"
+                    type: integer
                     description: |
                       The identifier of the entity that was not found.
-
-                      For leafs, the format is `<logId>|<recordId>`.
         "422":
           description: The proof bundle could not be generated.
           content:

--- a/crates/server/src/api/debug/mod.rs
+++ b/crates/server/src/api/debug/mod.rs
@@ -105,15 +105,17 @@ async fn get_package_info(
     let records = records
         .into_iter()
         .map(|record| {
-            package_state.validate(&record).context("validate")?;
-            let record_id = RecordId::package_record::<Sha256>(&record);
+            package_state.validate(&record.envelope).context("validate")?;
+            let record_id = RecordId::package_record::<Sha256>(&record.envelope);
             let timestamp = record
+                .envelope
                 .as_ref()
                 .timestamp
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .context("duration_since")?
                 .as_secs();
             let entries = record
+                .envelope
                 .as_ref()
                 .entries
                 .iter()

--- a/crates/server/src/api/debug/mod.rs
+++ b/crates/server/src/api/debug/mod.rs
@@ -92,11 +92,11 @@ async fn get_package_info(
         .get_latest_checkpoint()
         .await
         .context("get_latest_checkpoint")?;
-    let checkpoint_id = Hash::<Sha256>::of(&checkpoint.as_ref().checkpoint).into();
+    let checkpoint_log_length = checkpoint.as_ref().checkpoint.log_length;
 
     let log_id = LogId::package_log::<Sha256>(&package_id);
     let records = store
-        .get_package_records(&log_id, &checkpoint_id, None, u16::MAX)
+        .get_package_records(&log_id, checkpoint_log_length, None, u16::MAX)
         .await
         .context("get_package_records")?;
 

--- a/crates/server/src/api/debug/mod.rs
+++ b/crates/server/src/api/debug/mod.rs
@@ -105,7 +105,9 @@ async fn get_package_info(
     let records = records
         .into_iter()
         .map(|record| {
-            package_state.validate(&record.envelope).context("validate")?;
+            package_state
+                .validate(&record.envelope)
+                .context("validate")?;
             let record_id = RecordId::package_record::<Sha256>(&record.envelope);
             let timestamp = record
                 .envelope

--- a/crates/server/src/api/debug/mod.rs
+++ b/crates/server/src/api/debug/mod.rs
@@ -11,7 +11,7 @@ use axum::{
 };
 use serde::Serialize;
 use warg_crypto::{
-    hash::{AnyHash, Hash, Sha256},
+    hash::{AnyHash, Sha256},
     signing::KeyID,
 };
 use warg_protocol::{

--- a/crates/server/src/api/v1/fetch.rs
+++ b/crates/server/src/api/v1/fetch.rs
@@ -90,7 +90,7 @@ async fn fetch_logs(
         .store()
         .get_operator_records(
             &LogId::operator_log::<Sha256>(),
-            &body.checkpoint_id,
+            body.log_length,
             body.operator.as_deref(),
             limit,
         )
@@ -107,7 +107,7 @@ async fn fetch_logs(
         let records: Vec<PublishedProtoEnvelopeBody> = config
             .core_service
             .store()
-            .get_package_records(&id, &body.checkpoint_id, since.as_ref(), limit)
+            .get_package_records(&id, body.log_length, since.as_ref(), limit)
             .await?
             .into_iter()
             .map(Into::into)

--- a/crates/server/src/api/v1/fetch.rs
+++ b/crates/server/src/api/v1/fetch.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use warg_api::v1::fetch::{FetchError, FetchLogsRequest, FetchLogsResponse};
 use warg_crypto::hash::Sha256;
 use warg_protocol::registry::{LogId, TimestampedCheckpoint};
-use warg_protocol::{ProtoEnvelopeBody, SerdeEnvelope};
+use warg_protocol::{PublishedProtoEnvelopeBody, SerdeEnvelope};
 
 const DEFAULT_RECORDS_LIMIT: u16 = 100;
 const MAX_RECORDS_LIMIT: u16 = 1000;
@@ -85,7 +85,7 @@ async fn fetch_logs(
         )));
     }
 
-    let operator: Vec<ProtoEnvelopeBody> = config
+    let operator: Vec<PublishedProtoEnvelopeBody> = config
         .core_service
         .store()
         .get_operator_records(
@@ -104,7 +104,7 @@ async fn fetch_logs(
     let mut map = HashMap::new();
     let packages = body.packages.into_owned();
     for (id, since) in packages {
-        let records: Vec<ProtoEnvelopeBody> = config
+        let records: Vec<PublishedProtoEnvelopeBody> = config
             .core_service
             .store()
             .get_package_records(&id, &body.checkpoint_id, since.as_ref(), limit)

--- a/crates/server/src/api/v1/package.rs
+++ b/crates/server/src/api/v1/package.rs
@@ -306,7 +306,7 @@ async fn get_record(
                 })
                 .collect();
 
-            let registry_index = record.registry_index.unwrap().try_into().unwrap();
+            let registry_index = record.registry_index.unwrap();
 
             Ok(Json(PackageRecord {
                 id: record_id,

--- a/crates/server/src/api/v1/package.rs
+++ b/crates/server/src/api/v1/package.rs
@@ -306,13 +306,13 @@ async fn get_record(
                 })
                 .collect();
 
-            let index = record.index.unwrap().try_into().unwrap();
+            let registry_index = record.registry_index.unwrap().try_into().unwrap();
 
             Ok(Json(PackageRecord {
                 id: record_id,
                 state: PackageRecordState::Published {
                     record: record.envelope.into(),
-                    index,
+                    registry_index,
                     content_sources,
                 },
             }))

--- a/crates/server/src/api/v1/package.rs
+++ b/crates/server/src/api/v1/package.rs
@@ -306,13 +306,13 @@ async fn get_record(
                 })
                 .collect();
 
-            let registry_log_index = record.registry_log_index.unwrap().try_into().unwrap();
+            let index = record.index.unwrap().try_into().unwrap();
 
             Ok(Json(PackageRecord {
                 id: record_id,
                 state: PackageRecordState::Published {
                     record: record.envelope.into(),
-                    registry_log_index,
+                    index,
                     content_sources,
                 },
             }))

--- a/crates/server/src/api/v1/proof.rs
+++ b/crates/server/src/api/v1/proof.rs
@@ -85,7 +85,6 @@ async fn prove_inclusion(
         .collect::<Vec<RegistryIndex>>();
 
     let log_bundle = config.core.log_inclusion_proofs(log_length, &leafs).await?;
-
     let map_bundle = config.core.map_inclusion_proofs(log_length, &leafs).await?;
 
     Ok(Json(InclusionResponse {

--- a/crates/server/src/api/v1/proof.rs
+++ b/crates/server/src/api/v1/proof.rs
@@ -6,7 +6,7 @@ use axum::{
 use warg_api::v1::proof::{
     ConsistencyRequest, ConsistencyResponse, InclusionRequest, InclusionResponse, ProofError,
 };
-use warg_protocol::registry::RegistryIndex;
+use warg_protocol::registry::{RegistryIndex, RegistryLen};
 
 #[derive(Clone)]
 pub struct Config {
@@ -64,7 +64,7 @@ async fn prove_consistency(
 ) -> Result<Json<ConsistencyResponse>, ProofApiError> {
     let bundle = config
         .core
-        .log_consistency_proof(body.from as RegistryIndex, body.to as RegistryIndex)
+        .log_consistency_proof(body.from as RegistryLen, body.to as RegistryLen)
         .await?;
 
     Ok(Json(ConsistencyResponse {
@@ -77,7 +77,7 @@ async fn prove_inclusion(
     State(config): State<Config>,
     Json(body): Json<InclusionRequest>,
 ) -> Result<Json<InclusionResponse>, ProofApiError> {
-    let log_length = body.log_length as RegistryIndex;
+    let log_length = body.log_length as RegistryLen;
     let leafs = body
         .leafs
         .into_iter()

--- a/crates/server/src/api/v1/proof.rs
+++ b/crates/server/src/api/v1/proof.rs
@@ -34,7 +34,7 @@ impl From<CoreServiceError> for ProofApiError {
             CoreServiceError::CheckpointNotFound(log_length) => {
                 ProofError::CheckpointNotFound(log_length)
             }
-            //CoreServiceError::LeafNotFound(leaf) => ProofError::LeafNotFound(leaf),
+            CoreServiceError::LeafNotFound(leaf) => ProofError::LeafNotFound(leaf),
             CoreServiceError::BundleFailure(e) => ProofError::BundleFailure(e.to_string()),
             CoreServiceError::PackageNotIncluded(id) => ProofError::PackageLogNotIncluded(id),
             CoreServiceError::IncorrectProof { root, found } => {

--- a/crates/server/src/api/v1/proof.rs
+++ b/crates/server/src/api/v1/proof.rs
@@ -27,20 +27,13 @@ impl Config {
 
 struct ProofApiError(ProofError);
 
-impl ProofApiError {
-    fn bad_request(message: impl ToString) -> Self {
-        Self(ProofError::Message {
-            status: StatusCode::BAD_REQUEST.as_u16(),
-            message: message.to_string(),
-        })
-    }
-}
-
 impl From<CoreServiceError> for ProofApiError {
     fn from(value: CoreServiceError) -> Self {
         Self(match value {
-            CoreServiceError::RootNotFound(root) => ProofError::RootNotFound(root),
-            CoreServiceError::LeafNotFound(leaf) => ProofError::LeafNotFound(leaf),
+            CoreServiceError::CheckpointNotFound(log_length) => {
+                ProofError::CheckpointNotFound(log_length as u32)
+            }
+            //CoreServiceError::LeafNotFound(leaf) => ProofError::LeafNotFound(leaf),
             CoreServiceError::BundleFailure(e) => ProofError::BundleFailure(e.to_string()),
             CoreServiceError::PackageNotIncluded(id) => ProofError::PackageLogNotIncluded(id),
             CoreServiceError::IncorrectProof { root, found } => {
@@ -81,24 +74,18 @@ async fn prove_consistency(
 #[debug_handler]
 async fn prove_inclusion(
     State(config): State<Config>,
-    Json(body): Json<InclusionRequest<'static>>,
+    Json(body): Json<InclusionRequest>,
 ) -> Result<Json<InclusionResponse>, ProofApiError> {
-    let checkpoint = body.checkpoint.into_owned();
-    let log_length = checkpoint.log_length;
-    let map_root = checkpoint
-        .map_root
-        .try_into()
-        .map_err(ProofApiError::bad_request)?;
+    let log_length = body.log_length as usize;
+    let leafs = body
+        .leafs
+        .into_iter()
+        .map(|index| index as usize)
+        .collect::<Vec<usize>>();
 
-    let log_bundle = config
-        .core
-        .log_inclusion_proofs(log_length as usize, &body.leafs)
-        .await?;
+    let log_bundle = config.core.log_inclusion_proofs(log_length, &leafs).await?;
 
-    let map_bundle = config
-        .core
-        .map_inclusion_proofs(&map_root, &body.leafs)
-        .await?;
+    let map_bundle = config.core.map_inclusion_proofs(log_length, &leafs).await?;
 
     Ok(Json(InclusionResponse {
         log: log_bundle.encode(),

--- a/crates/server/src/api/v1/proof.rs
+++ b/crates/server/src/api/v1/proof.rs
@@ -6,7 +6,7 @@ use axum::{
 use warg_api::v1::proof::{
     ConsistencyRequest, ConsistencyResponse, InclusionRequest, InclusionResponse, ProofError,
 };
-use warg_protocol::registry::LogIndex;
+use warg_protocol::registry::RegistryIndex;
 
 #[derive(Clone)]
 pub struct Config {
@@ -64,7 +64,7 @@ async fn prove_consistency(
 ) -> Result<Json<ConsistencyResponse>, ProofApiError> {
     let bundle = config
         .core
-        .log_consistency_proof(body.from as LogIndex, body.to as LogIndex)
+        .log_consistency_proof(body.from as RegistryIndex, body.to as RegistryIndex)
         .await?;
 
     Ok(Json(ConsistencyResponse {
@@ -77,12 +77,12 @@ async fn prove_inclusion(
     State(config): State<Config>,
     Json(body): Json<InclusionRequest>,
 ) -> Result<Json<InclusionResponse>, ProofApiError> {
-    let log_length = body.log_length as LogIndex;
+    let log_length = body.log_length as RegistryIndex;
     let leafs = body
         .leafs
         .into_iter()
-        .map(|index| index as LogIndex)
-        .collect::<Vec<LogIndex>>();
+        .map(|index| index as RegistryIndex)
+        .collect::<Vec<RegistryIndex>>();
 
     let log_bundle = config.core.log_inclusion_proofs(log_length, &leafs).await?;
 

--- a/crates/server/src/datastore/memory.rs
+++ b/crates/server/src/datastore/memory.rs
@@ -114,8 +114,10 @@ impl DataStore for MemoryDataStore {
 
     async fn get_all_validated_records(
         &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<LogLeaf, DataStoreError>> + Send>>, DataStoreError>
-    {
+    ) -> Result<
+        Pin<Box<dyn Stream<Item = Result<(usize, LogLeaf), DataStoreError>> + Send>>,
+        DataStoreError,
+    > {
         Ok(Box::pin(futures::stream::empty()))
     }
 
@@ -191,7 +193,10 @@ impl DataStore for MemoryDataStore {
         let mut state = self.0.write().await;
 
         let State {
-            operators, records, log_leafs, ..
+            operators,
+            records,
+            log_leafs,
+            ..
         } = &mut *state;
 
         let status = records
@@ -219,7 +224,13 @@ impl DataStore for MemoryDataStore {
                             index,
                             registry_index: registry_log_index as u32,
                         });
-                        log_leafs.insert(registry_log_index as u32, LogLeaf { log_id: log_id.clone(), record_id: record_id.clone() });
+                        log_leafs.insert(
+                            registry_log_index as u32,
+                            LogLeaf {
+                                log_id: log_id.clone(),
+                                record_id: record_id.clone(),
+                            },
+                        );
                         Ok(())
                     }
                     Err(e) => {
@@ -301,7 +312,10 @@ impl DataStore for MemoryDataStore {
         let mut state = self.0.write().await;
 
         let State {
-            packages, records, log_leafs, ..
+            packages,
+            records,
+            log_leafs,
+            ..
         } = &mut *state;
 
         let status = records
@@ -329,10 +343,13 @@ impl DataStore for MemoryDataStore {
                             index,
                             registry_index: registry_log_index as u32,
                         });
-                        log_leafs.insert(registry_log_index as u32, LogLeaf {
-                            log_id: log_id.clone(),
-                            record_id: record_id.clone(),
-                        });
+                        log_leafs.insert(
+                            registry_log_index as u32,
+                            LogLeaf {
+                                log_id: log_id.clone(),
+                                record_id: record_id.clone(),
+                            },
+                        );
                         Ok(())
                     }
                     Err(e) => {

--- a/crates/server/src/datastore/memory.rs
+++ b/crates/server/src/datastore/memory.rs
@@ -11,7 +11,7 @@ use warg_crypto::{hash::AnyHash, Signable};
 use warg_protocol::{
     operator,
     package::{self, PackageEntry},
-    registry::{LogId, LogLeaf, RegistryIndex, PackageId, RecordId, TimestampedCheckpoint},
+    registry::{LogId, LogLeaf, PackageId, RecordId, RegistryIndex, TimestampedCheckpoint},
     ProtoEnvelope, PublishedProtoEnvelope, SerdeEnvelope,
 };
 

--- a/crates/server/src/datastore/memory.rs
+++ b/crates/server/src/datastore/memory.rs
@@ -223,7 +223,7 @@ impl DataStore for MemoryDataStore {
                             record_content: record,
                         });
                         *status = RecordStatus::Validated(Record {
-                            index: index,
+                            index,
                             registry_index,
                         });
                         log_leafs.insert(
@@ -342,7 +342,7 @@ impl DataStore for MemoryDataStore {
                             record_content: record,
                         });
                         *status = RecordStatus::Validated(Record {
-                            index: index,
+                            index,
                             registry_index,
                         });
                         log_leafs.insert(
@@ -480,7 +480,7 @@ impl DataStore for MemoryDataStore {
         Ok(log
             .entries
             .iter()
-            .skip(start_log_idx as usize)
+            .skip(start_log_idx)
             .take_while(|entry| entry.registry_index < registry_log_length)
             .map(|entry| PublishedProtoEnvelope {
                 envelope: entry.record_content.clone(),
@@ -519,7 +519,7 @@ impl DataStore for MemoryDataStore {
         Ok(log
             .entries
             .iter()
-            .skip(start_log_idx as usize)
+            .skip(start_log_idx)
             .take_while(|entry| entry.registry_index < registry_log_length)
             .map(|entry| PublishedProtoEnvelope {
                 envelope: entry.record_content.clone(),
@@ -569,7 +569,7 @@ impl DataStore for MemoryDataStore {
                     } else {
                         super::RecordStatus::Validated
                     },
-                    log.entries[r.index as usize].record_content.clone(),
+                    log.entries[r.index].record_content.clone(),
                     Some(r.registry_index),
                 )
             }
@@ -623,7 +623,7 @@ impl DataStore for MemoryDataStore {
                     } else {
                         super::RecordStatus::Validated
                     },
-                    log.entries[r.index as usize].record_content.clone(),
+                    log.entries[r.index].record_content.clone(),
                     Some(r.registry_index),
                 )
             }

--- a/crates/server/src/datastore/memory.rs
+++ b/crates/server/src/datastore/memory.rs
@@ -116,10 +116,8 @@ impl DataStore for MemoryDataStore {
 
     async fn get_all_validated_records(
         &self,
-    ) -> Result<
-        Pin<Box<dyn Stream<Item = Result<(RegistryIndex, LogLeaf), DataStoreError>> + Send>>,
-        DataStoreError,
-    > {
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<LogLeaf, DataStoreError>> + Send>>, DataStoreError>
+    {
         Ok(Box::pin(futures::stream::empty()))
     }
 

--- a/crates/server/src/datastore/mod.rs
+++ b/crates/server/src/datastore/mod.rs
@@ -4,7 +4,9 @@ use thiserror::Error;
 use warg_crypto::{hash::AnyHash, signing::KeyID};
 use warg_protocol::{
     operator, package,
-    registry::{LogId, LogLeaf, PackageId, RecordId, RegistryIndex, TimestampedCheckpoint},
+    registry::{
+        LogId, LogLeaf, PackageId, RecordId, RegistryIndex, RegistryLen, TimestampedCheckpoint,
+    },
     ProtoEnvelope, PublishedProtoEnvelope, SerdeEnvelope,
 };
 
@@ -21,8 +23,8 @@ pub enum DataStoreError {
     #[error("a conflicting operation was processed: update to the latest checkpoint and try the operation again")]
     Conflict,
 
-    #[error("checkpoint `{0}` was not found")]
-    CheckpointNotFound(AnyHash),
+    #[error("checkpoint log length `{0}` was not found")]
+    CheckpointNotFound(RegistryLen),
 
     #[error("log `{0}` was not found")]
     LogNotFound(LogId),
@@ -227,20 +229,20 @@ pub trait DataStore: Send + Sync {
         &self,
     ) -> Result<SerdeEnvelope<TimestampedCheckpoint>, DataStoreError>;
 
-    /// Gets the operator records for the given registry checkpoint ID hash.
+    /// Gets the operator records for the given registry log length.
     async fn get_operator_records(
         &self,
         log_id: &LogId,
-        checkpoint_id: &AnyHash,
+        registry_log_length: RegistryLen,
         since: Option<&RecordId>,
         limit: u16,
     ) -> Result<Vec<PublishedProtoEnvelope<operator::OperatorRecord>>, DataStoreError>;
 
-    /// Gets the package records for the given registry checkpoint ID hash.
+    /// Gets the package records for the given registry log length.
     async fn get_package_records(
         &self,
         log_id: &LogId,
-        checkpoint_id: &AnyHash,
+        registry_log_length: RegistryLen,
         since: Option<&RecordId>,
         limit: u16,
     ) -> Result<Vec<PublishedProtoEnvelope<package::PackageRecord>>, DataStoreError>;

--- a/crates/server/src/datastore/mod.rs
+++ b/crates/server/src/datastore/mod.rs
@@ -5,7 +5,7 @@ use warg_crypto::{hash::AnyHash, signing::KeyID};
 use warg_protocol::{
     operator, package,
     registry::{LogId, LogLeaf, PackageId, RecordId, TimestampedCheckpoint},
-    ProtoEnvelope, SerdeEnvelope,
+    ProtoEnvelope, PublishedProtoEnvelope, SerdeEnvelope,
 };
 
 mod memory;
@@ -90,7 +90,7 @@ where
     /// The index of the record in the registry log.
     ///
     /// This is `None` if the record is not published.
-    pub registry_log_index: Option<u64>,
+    pub index: Option<u32>,
 }
 
 /// Implemented by data stores.
@@ -222,7 +222,7 @@ pub trait DataStore: Send + Sync {
         checkpoint_id: &AnyHash,
         since: Option<&RecordId>,
         limit: u16,
-    ) -> Result<Vec<ProtoEnvelope<operator::OperatorRecord>>, DataStoreError>;
+    ) -> Result<Vec<PublishedProtoEnvelope<operator::OperatorRecord>>, DataStoreError>;
 
     /// Gets the package records for the given registry checkpoint ID hash.
     async fn get_package_records(
@@ -231,7 +231,7 @@ pub trait DataStore: Send + Sync {
         checkpoint_id: &AnyHash,
         since: Option<&RecordId>,
         limit: u16,
-    ) -> Result<Vec<ProtoEnvelope<package::PackageRecord>>, DataStoreError>;
+    ) -> Result<Vec<PublishedProtoEnvelope<package::PackageRecord>>, DataStoreError>;
 
     /// Gets an operator record.
     async fn get_operator_record(

--- a/crates/server/src/datastore/mod.rs
+++ b/crates/server/src/datastore/mod.rs
@@ -116,10 +116,7 @@ pub trait DataStore: Send + Sync {
     /// This is an expensive operation and should only be performed on startup.
     async fn get_all_validated_records(
         &self,
-    ) -> Result<
-        Pin<Box<dyn Stream<Item = Result<(RegistryIndex, LogLeaf), DataStoreError>> + Send>>,
-        DataStoreError,
-    >;
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<LogLeaf, DataStoreError>> + Send>>, DataStoreError>;
 
     /// Looks up the log_id and record_id from the registry log index.  
     async fn get_log_leafs_with_registry_index(

--- a/crates/server/src/datastore/mod.rs
+++ b/crates/server/src/datastore/mod.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 use warg_crypto::{hash::AnyHash, signing::KeyID};
 use warg_protocol::{
     operator, package,
-    registry::{LogId, LogLeaf, RegistryIndex, PackageId, RecordId, TimestampedCheckpoint},
+    registry::{LogId, LogLeaf, PackageId, RecordId, RegistryIndex, TimestampedCheckpoint},
     ProtoEnvelope, PublishedProtoEnvelope, SerdeEnvelope,
 };
 
@@ -114,7 +114,10 @@ pub trait DataStore: Send + Sync {
     /// This is an expensive operation and should only be performed on startup.
     async fn get_all_validated_records(
         &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<(RegistryIndex, LogLeaf), DataStoreError>> + Send>>, DataStoreError>;
+    ) -> Result<
+        Pin<Box<dyn Stream<Item = Result<(RegistryIndex, LogLeaf), DataStoreError>> + Send>>,
+        DataStoreError,
+    >;
 
     /// Looks up the log_id and record_id from the registry log index.  
     async fn get_log_leafs_with_registry_index(

--- a/crates/server/src/datastore/mod.rs
+++ b/crates/server/src/datastore/mod.rs
@@ -30,6 +30,9 @@ pub enum DataStoreError {
     #[error("record `{0}` was not found")]
     RecordNotFound(RecordId),
 
+    #[error("log leaf {0} was not found")]
+    LogLeafNotFound(usize),
+
     #[error("record `{0}` cannot be validated as it is not in a pending state")]
     RecordNotPending(RecordId),
 
@@ -112,6 +115,12 @@ pub trait DataStore: Send + Sync {
     async fn get_all_validated_records(
         &self,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<LogLeaf, DataStoreError>> + Send>>, DataStoreError>;
+
+    /// Looks up the log_id and record_id from the registry log index.  
+    async fn get_log_leafs_from_registry_index(
+        &self,
+        entries: &[usize],
+    ) -> Result<Vec<LogLeaf>, DataStoreError>;
 
     /// Stores the given operator record.
     async fn store_operator_record(

--- a/crates/server/src/datastore/mod.rs
+++ b/crates/server/src/datastore/mod.rs
@@ -114,7 +114,10 @@ pub trait DataStore: Send + Sync {
     /// This is an expensive operation and should only be performed on startup.
     async fn get_all_validated_records(
         &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<LogLeaf, DataStoreError>> + Send>>, DataStoreError>;
+    ) -> Result<
+        Pin<Box<dyn Stream<Item = Result<(usize, LogLeaf), DataStoreError>> + Send>>,
+        DataStoreError,
+    >;
 
     /// Looks up the log_id and record_id from the registry log index.  
     async fn get_log_leafs_from_registry_index(

--- a/crates/server/src/datastore/postgres/mod.rs
+++ b/crates/server/src/datastore/postgres/mod.rs
@@ -21,7 +21,9 @@ use warg_crypto::{hash::AnyHash, Decode, Signable};
 use warg_protocol::{
     operator,
     package::{self, PackageEntry},
-    registry::{Checkpoint, LogId, LogLeaf, RegistryIndex, PackageId, RecordId, TimestampedCheckpoint},
+    registry::{
+        Checkpoint, LogId, LogLeaf, PackageId, RecordId, RegistryIndex, TimestampedCheckpoint,
+    },
     ProtoEnvelope, PublishedProtoEnvelope, Record as _, SerdeEnvelope, Validator,
 };
 
@@ -555,13 +557,8 @@ impl DataStore for PostgresDataStore {
             .optional()?
             .ok_or_else(|| DataStoreError::LogNotFound(log_id.clone()))?;
 
-        match commit_record::<operator::LogState>(
-            conn.as_mut(),
-            log_id,
-            record_id,
-            registry_index,
-        )
-        .await
+        match commit_record::<operator::LogState>(conn.as_mut(), log_id, record_id, registry_index)
+            .await
         {
             Ok(()) => Ok(()),
             Err(e) => {
@@ -624,13 +621,8 @@ impl DataStore for PostgresDataStore {
             .optional()?
             .ok_or_else(|| DataStoreError::LogNotFound(log_id.clone()))?;
 
-        match commit_record::<package::LogState>(
-            conn.as_mut(),
-            log_id,
-            record_id,
-            registry_index,
-        )
-        .await
+        match commit_record::<package::LogState>(conn.as_mut(), log_id, record_id, registry_index)
+            .await
         {
             Ok(()) => Ok(()),
             Err(e) => {

--- a/crates/server/src/datastore/postgres/mod.rs
+++ b/crates/server/src/datastore/postgres/mod.rs
@@ -439,7 +439,7 @@ impl DataStore for PostgresDataStore {
                     schema::records::registry_log_index,
                 ))
                 .filter(schema::records::status.eq(RecordStatus::Validated))
-                .order_by(schema::records::registry_log_index)
+                .order(schema::records::registry_log_index.asc())
                 .load_stream::<(ParsedText<AnyHash>, ParsedText<AnyHash>, Option<i64>)>(&mut conn)
                 .await?
                 .map(|r| {

--- a/crates/server/src/datastore/postgres/schema.rs
+++ b/crates/server/src/datastore/postgres/schema.rs
@@ -63,9 +63,4 @@ diesel::table! {
 diesel::joinable!(contents -> records (record_id));
 diesel::joinable!(records -> logs (log_id));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    checkpoints,
-    contents,
-    logs,
-    records,
-);
+diesel::allow_tables_to_appear_in_same_query!(checkpoints, contents, logs, records,);

--- a/crates/server/src/datastore/postgres/schema.rs
+++ b/crates/server/src/datastore/postgres/schema.rs
@@ -63,4 +63,9 @@ diesel::table! {
 diesel::joinable!(contents -> records (record_id));
 diesel::joinable!(records -> logs (log_id));
 
-diesel::allow_tables_to_appear_in_same_query!(checkpoints, contents, logs, records,);
+diesel::allow_tables_to_appear_in_same_query!(
+    checkpoints,
+    contents,
+    logs,
+    records,
+);

--- a/crates/server/src/services/core.rs
+++ b/crates/server/src/services/core.rs
@@ -85,20 +85,14 @@ impl<Digest: SupportedDigest> CoreService<Digest> {
     pub async fn log_inclusion_proofs(
         &self,
         log_length: usize,
-        entries: &[LogLeaf],
+        entries: &[usize],
     ) -> Result<LogProofBundle<Digest, LogLeaf>, CoreServiceError> {
         let state = self.inner.state.read().await;
 
         let proofs = entries
             .iter()
-            .map(|entry| {
-                let node = state
-                    .leaf_index
-                    .get(entry)
-                    .ok_or_else(|| CoreServiceError::LeafNotFound(entry.clone()))?;
-                Ok(state.log.prove_inclusion(*node, log_length))
-            })
-            .collect::<Result<Vec<_>, CoreServiceError>>()?;
+            .map(|index| state.log.prove_inclusion(Node(*index), log_length))
+            .collect();
 
         LogProofBundle::bundle(vec![], proofs, &state.log).map_err(CoreServiceError::BundleFailure)
     }
@@ -106,20 +100,27 @@ impl<Digest: SupportedDigest> CoreService<Digest> {
     /// Constructs map inclusion proofs for the given entries at the given map tree root.
     pub async fn map_inclusion_proofs(
         &self,
-        root: &Hash<Digest>,
-        entries: &[LogLeaf],
+        log_length: usize,
+        entries: &[usize],
     ) -> Result<MapProofBundle<Digest, LogId, MapLeaf>, CoreServiceError> {
         let state = self.inner.state.read().await;
 
-        let map = state
+        let (map_root, map) = state
             .map_index
-            .get(root)
-            .ok_or_else(|| CoreServiceError::RootNotFound(root.into()))?;
+            .get(&log_length)
+            .ok_or_else(|| CoreServiceError::CheckpointNotFound(log_length))?;
 
-        let proofs = entries
+        let indexes = self
+            .inner
+            .store
+            .get_log_leafs_from_registry_index(entries)
+            .await
+            .map_err(CoreServiceError::DataStore)?;
+
+        let proofs = indexes
             .iter()
-            .map(|entry| {
-                let LogLeaf { log_id, record_id } = entry;
+            .map(|log_leaf| {
+                let LogLeaf { log_id, record_id } = log_leaf;
 
                 let proof = map
                     .prove(log_id.clone())
@@ -129,9 +130,9 @@ impl<Digest: SupportedDigest> CoreService<Digest> {
                     record_id: record_id.clone(),
                 };
                 let found_root = proof.evaluate(log_id, &map_leaf);
-                if &found_root != root {
+                if &found_root != map_root {
                     return Err(CoreServiceError::IncorrectProof {
-                        root: root.into(),
+                        root: map_root.into(),
                         found: found_root.into(),
                     });
                 }
@@ -345,8 +346,8 @@ struct State<Digest: SupportedDigest> {
 
     // The verifiable map of package logs' latest entries (log_id -> record_id)
     map: VerifiableMap<Digest>,
-    // Index verifiable map snapshots by root (at checkpoints only)
-    map_index: HashMap<Hash<Digest>, VerifiableMap<Digest>>,
+    // Index verifiable map snapshots by log length (at checkpoints only)
+    map_index: HashMap<usize, (Hash<Digest>, VerifiableMap<Digest>)>,
 }
 
 impl<Digest: SupportedDigest> State<Digest> {
@@ -369,14 +370,16 @@ impl<Digest: SupportedDigest> State<Digest> {
     fn checkpoint(&mut self) -> Checkpoint {
         let log_checkpoint = self.log.checkpoint();
         let map_root = self.map.root();
+        let log_length = log_checkpoint.length();
 
         // Update map snapshot
-        if log_checkpoint.length() > 0 {
-            self.map_index.insert(map_root.clone(), self.map.clone());
+        if log_length > 0 {
+            self.map_index
+                .insert(log_length, (map_root.clone(), self.map.clone()));
         }
 
         Checkpoint {
-            log_length: log_checkpoint.length().try_into().unwrap(),
+            log_length: log_length.try_into().unwrap(),
             log_root: log_checkpoint.root().into(),
             map_root: map_root.into(),
         }
@@ -385,10 +388,8 @@ impl<Digest: SupportedDigest> State<Digest> {
 
 #[derive(Debug, Error)]
 pub enum CoreServiceError {
-    #[error("root `{0}` was not found")]
-    RootNotFound(AnyHash),
-    #[error("log leaf `{}:{}` was not found", .0.log_id, .0.record_id)]
-    LeafNotFound(LogLeaf),
+    #[error("checkpoint at log length `{0}` was not found")]
+    CheckpointNotFound(usize),
     #[error("failed to bundle proofs: `{0}`")]
     BundleFailure(anyhow::Error),
     #[error("failed to prove inclusion of package `{0}`")]

--- a/crates/server/src/services/core.rs
+++ b/crates/server/src/services/core.rs
@@ -17,7 +17,9 @@ use warg_crypto::{
 };
 use warg_protocol::{
     operator,
-    registry::{Checkpoint, LogId, RegistryIndex, LogLeaf, MapLeaf, RecordId, TimestampedCheckpoint},
+    registry::{
+        Checkpoint, LogId, LogLeaf, MapLeaf, RecordId, RegistryIndex, TimestampedCheckpoint,
+    },
     ProtoEnvelope, SerdeEnvelope,
 };
 use warg_transparency::{
@@ -76,7 +78,9 @@ impl<Digest: SupportedDigest> CoreService<Digest> {
     ) -> Result<LogProofBundle<Digest, LogLeaf>, CoreServiceError> {
         let state = self.inner.state.read().await;
 
-        let proof = state.log.prove_consistency(from_log_length as usize, to_log_length as usize);
+        let proof = state
+            .log
+            .prove_consistency(from_log_length as usize, to_log_length as usize);
         LogProofBundle::bundle(vec![proof], vec![], &state.log)
             .map_err(CoreServiceError::BundleFailure)
     }
@@ -202,7 +206,9 @@ impl<Digest: SupportedDigest> Inner<Digest> {
         while let Some(entry) = published.next().await {
             let (index, log_leaf) = entry?;
             state.push_entry(index, log_leaf);
-            if let Some(stored_checkpoint) = checkpoints_by_len.get(&(state.log.length() as RegistryIndex)) {
+            if let Some(stored_checkpoint) =
+                checkpoints_by_len.get(&(state.log.length() as RegistryIndex))
+            {
                 // Validate stored checkpoint (and update internal state as a side-effect)
                 let computed_checkpoint = state.checkpoint();
                 assert!(stored_checkpoint == &computed_checkpoint);
@@ -363,8 +369,10 @@ impl<Digest: SupportedDigest> State<Digest> {
         self.leaf_index.insert(registry_index, node);
 
         let log_checkpoint = self.log.checkpoint();
-        self.root_index
-            .insert(log_checkpoint.root(), log_checkpoint.length() as RegistryIndex);
+        self.root_index.insert(
+            log_checkpoint.root(),
+            log_checkpoint.length() as RegistryIndex,
+        );
 
         self.map = self.map.insert(
             entry.log_id.clone(),

--- a/crates/server/src/services/core.rs
+++ b/crates/server/src/services/core.rs
@@ -296,7 +296,7 @@ impl<Digest: SupportedDigest> Inner<Digest> {
         let LogLeaf { log_id, record_id } = entry;
 
         // Validate and commit the package entry to the store
-        let registry_index = state.log.length().try_into().unwrap();
+        let registry_index = state.log.length() as RegistryIndex;
         let commit_res = self
             .store
             .commit_package_record(log_id, record_id, registry_index)
@@ -387,7 +387,7 @@ impl<Digest: SupportedDigest> State<Digest> {
         }
 
         Checkpoint {
-            log_length: log_length.try_into().unwrap(),
+            log_length,
             log_root: log_checkpoint.root().into(),
             map_root: map_root.into(),
         }

--- a/crates/server/src/services/core.rs
+++ b/crates/server/src/services/core.rs
@@ -204,8 +204,8 @@ impl<Digest: SupportedDigest> Inner<Digest> {
 
         let state = self.state.get_mut();
         while let Some(entry) = published.next().await {
-            let (index, log_leaf) = entry?;
-            state.push_entry(index, log_leaf);
+            let (registry_index, log_leaf) = entry?;
+            state.push_entry(registry_index, log_leaf);
             if let Some(stored_checkpoint) =
                 checkpoints_by_len.get(&(state.log.length() as RegistryIndex))
             {

--- a/crates/server/src/services/core.rs
+++ b/crates/server/src/services/core.rs
@@ -18,7 +18,8 @@ use warg_crypto::{
 use warg_protocol::{
     operator,
     registry::{
-        Checkpoint, LogId, LogLeaf, MapLeaf, RecordId, RegistryIndex, RegistryLen, TimestampedCheckpoint,
+        Checkpoint, LogId, LogLeaf, MapLeaf, RecordId, RegistryIndex, RegistryLen,
+        TimestampedCheckpoint,
     },
     ProtoEnvelope, SerdeEnvelope,
 };

--- a/crates/server/src/services/core.rs
+++ b/crates/server/src/services/core.rs
@@ -354,8 +354,6 @@ struct State<Digest: SupportedDigest> {
     log: VecLog<Digest, LogLeaf>,
     // Index log tree nodes by registry log index of the record
     leaf_index: HashMap<RegistryIndex, Node>,
-    // Index log size by log tree root
-    root_index: HashMap<Hash<Digest>, RegistryIndex>,
 
     // The verifiable map of package logs' latest entries (log_id -> record_id)
     map: VerifiableMap<Digest>,
@@ -367,12 +365,6 @@ impl<Digest: SupportedDigest> State<Digest> {
     fn push_entry(&mut self, registry_index: RegistryIndex, entry: LogLeaf) {
         let node = self.log.push(&entry);
         self.leaf_index.insert(registry_index, node);
-
-        let log_checkpoint = self.log.checkpoint();
-        self.root_index.insert(
-            log_checkpoint.root(),
-            log_checkpoint.length() as RegistryIndex,
-        );
 
         self.map = self.map.insert(
             entry.log_id.clone(),

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result};
 use testresult::TestResult;
 use warg_client::api;
 use warg_server::datastore::{DataStore, PostgresDataStore};
+use warg_protocol::registry::RegistryIndex;
 
 fn data_store() -> Result<Box<dyn DataStore>> {
     Ok(Box::new(PostgresDataStore::new(
@@ -65,7 +66,7 @@ async fn it_works_with_postgres() -> TestResult {
     let ts_checkpoint = client.latest_checkpoint().await?;
     assert_eq!(
         ts_checkpoint.as_ref().checkpoint.log_length,
-        packages.len() as u32 + 2, /* publishes + initial checkpoint + yank */
+        packages.len() as RegistryIndex + 2, /* publishes + initial checkpoint + yank */
         "expected {len} packages plus the initial checkpoint and yank",
         len = packages.len()
     );
@@ -83,7 +84,7 @@ async fn it_works_with_postgres() -> TestResult {
     let ts_checkpoint = client.latest_checkpoint().await?;
     assert_eq!(
         ts_checkpoint.as_ref().checkpoint.log_length,
-        packages.len() as u32 + 2, /* publishes + initial checkpoint + yank*/
+        packages.len() as RegistryIndex + 2, /* publishes + initial checkpoint + yank*/
         "expected {len} packages plus the initial checkpoint and yank",
         len = packages.len()
     );

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -4,8 +4,8 @@ use super::{support::*, *};
 use anyhow::{Context, Result};
 use testresult::TestResult;
 use warg_client::api;
-use warg_server::datastore::{DataStore, PostgresDataStore};
 use warg_protocol::registry::RegistryIndex;
+use warg_server::datastore::{DataStore, PostgresDataStore};
 
 fn data_store() -> Result<Box<dyn DataStore>> {
     Ok(Box::new(PostgresDataStore::new(

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -4,7 +4,7 @@ use super::{support::*, *};
 use anyhow::{Context, Result};
 use testresult::TestResult;
 use warg_client::api;
-use warg_protocol::registry::RegistryIndex;
+use warg_protocol::registry::RegistryLen;
 use warg_server::datastore::{DataStore, PostgresDataStore};
 
 fn data_store() -> Result<Box<dyn DataStore>> {
@@ -66,7 +66,7 @@ async fn it_works_with_postgres() -> TestResult {
     let ts_checkpoint = client.latest_checkpoint().await?;
     assert_eq!(
         ts_checkpoint.as_ref().checkpoint.log_length,
-        packages.len() as RegistryIndex + 2, /* publishes + initial checkpoint + yank */
+        packages.len() as RegistryLen + 2, /* publishes + initial checkpoint + yank */
         "expected {len} packages plus the initial checkpoint and yank",
         len = packages.len()
     );
@@ -84,7 +84,7 @@ async fn it_works_with_postgres() -> TestResult {
     let ts_checkpoint = client.latest_checkpoint().await?;
     assert_eq!(
         ts_checkpoint.as_ref().checkpoint.log_length,
-        packages.len() as RegistryIndex + 2, /* publishes + initial checkpoint + yank*/
+        packages.len() as RegistryLen + 2, /* publishes + initial checkpoint + yank*/
         "expected {len} packages plus the initial checkpoint and yank",
         len = packages.len()
     );


### PR DESCRIPTION
The registry index for a published record is going to be different than the `VecLog`'s `Node(usize)` value that is required for the log inclusion proof. For now, keeping the existing pattern of using a `HashMap` (could be a `Vec` if added back in the same order) to lookup the value in memory.

To make it easier to adjust the size of the integer for the `log_length` and `registry_index`, I added a type alias `RegistryIndex`.

As always, suggestions appreciated. This was more of a change than I expected.