### PR TITLE
Update crates for publishing.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,13 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches:
+      - main
     tags: ['[0-9]*']
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'release-*'
 
 jobs:
   test:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "warg-cli"
+description = "The warg registry command line interface."
 version = { workspace = true }
 edition = { workspace = true }
 authors = { workspace = true }
 rust-version = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true}
 
 [dependencies]
 warg-crypto = { workspace = true }
@@ -53,15 +57,18 @@ version = "0.1.0"
 authors = ["The Warg Registry Project Developers"]
 edition = "2021"
 rust-version = "1.66.0"
+license = "Apache-2.0 WITH LLVM-exception"
+homepage = "https://warg.io/"
+repository = "https://github.com/bytecodealliance/registry"
 
 [workspace.dependencies]
-warg-api = { path = "crates/api" }
-warg-client = { path = "crates/client" }
-warg-crypto = { path = "crates/crypto" }
-warg-protobuf = { path = "proto" }
-warg-protocol = { path = "crates/protocol" }
-warg-transparency = { path = "crates/transparency" }
-warg-server = { path = "crates/server" }
+warg-api = { path = "crates/api", version = "0.1.0" }
+warg-client = { path = "crates/client", version = "0.1.0" }
+warg-crypto = { path = "crates/crypto", version = "0.1.0" }
+warg-protobuf = { path = "proto", version = "0.1.0" }
+warg-protocol = { path = "crates/protocol", version = "0.1.0" }
+warg-transparency = { path = "crates/transparency", version = "0.1.0" }
+warg-server = { path = "crates/server", version = "0.1.0" }
 clap = { version = "4.3.11", features = ["derive", "env"] }
 thiserror = "1.0.43"
 anyhow = "1.0.71"

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "warg-api"
+description = "Serializable types for the Warg registry REST API."
 version = { workspace = true }
 edition = { workspace = true }
 authors = { workspace = true }
 rust-version = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true}
 
 [dependencies]
 warg-protocol = { workspace = true }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "warg-client"
+description = "A client library for Warg component registries."
 version = { workspace = true }
 edition = { workspace = true }
 authors = { workspace = true }
 rust-version = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true}
 
 [dependencies]
 warg-crypto = { workspace = true }

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "warg-crypto"
+description = "A collection of cryptographic primitives for Warg registries."
 version = { workspace = true }
 edition = { workspace = true }
 authors = { workspace = true }
 rust-version = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true}
 
 [dependencies]
 hex = { workspace = true }

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "warg-protocol"
+description = "An implementation of the operator and package log protocols for Warg registries."
 version = { workspace = true }
 edition = { workspace = true }
 authors = { workspace = true }
 rust-version = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true}
 
 [dependencies]
 warg-crypto = { workspace = true }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "warg-server"
+description = "A server library for Warg component registries."
 version = { workspace = true }
 edition = { workspace = true }
 authors = { workspace = true }
 rust-version = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true}
 
 [dependencies]
 warg-api = { workspace = true }

--- a/crates/transparency/Cargo.toml
+++ b/crates/transparency/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "warg-transparency"
+description = "A library for transparency data structures."
 version = { workspace = true }
 edition = { workspace = true }
 authors = { workspace = true }
 rust-version = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true}
 
 [dependencies]
 warg-crypto = { workspace = true }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "warg-protobuf"
+description = "Protobuf definitions for the Warg protocol."
 version = { workspace = true }
 edition = { workspace = true }
 authors = { workspace = true }
 rust-version = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true}
 
 [lib]
 path = "lib.rs"


### PR DESCRIPTION
This PR is going into the `release-0.1.0` branch (off of the `v0.1.0` tag), which, when ready, will contain everything for the 0.1.0 crates to be published.

To start, this updates the various `Cargo.toml` for fields related to publishing. The next step is creating a publish script for a GitHub action to auto publish with.

Please 🚲 🏠  on the crate descriptions a bit.