### PR TITLE
added missing serde flatten

### DIFF
--- a/crates/api/src/v1/package.rs
+++ b/crates/api/src/v1/package.rs
@@ -62,6 +62,7 @@ pub struct PackageRecord {
     /// The identifier of the package record.
     pub id: RecordId,
     /// The current state of the package.
+    #[serde(flatten)]
     pub state: PackageRecordState,
 }
 


### PR DESCRIPTION
This fixes a mismatch between the intended JSON schema, described in the [OpenAPI spec](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/bytecodealliance/registry/main/crates/server/openapi.yaml#tag/package/operation/getPackageRecord), and the implementation.