### PR TITLE
changes to make it easier for other server implementations and componentizing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4103,7 +4103,7 @@ dependencies = [
 
 [[package]]
 name = "warg-api"
-version = "0.2.0"
+version = "0.2.0-dev"
 dependencies = [
  "itertools 0.11.0",
  "serde",
@@ -4115,7 +4115,7 @@ dependencies = [
 
 [[package]]
 name = "warg-cli"
-version = "0.2.0"
+version = "0.2.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4151,7 +4151,7 @@ dependencies = [
 
 [[package]]
 name = "warg-client"
-version = "0.2.0"
+version = "0.2.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "warg-crypto"
-version = "0.2.0"
+version = "0.2.0-dev"
 dependencies = [
  "anyhow",
  "base64 0.21.2",
@@ -4203,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "warg-protobuf"
-version = "0.2.0"
+version = "0.2.0-dev"
 dependencies = [
  "anyhow",
  "pbjson",
@@ -4220,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "warg-protocol"
-version = "0.2.0"
+version = "0.2.0-dev"
 dependencies = [
  "anyhow",
  "base64 0.21.2",
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "warg-server"
-version = "0.2.0"
+version = "0.2.0-dev"
 dependencies = [
  "anyhow",
  "axum",
@@ -4279,7 +4279,7 @@ dependencies = [
 
 [[package]]
 name = "warg-transparency"
-version = "0.2.0"
+version = "0.2.0-dev"
 dependencies = [
  "anyhow",
  "criterion",

--- a/crates/crypto/src/hash/dynamic.rs
+++ b/crates/crypto/src/hash/dynamic.rs
@@ -54,6 +54,10 @@ pub struct AnyHash {
 }
 
 impl AnyHash {
+    pub fn new(algo: HashAlgorithm, bytes: Vec<u8>) -> AnyHash {
+        AnyHash { algo, bytes }
+    }
+
     pub fn algorithm(&self) -> HashAlgorithm {
         self.algo
     }

--- a/crates/protocol/src/operator/mod.rs
+++ b/crates/protocol/src/operator/mod.rs
@@ -9,7 +9,7 @@ use crate::{pbjson_to_prost_timestamp, prost_to_pbjson_timestamp, registry::Reco
 mod model;
 mod state;
 
-pub use model::{OperatorEntry, OperatorRecord};
+pub use model::{OperatorEntry, OperatorRecord, Permission};
 pub use state::{LogState, ValidationError};
 
 /// The currently supported operator protocol version.
@@ -114,9 +114,10 @@ struct PermissionParseError {
 }
 
 // Serialization
+pub const SIGNING_PREFIX: &[u8] = b"WARG-OPERATOR-RECORD-SIGNATURE-V0";
 
 impl Signable for model::OperatorRecord {
-    const PREFIX: &'static [u8] = b"WARG-OPERATOR-RECORD-SIGNATURE-V0";
+    const PREFIX: &'static [u8] = SIGNING_PREFIX;
 }
 
 impl Encode for model::OperatorRecord {
@@ -217,7 +218,7 @@ mod tests {
         let bytes = first_envelope.to_protobuf();
 
         let second_envelope: ProtoEnvelope<model::OperatorRecord> =
-            match ProtoEnvelope::from_protobuf(bytes) {
+            match ProtoEnvelope::from_protobuf(&bytes) {
                 Ok(value) => value,
                 Err(error) => panic!("Failed to create envelope 2: {:?}", error),
             };

--- a/crates/protocol/src/operator/mod.rs
+++ b/crates/protocol/src/operator/mod.rs
@@ -114,7 +114,7 @@ struct PermissionParseError {
 }
 
 // Serialization
-pub const SIGNING_PREFIX: &[u8] = b"WARG-OPERATOR-RECORD-SIGNATURE-V0";
+const SIGNING_PREFIX: &[u8] = b"WARG-OPERATOR-RECORD-SIGNATURE-V0";
 
 impl Signable for model::OperatorRecord {
     const PREFIX: &'static [u8] = SIGNING_PREFIX;

--- a/crates/protocol/src/operator/state.rs
+++ b/crates/protocol/src/operator/state.rs
@@ -172,7 +172,7 @@ impl LogState {
 
         // Update the validator head
         self.head = Some(Head {
-            digest: RecordId::operator_record::<Sha256>(envelope),
+            digest: RecordId::operator_record::<Sha256>(envelope.content_bytes()),
             timestamp: record.timestamp,
         });
 
@@ -437,7 +437,7 @@ mod tests {
             validator,
             LogState {
                 head: Some(Head {
-                    digest: RecordId::operator_record::<Sha256>(&envelope),
+                    digest: RecordId::operator_record::<Sha256>(envelope.content_bytes()),
                     timestamp,
                 }),
                 algorithm: Some(HashAlgorithm::Sha256),
@@ -474,7 +474,7 @@ mod tests {
 
         let expected = LogState {
             head: Some(Head {
-                digest: RecordId::operator_record::<Sha256>(&envelope),
+                digest: RecordId::operator_record::<Sha256>(envelope.content_bytes()),
                 timestamp,
             }),
             algorithm: Some(HashAlgorithm::Sha256),
@@ -488,7 +488,9 @@ mod tests {
         assert_eq!(validator, expected);
 
         let record = model::OperatorRecord {
-            prev: Some(RecordId::operator_record::<Sha256>(&envelope)),
+            prev: Some(RecordId::operator_record::<Sha256>(
+                envelope.content_bytes(),
+            )),
             version: 0,
             timestamp: SystemTime::now(),
             entries: vec![

--- a/crates/protocol/src/package/mod.rs
+++ b/crates/protocol/src/package/mod.rs
@@ -125,9 +125,10 @@ struct PermissionParseError {
 }
 
 // Serialization
+pub const SIGNING_PREFIX: &[u8] = b"WARG-PACKAGE-RECORD-SIGNATURE-V0";
 
 impl Signable for model::PackageRecord {
-    const PREFIX: &'static [u8] = b"WARG-PACKAGE-RECORD-SIGNATURE-V0";
+    const PREFIX: &'static [u8] = SIGNING_PREFIX;
 }
 
 impl Encode for model::PackageRecord {
@@ -247,7 +248,7 @@ mod tests {
         let bytes = first_envelope.to_protobuf();
 
         let second_envelope: ProtoEnvelope<model::PackageRecord> =
-            match ProtoEnvelope::from_protobuf(bytes) {
+            match ProtoEnvelope::from_protobuf(&bytes) {
                 Ok(value) => value,
                 Err(error) => panic!("Failed to create envelope 2: {:?}", error),
             };

--- a/crates/protocol/src/package/mod.rs
+++ b/crates/protocol/src/package/mod.rs
@@ -125,7 +125,7 @@ struct PermissionParseError {
 }
 
 // Serialization
-pub const SIGNING_PREFIX: &[u8] = b"WARG-PACKAGE-RECORD-SIGNATURE-V0";
+const SIGNING_PREFIX: &[u8] = b"WARG-PACKAGE-RECORD-SIGNATURE-V0";
 
 impl Signable for model::PackageRecord {
     const PREFIX: &'static [u8] = SIGNING_PREFIX;

--- a/crates/protocol/src/package/state.rs
+++ b/crates/protocol/src/package/state.rs
@@ -234,7 +234,7 @@ impl LogState {
         envelope: &ProtoEnvelope<model::PackageRecord>,
     ) -> Result<(), ValidationError> {
         let record = envelope.as_ref();
-        let record_id = RecordId::package_record::<Sha256>(envelope);
+        let record_id = RecordId::package_record::<Sha256>(envelope.content_bytes());
 
         // Validate previous hash
         self.validate_record_hash(record)?;
@@ -612,7 +612,7 @@ mod tests {
             validator,
             LogState {
                 head: Some(Head {
-                    digest: RecordId::package_record::<Sha256>(&envelope),
+                    digest: RecordId::package_record::<Sha256>(envelope.content_bytes()),
                     timestamp,
                 }),
                 algorithm: Some(HashAlgorithm::Sha256),
@@ -660,7 +660,9 @@ mod tests {
         let timestamp1 = timestamp0 + Duration::from_secs(1);
         let content = hash_algo.digest(&[0, 1, 2, 3]);
         let record1 = model::PackageRecord {
-            prev: Some(RecordId::package_record::<Sha256>(&envelope0)),
+            prev: Some(RecordId::package_record::<Sha256>(
+                envelope0.content_bytes(),
+            )),
             version: PACKAGE_RECORD_VERSION,
             timestamp: timestamp1,
             entries: vec![model::PackageEntry::Release {
@@ -670,7 +672,7 @@ mod tests {
         };
 
         let envelope1 = ProtoEnvelope::signed_contents(&bob_priv, record1).unwrap();
-        let record_id1 = RecordId::package_record::<Sha256>(&envelope1);
+        let record_id1 = RecordId::package_record::<Sha256>(envelope1.content_bytes());
         validator.validate(&envelope1).unwrap();
 
         // At this point, the validator should consider 1.1.0 released
@@ -703,7 +705,9 @@ mod tests {
         // In envelope 2: alice revokes bobs access and yanks 1.1.0
         let timestamp2 = timestamp1 + Duration::from_secs(1);
         let record2 = model::PackageRecord {
-            prev: Some(RecordId::package_record::<Sha256>(&envelope1)),
+            prev: Some(RecordId::package_record::<Sha256>(
+                envelope1.content_bytes(),
+            )),
             version: PACKAGE_RECORD_VERSION,
             timestamp: timestamp2,
             entries: vec![
@@ -742,7 +746,7 @@ mod tests {
             LogState {
                 algorithm: Some(HashAlgorithm::Sha256),
                 head: Some(Head {
-                    digest: RecordId::package_record::<Sha256>(&envelope2),
+                    digest: RecordId::package_record::<Sha256>(envelope2.content_bytes()),
                     timestamp: timestamp2,
                 }),
                 permissions: IndexMap::from([
@@ -794,7 +798,7 @@ mod tests {
 
         let expected = LogState {
             head: Some(Head {
-                digest: RecordId::package_record::<Sha256>(&envelope),
+                digest: RecordId::package_record::<Sha256>(envelope.content_bytes()),
                 timestamp,
             }),
             algorithm: Some(HashAlgorithm::Sha256),
@@ -809,7 +813,7 @@ mod tests {
         assert_eq!(validator, expected);
 
         let record = model::PackageRecord {
-            prev: Some(RecordId::package_record::<Sha256>(&envelope)),
+            prev: Some(RecordId::package_record::<Sha256>(envelope.content_bytes())),
             version: 0,
             timestamp: SystemTime::now(),
             entries: vec![

--- a/crates/protocol/src/proto_envelope.rs
+++ b/crates/protocol/src/proto_envelope.rs
@@ -24,13 +24,13 @@ pub struct PublishedProtoEnvelope<Contents> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProtoEnvelope<Contents> {
     /// The content represented by content_bytes
-    contents: Contents,
+    pub contents: Contents,
     /// The serialized representation of the content
-    content_bytes: Vec<u8>,
+    pub content_bytes: Vec<u8>,
     /// The hash of the key that signed this envelope
-    key_id: signing::KeyID,
+    pub key_id: signing::KeyID,
     /// The signature for the content_bytes
-    signature: signing::Signature,
+    pub signature: signing::Signature,
 }
 
 impl<Contents> ProtoEnvelope<Contents> {
@@ -80,12 +80,12 @@ impl<Contents> ProtoEnvelope<Contents> {
 
     /// Create an entire envelope from a byte vector.
     /// This is the logical inverse of `Envelope::as_bytes`.
-    pub fn from_protobuf(bytes: Vec<u8>) -> Result<Self, ParseEnvelopeError>
+    pub fn from_protobuf(bytes: &[u8]) -> Result<Self, ParseEnvelopeError>
     where
         Contents: Decode,
     {
         // Parse outer envelope
-        let envelope = protobuf::Envelope::decode(bytes.as_slice())?;
+        let envelope = protobuf::Envelope::decode(bytes)?;
         let contents = Contents::decode(&envelope.contents)?;
 
         // Read key ID and signature

--- a/crates/protocol/src/registry.rs
+++ b/crates/protocol/src/registry.rs
@@ -8,7 +8,7 @@ use warg_crypto::prefix::VisitPrefixEncode;
 use warg_crypto::{prefix, ByteVisitor, Signable, VisitBytes};
 use wasmparser::names::KebabStr;
 
-pub const TIMESTAMPED_CHECKPOINT_SIGNING_PREFIX: &[u8] = b"WARG-CHECKPOINT-SIGNATURE-V0";
+const TIMESTAMPED_CHECKPOINT_SIGNING_PREFIX: &[u8] = b"WARG-CHECKPOINT-SIGNATURE-V0";
 
 /// Type alias for registry log index
 pub type RegistryIndex = usize;

--- a/crates/protocol/tests/operator.rs
+++ b/crates/protocol/tests/operator.rs
@@ -43,7 +43,9 @@ fn validate_input(input: Vec<EnvelopeData>) -> Result<LogState> {
 
             let envelope = ProtoEnvelope::signed_contents(&key, record).unwrap();
 
-            *last = Some(RecordId::operator_record::<Sha256>(&envelope));
+            *last = Some(RecordId::operator_record::<Sha256>(
+                envelope.content_bytes(),
+            ));
 
             Some(envelope)
         })

--- a/crates/protocol/tests/package.rs
+++ b/crates/protocol/tests/package.rs
@@ -42,7 +42,7 @@ fn validate_input(input: Vec<EnvelopeData>) -> Result<LogState> {
 
             let envelope = ProtoEnvelope::signed_contents(&key, record).unwrap();
 
-            *last = Some(RecordId::package_record::<Sha256>(&envelope));
+            *last = Some(RecordId::package_record::<Sha256>(envelope.content_bytes()));
 
             Some(envelope)
         })

--- a/crates/server/src/api/debug/mod.rs
+++ b/crates/server/src/api/debug/mod.rs
@@ -108,7 +108,7 @@ async fn get_package_info(
             package_state
                 .validate(&record.envelope)
                 .context("validate")?;
-            let record_id = RecordId::package_record::<Sha256>(&record.envelope);
+            let record_id = RecordId::package_record::<Sha256>(&record.envelope.content_bytes());
             let timestamp = record
                 .envelope
                 .as_ref()

--- a/crates/server/src/api/v1/package.rs
+++ b/crates/server/src/api/v1/package.rs
@@ -226,7 +226,7 @@ async fn publish_record(
         .verify_package_record_signature(&log_id, &record)
         .await?;
 
-    let record_id = RecordId::package_record::<Sha256>(&record);
+    let record_id = RecordId::package_record::<Sha256>(record.content_bytes());
     let mut missing = record.as_ref().contents();
     missing.retain(|d| !config.content_present(d));
 

--- a/crates/server/src/datastore/postgres/mod.rs
+++ b/crates/server/src/datastore/postgres/mod.rs
@@ -82,7 +82,7 @@ async fn get_records<R: Decode>(
         .await?
         .into_iter()
         .map(
-            |(record_id, c, index)| match ProtoEnvelope::from_protobuf(c) {
+            |(record_id, c, index)| match ProtoEnvelope::from_protobuf(&c) {
                 Ok(envelope) => Ok(PublishedProtoEnvelope {
                     envelope,
                     registry_index: index.unwrap() as RegistryIndex,
@@ -240,7 +240,7 @@ where
                 .optional()?
                 .ok_or_else(|| DataStoreError::RecordNotPending(record_id.clone()))?;
 
-            let record = ProtoEnvelope::<V::Record>::from_protobuf(content).map_err(|e| {
+            let record = ProtoEnvelope::<V::Record>::from_protobuf(&content).map_err(|e| {
                 DataStoreError::InvalidRecordContents {
                     record_id: record_id.clone(),
                     message: e.to_string(),
@@ -341,7 +341,7 @@ where
                 super::RecordStatus::Rejected(record.reason.unwrap_or_default())
             }
         },
-        envelope: ProtoEnvelope::from_protobuf(record.content).map_err(|e| {
+        envelope: ProtoEnvelope::from_protobuf(&record.content).map_err(|e| {
             DataStoreError::InvalidRecordContents {
                 record_id: record_id.clone(),
                 message: e.to_string(),

--- a/crates/server/src/services/core.rs
+++ b/crates/server/src/services/core.rs
@@ -79,9 +79,7 @@ impl<Digest: SupportedDigest> CoreService<Digest> {
     ) -> Result<LogProofBundle<Digest, LogLeaf>, CoreServiceError> {
         let state = self.inner.state.read().await;
 
-        let proof = state
-            .log
-            .prove_consistency(from_log_length as usize, to_log_length as usize);
+        let proof = state.log.prove_consistency(from_log_length, to_log_length);
         LogProofBundle::bundle(vec![proof], vec![], &state.log)
             .map_err(CoreServiceError::BundleFailure)
     }
@@ -98,11 +96,11 @@ impl<Digest: SupportedDigest> CoreService<Digest> {
             .iter()
             .map(|&index| {
                 let node = if index < state.leaf_index.len() as RegistryIndex {
-                    state.leaf_index[index as usize]
+                    state.leaf_index[index]
                 } else {
                     return Err(CoreServiceError::LeafNotFound(index));
                 };
-                Ok(state.log.prove_inclusion(node, log_length as usize))
+                Ok(state.log.prove_inclusion(node, log_length))
             })
             .collect::<Result<Vec<_>, CoreServiceError>>()?;
 

--- a/proto/warg/transparency/proofs.proto
+++ b/proto/warg/transparency/proofs.proto
@@ -25,3 +25,13 @@ message HashEntry {
     uint32 index = 1;
     bytes hash = 2;
 }
+
+message StackLog {
+    uint32 length = 1;
+    repeated HashEntry stack = 2;
+}
+
+message VecLog {
+    uint32 length = 1;
+    repeated bytes tree = 2;
+}


### PR DESCRIPTION
I'm holding on the Wasm Componentizing PR until it is cleaned up.

I found the following changes make it easier for componentizing pieces of the Registry implementation as well as building another server implementation that imports from these crates.

It would be helpful to have them in the main repo as opposed to on a branch. Please let me know if some variation of this PR is acceptable to merge.