### PR TITLE
fixed openapi.yaml

### DIFF
--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -551,10 +551,10 @@ components:
       description: A request to publish a record to a package log.
       additionalProperties: false
       required:
-        - name
+        - id
         - record
       properties:
-        name:
+        id:
           type: string
           description: The name of the package log being published to.
           maxLength: 128


### PR DESCRIPTION
publish package record endpoint to reflect the JSON field "id" instead of "name"