### PR TITLE
Bump `warg-api` crate version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4103,7 +4103,7 @@ dependencies = [
 
 [[package]]
 name = "warg-api"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "itertools 0.11.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,8 @@ homepage = "https://warg.io/"
 repository = "https://github.com/bytecodealliance/registry"
 
 [workspace.dependencies]
-warg-api = { path = "crates/api", version = "0.1.0" }
+# TODO: set this back to a matching version for the next release
+warg-api = { path = "crates/api", version = "0.1.1" }
 warg-client = { path = "crates/client", version = "0.1.0" }
 warg-crypto = { path = "crates/crypto", version = "0.1.0" }
 warg-protobuf = { path = "proto", version = "0.1.0" }

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "warg-api"
 description = "Serializable types for the Warg registry REST API."
-version = { workspace = true }
+# TODO: set this back to the workspace version before next release
+version = "0.1.1"
 edition = { workspace = true }
 authors = { workspace = true }
 rust-version = { workspace = true }


### PR DESCRIPTION
This PR sets the `warg-api` crate version to 0.1.1.

I accidentally published a 0.1.0 placeholder crate for the `warg-api` crate, which has now been yanked.

To workaround this, `warg-api` will be at 0.1.1 and the rest of the crates will be 0.1.0 until a 0.2.0 release.