### PR TITLE
publish record endpoint changes contentSources to optional JSON field

### DIFF
--- a/crates/api/src/v1/package.rs
+++ b/crates/api/src/v1/package.rs
@@ -52,7 +52,7 @@ pub struct PublishRecordRequest<'a> {
     /// The complete set of content sources for the record.
     ///
     /// A registry may not support specifying content sources directly.
-    pub content_sources: HashMap<AnyHash, Vec<ContentSource>>,
+    pub content_sources: Option<HashMap<AnyHash, Vec<ContentSource>>>,
 }
 
 /// Represents a package record API entity in a registry.

--- a/crates/api/src/v1/package.rs
+++ b/crates/api/src/v1/package.rs
@@ -52,7 +52,8 @@ pub struct PublishRecordRequest<'a> {
     /// The complete set of content sources for the record.
     ///
     /// A registry may not support specifying content sources directly.
-    pub content_sources: Option<HashMap<AnyHash, Vec<ContentSource>>>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub content_sources: HashMap<AnyHash, Vec<ContentSource>>,
 }
 
 /// Represents a package record API entity in a registry.

--- a/crates/server/src/api/v1/package.rs
+++ b/crates/server/src/api/v1/package.rs
@@ -207,7 +207,7 @@ async fn publish_record(
         .map_err(PackageApiError::bad_request)?;
 
     // Specifying content sources is not allowed in this implementation
-    if !body.content_sources.is_empty() {
+    if body.content_sources.is_some_and(|m| !m.is_empty()) {
         return Err(PackageApiError::unsupported(
             "specifying content sources is not supported",
         ));

--- a/crates/server/src/api/v1/package.rs
+++ b/crates/server/src/api/v1/package.rs
@@ -207,7 +207,7 @@ async fn publish_record(
         .map_err(PackageApiError::bad_request)?;
 
     // Specifying content sources is not allowed in this implementation
-    if body.content_sources.is_some_and(|m| !m.is_empty()) {
+    if !body.content_sources.is_empty() {
         return Err(PackageApiError::unsupported(
             "specifying content sources is not supported",
         ));


### PR DESCRIPTION
Currently, requires `contentSources` JSON field to be provided even if it is empty. This makes it optional and matches the OpenAPI spec.