### PR TITLE
fetch logs endpoint using fetch token String

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4103,7 +4103,7 @@ dependencies = [
 
 [[package]]
 name = "warg-api"
-version = "0.2.0"
+version = "0.2.0-dev"
 dependencies = [
  "itertools 0.11.0",
  "serde",
@@ -4115,7 +4115,7 @@ dependencies = [
 
 [[package]]
 name = "warg-cli"
-version = "0.2.0"
+version = "0.2.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4151,7 +4151,7 @@ dependencies = [
 
 [[package]]
 name = "warg-client"
-version = "0.2.0"
+version = "0.2.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "warg-crypto"
-version = "0.2.0"
+version = "0.2.0-dev"
 dependencies = [
  "anyhow",
  "base64 0.21.2",
@@ -4203,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "warg-protobuf"
-version = "0.2.0"
+version = "0.2.0-dev"
 dependencies = [
  "anyhow",
  "pbjson",
@@ -4220,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "warg-protocol"
-version = "0.2.0"
+version = "0.2.0-dev"
 dependencies = [
  "anyhow",
  "base64 0.21.2",
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "warg-server"
-version = "0.2.0"
+version = "0.2.0-dev"
 dependencies = [
  "anyhow",
  "axum",
@@ -4279,7 +4279,7 @@ dependencies = [
 
 [[package]]
 name = "warg-transparency"
-version = "0.2.0"
+version = "0.2.0-dev"
 dependencies = [
  "anyhow",
  "criterion",

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -401,12 +401,11 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
             for record in response.operator {
                 let proto_envelope: PublishedProtoEnvelope<operator::OperatorRecord> =
                     record.envelope.try_into()?;
+
+                // skip over records that has already seen
                 if operator.head_registry_index.is_none()
-                    || operator.head_registry_index.is_some_and(|registry_index| {
-                        proto_envelope.registry_index > registry_index
-                    })
+                    || proto_envelope.registry_index > operator.head_registry_index.unwrap()
                 {
-                    // skips over records that has already seen
                     operator
                         .state
                         .validate(&proto_envelope.envelope)
@@ -424,12 +423,11 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
                 for record in records {
                     let proto_envelope: PublishedProtoEnvelope<package::PackageRecord> =
                         record.envelope.try_into()?;
+
+                    // skip over records that has already seen
                     if package.head_registry_index.is_none()
-                        || package.head_registry_index.is_some_and(|registry_index| {
-                            proto_envelope.registry_index > registry_index
-                        })
+                        || proto_envelope.registry_index > package.head_registry_index.unwrap()
                     {
-                        // skips over records that has already seen
                         package
                             .state
                             .validate(&proto_envelope.envelope)

--- a/crates/client/src/storage.rs
+++ b/crates/client/src/storage.rs
@@ -110,8 +110,11 @@ pub struct OperatorInfo {
     #[serde(default)]
     pub state: operator::LogState,
     /// The registry log index of the most recent record
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub head_registry_index: Option<RegistryIndex>,
+    /// The fetch token for the most recent record
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head_fetch_token: Option<String>,
 }
 
 /// Represents information about a registry package.
@@ -127,8 +130,11 @@ pub struct PackageInfo {
     #[serde(default)]
     pub state: package::LogState,
     /// The registry log index of the most recent record
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub head_registry_index: Option<RegistryIndex>,
+    /// The fetch token for the most recent record
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head_fetch_token: Option<String>,
 }
 
 impl PackageInfo {
@@ -139,6 +145,7 @@ impl PackageInfo {
             checkpoint: None,
             state: package::LogState::default(),
             head_registry_index: None,
+            head_fetch_token: None,
         }
     }
 }

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -819,7 +819,7 @@ components:
               example: 42
             fetchToken:
               type: string
-              description: The fetch token for the registry log. Used for pagination in the fetch logs endpoint.
+              description: The fetch token for the registry log. Used as a cursor for incrementally fetching log records.
               example: "sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
         - $ref: "#/components/schemas/EnvelopeBody"
         - $ref: "#/components/schemas/Signature"

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -486,11 +486,11 @@ components:
           format: int16
         operator:
           $ref: "#/components/schemas/AnyHash"
-          description: The last known operator record identifier.
+          description: The last known operator record fetch token.
         packages:
           type: object
           description: |
-            The map of package log identifier to last known package record identifier.
+            The map of package log identifier to last known package record fetch token.
 
             If the last package record identifier is null, records are returned from the start of the log.
           patternProperties:
@@ -520,7 +520,7 @@ components:
           description: The operator log records for the given checkpoint since the last known record.
           maxItems: 1000
           items:
-            $ref: "#/components/schemas/PublishedEnvelopeBody"
+            $ref: "#/components/schemas/PublishedRecord"
         packages:
           type: object
           description: The map of package log identifier to package records.
@@ -530,7 +530,7 @@ components:
               description: The package log records for the given checkpoint since the last known record.
               maxItems: 1000
               items:
-                $ref: "#/components/schemas/PublishedEnvelopeBody"
+                $ref: "#/components/schemas/PublishedRecord"
           example:
             ? "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730"
             : - contentBytes: "ZXhhbXBsZQ=="
@@ -802,16 +802,21 @@ components:
               maxLength: 1048576
               example: "ZXhhbXBsZQ=="
         - $ref: "#/components/schemas/Signature"
-    PublishedEnvelopeBody:
+    PublishedRecord:
       description: A signed envelope body with the published registry log index.
       allOf:
         - type: object
           required:
             - registryIndex
+            - fetchToken
           properties:
             registryIndex:
               type: integer
               description: The index of the published record in the registry log.
+              example: 42
+            fetchToken:
+              type: string
+              description: The fetch token for the registry log. Used for pagination in the fetch logs endpoint.
               example: 42
         - $ref: "#/components/schemas/EnvelopeBody"
         - $ref: "#/components/schemas/Signature"

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -993,7 +993,7 @@ components:
           type:
             type: string
             description: The type of entity that was not found.
-            enum: [log, record]
+            enum: [log, fetchToken]
             example: log
           id:
             type: string

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -537,15 +537,18 @@ components:
                 keyId: "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730"
                 signature: "ecdsa-p256:MEUCIQCzWZBW6ux9LecP66Y+hjmLZTP/hZVz7puzlPTXcRT2wwIgQZO7nxP0nugtw18MwHZ26ROFWcJmgCtKOguK031Y1D0="
                 registryIndex: 101
+                fetchToken: "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730"
               - contentBytes: "ZXhhbXBsZQ=="
                 keyId: "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730"
                 signature: "ecdsa-p256:MEUCIQCzWZBW6ux9LecP66Y+hjmLZTP/hZVz7puzlPTXcRT2wwIgQZO7nxP0nugtw18MwHZ26ROFWcJmgCtKOguK031Y1D0="
                 registryIndex: 305
+                fetchToken: "sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
             ? "sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
             : - contentBytes: "ZXhhbXBsZQ=="
                 keyId: "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730"
                 signature: "ecdsa-p256:MEUCIQCzWZBW6ux9LecP66Y+hjmLZTP/hZVz7puzlPTXcRT2wwIgQZO7nxP0nugtw18MwHZ26ROFWcJmgCtKOguK031Y1D0="
                 registryIndex: 732
+                fetchToken: "sha256:ygdb4e8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae00a8y"
     PublishPackageRecordRequest:
       type: object
       description: A request to publish a record to a package log.
@@ -817,7 +820,7 @@ components:
             fetchToken:
               type: string
               description: The fetch token for the registry log. Used for pagination in the fetch logs endpoint.
-              example: 42
+              example: "sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
         - $ref: "#/components/schemas/EnvelopeBody"
         - $ref: "#/components/schemas/Signature"
     Signature:

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -520,7 +520,7 @@ components:
           description: The operator log records for the given checkpoint since the last known record.
           maxItems: 1000
           items:
-            $ref: "#/components/schemas/PublishedRecord"
+            $ref: "#/components/schemas/PublishedRecordEnvelope"
         packages:
           type: object
           description: The map of package log identifier to package records.
@@ -530,7 +530,7 @@ components:
               description: The package log records for the given checkpoint since the last known record.
               maxItems: 1000
               items:
-                $ref: "#/components/schemas/PublishedRecord"
+                $ref: "#/components/schemas/PublishedRecordEnvelope"
           example:
             ? "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730"
             : - contentBytes: "ZXhhbXBsZQ=="
@@ -802,7 +802,7 @@ components:
               maxLength: 1048576
               example: "ZXhhbXBsZQ=="
         - $ref: "#/components/schemas/Signature"
-    PublishedRecord:
+    PublishedRecordEnvelope:
       description: A signed envelope body with the published registry log index.
       allOf:
         - type: object

--- a/crates/server/src/api/v1/fetch.rs
+++ b/crates/server/src/api/v1/fetch.rs
@@ -55,7 +55,7 @@ impl From<DataStoreError> for FetchApiError {
             }
             DataStoreError::LogNotFound(log_id) => FetchError::LogNotFound(log_id),
             DataStoreError::RecordNotFound(record_id) => {
-                FetchError::RecordNotFound(record_id.to_string())
+                FetchError::FetchTokenNotFound(record_id.to_string())
             }
             // Other errors are internal server errors
             e => {
@@ -90,7 +90,7 @@ async fn fetch_logs(
     let operator_fetch_token: Option<RecordId> = match body.operator {
         Some(s) => Some(
             s.parse::<AnyHash>()
-                .map_err(|_| FetchApiError(FetchError::RecordNotFound(s.into_owned())))?
+                .map_err(|_| FetchApiError(FetchError::FetchTokenNotFound(s.into_owned())))?
                 .into(),
         ),
         None => None,
@@ -124,7 +124,7 @@ async fn fetch_logs(
         let since: Option<RecordId> = match fetch_token {
             Some(s) => Some(
                 s.parse::<AnyHash>()
-                    .map_err(|_| FetchApiError(FetchError::RecordNotFound(s)))?
+                    .map_err(|_| FetchApiError(FetchError::FetchTokenNotFound(s)))?
                     .into(),
             ),
             None => None,


### PR DESCRIPTION
This changes the `POST /v1/fetch/logs` endpoint to use a server implementation defined `fetchToken` for the last known record instead of the `RecordId`. It still can be the `RecordId`, but it doesn't need to be. In fact, the reference implementation still uses the `RecordId` for the `fetchToken`.

The motivation here is to give server implementations greater flexibility on implementing the fetch logs endpoint.

Also, in this PR, the Client CLI will be more resilient in handling records that are returned that it has already seen before.