### PR TITLE
Proposed changes before release

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,29 @@ echo 'hello world' | warg run demo:simple-grep hello
 
 This should download and run the package, and print out the line `hello world` as it matches the pattern `hello`.
 
+### Resetting and clearing local data
+
+To reset local data for the default registry:
+```
+warg reset
+```
+
+To reset local data for a specific registry, such as `registry.example.com`:
+```
+warg reset --registry registry.example.com
+```
+
+To reset local data for all registries:
+```
+warg reset --all
+```
+
+To clear local content for all registries:
+```
+warg clear
+```
+
+
 ## Contributing
 
 This is a [Bytecode Alliance](https://bytecodealliance.org/) project, and

--- a/crates/api/src/v1/content.rs
+++ b/crates/api/src/v1/content.rs
@@ -1,0 +1,109 @@
+//! Types relating to the content API.
+
+pub use super::ContentSource;
+use crate::Status;
+use serde::{de::Unexpected, Deserialize, Serialize, Serializer};
+use std::{borrow::Cow, collections::HashMap};
+use thiserror::Error;
+use warg_crypto::hash::AnyHash;
+
+/// Represents a response for content digest.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContentSourcesResponse {
+    /// The content sources for the requested content digest, as well as additional
+    /// content digests imported by the requested content digest.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub content_sources: HashMap<AnyHash, Vec<ContentSource>>,
+}
+
+/// Represents a content API error.
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum ContentError {
+    /// The provided content digest was not found.
+    #[error("content digest `{0}` was not found")]
+    ContentDigestNotFound(AnyHash),
+    /// An error with a message occurred.
+    #[error("{message}")]
+    Message {
+        /// The HTTP status code.
+        status: u16,
+        /// The error message
+        message: String,
+    },
+}
+
+impl ContentError {
+    /// Returns the HTTP status code of the error.
+    pub fn status(&self) -> u16 {
+        match self {
+            Self::ContentDigestNotFound(_) => 404,
+            Self::Message { status, .. } => *status,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum EntityType {
+    ContentDigest,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(untagged, rename_all = "camelCase")]
+enum RawError<'a, T>
+where
+    T: Clone + ToOwned,
+    <T as ToOwned>::Owned: Serialize + for<'b> Deserialize<'b>,
+{
+    NotFound {
+        status: Status<404>,
+        #[serde(rename = "type")]
+        ty: EntityType,
+        id: Cow<'a, T>,
+    },
+    Message {
+        status: u16,
+        message: Cow<'a, str>,
+    },
+}
+
+impl Serialize for ContentError {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::ContentDigestNotFound(digest) => RawError::NotFound {
+                status: Status::<404>,
+                ty: EntityType::ContentDigest,
+                id: Cow::Borrowed(digest),
+            }
+            .serialize(serializer),
+            Self::Message { status, message } => RawError::Message::<()> {
+                status: *status,
+                message: Cow::Borrowed(message),
+            }
+            .serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ContentError {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        match RawError::<String>::deserialize(deserializer)? {
+            RawError::NotFound { status: _, ty, id } => match ty {
+                EntityType::ContentDigest => Ok(Self::ContentDigestNotFound(
+                    id.parse::<AnyHash>().map_err(|_| {
+                        serde::de::Error::invalid_value(Unexpected::Str(&id), &"a valid digest")
+                    })?,
+                )),
+            },
+            RawError::Message { status, message } => Ok(Self::Message {
+                status,
+                message: message.into_owned(),
+            }),
+        }
+    }
+}

--- a/crates/api/src/v1/mod.rs
+++ b/crates/api/src/v1/mod.rs
@@ -19,9 +19,9 @@ pub enum ContentSource {
         /// Optional support for HTTP Range header.
         #[serde(default, skip_serializing_if = "is_false")]
         supports_range_header: bool,
-        /// Optional content size hint in bytes.
+        /// Optional content size in bytes.
         #[serde(skip_serializing_if = "Option::is_none")]
-        size_hint: Option<u64>,
+        size: Option<u64>,
     },
 }
 

--- a/crates/api/src/v1/mod.rs
+++ b/crates/api/src/v1/mod.rs
@@ -7,7 +7,6 @@ pub mod paths;
 pub mod proof;
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 /// Represents the supported kinds of content sources.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -17,9 +16,6 @@ pub enum ContentSource {
     HttpGet {
         /// The URL of the content.
         url: String,
-        /// Optional header names and values for the request.
-        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-        headers: HashMap<String, String>,
         /// Optional support for HTTP Range header.
         #[serde(default, skip_serializing_if = "is_false")]
         supports_range_header: bool,

--- a/crates/api/src/v1/mod.rs
+++ b/crates/api/src/v1/mod.rs
@@ -16,9 +16,9 @@ pub enum ContentSource {
     HttpGet {
         /// The URL of the content.
         url: String,
-        /// Optional support for HTTP Range header.
+        /// Optional accepts for HTTP Range header.
         #[serde(default, skip_serializing_if = "is_false")]
-        supports_range_header: bool,
+        accept_ranges: bool,
         /// Optional content size in bytes.
         #[serde(skip_serializing_if = "Option::is_none")]
         size: Option<u64>,

--- a/crates/api/src/v1/mod.rs
+++ b/crates/api/src/v1/mod.rs
@@ -1,6 +1,34 @@
 //! Types representing v1 of the Warg REST API.
 
+pub mod content;
 pub mod fetch;
 pub mod package;
 pub mod paths;
 pub mod proof;
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Represents the supported kinds of content sources.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum ContentSource {
+    /// The content is located at an GET HTTP URL.
+    HttpGet {
+        /// The URL of the content.
+        url: String,
+        /// Optional header names and values for the request.
+        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        headers: HashMap<String, String>,
+        /// Optional support for HTTP Range header.
+        #[serde(default, skip_serializing_if = "is_false")]
+        supports_range_header: bool,
+        /// Optional content size in bytes.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        size: Option<u64>,
+    },
+}
+
+fn is_false(b: &bool) -> bool {
+    !b
+}

--- a/crates/api/src/v1/mod.rs
+++ b/crates/api/src/v1/mod.rs
@@ -16,10 +16,10 @@ pub enum ContentSource {
     HttpGet {
         /// The URL of the content.
         url: String,
-        /// Optional accepts for HTTP Range header.
+        /// Optional, server accepts for HTTP Range header.
         #[serde(default, skip_serializing_if = "is_false")]
         accept_ranges: bool,
-        /// Optional content size in bytes.
+        /// Optional, provides content size in bytes.
         #[serde(skip_serializing_if = "Option::is_none")]
         size: Option<u64>,
     },

--- a/crates/api/src/v1/mod.rs
+++ b/crates/api/src/v1/mod.rs
@@ -19,9 +19,9 @@ pub enum ContentSource {
         /// Optional support for HTTP Range header.
         #[serde(default, skip_serializing_if = "is_false")]
         supports_range_header: bool,
-        /// Optional content size in bytes.
+        /// Optional content size hint in bytes.
         #[serde(skip_serializing_if = "Option::is_none")]
-        size: Option<u64>,
+        size_hint: Option<u64>,
     },
 }
 

--- a/crates/api/src/v1/package.rs
+++ b/crates/api/src/v1/package.rs
@@ -18,10 +18,12 @@ pub enum UploadEndpoint {
     /// Content may be uploaded via HTTP request to the given URL.
     Http {
         /// The http method for the upload request.
+        /// Only `POST` and `PUT` methods are accepted by the client.
         method: String,
         /// The URL to POST content to.
         url: String,
         /// Optional header names and values for the upload request.
+        /// Only `authorization` and `content-type` headers are accepted by the client.
         #[serde(default, skip_serializing_if = "HashMap::is_empty")]
         headers: HashMap<String, String>,
     },

--- a/crates/api/src/v1/package.rs
+++ b/crates/api/src/v1/package.rs
@@ -41,7 +41,7 @@ pub struct MissingContent {
 #[serde(rename_all = "camelCase")]
 pub struct PublishRecordRequest<'a> {
     /// The id of the package being published.
-    pub id: Cow<'a, PackageId>,
+    pub package_id: Cow<'a, PackageId>,
     /// The publish record to add to the package log.
     pub record: Cow<'a, ProtoEnvelopeBody>,
     /// The complete set of content sources for the record.

--- a/crates/api/src/v1/paths.rs
+++ b/crates/api/src/v1/paths.rs
@@ -1,5 +1,6 @@
 //! The paths of the Warg REST API.
 
+use warg_crypto::hash::AnyHash;
 use warg_protocol::registry::{LogId, RecordId};
 
 /// The path of the "fetch logs" API.
@@ -15,6 +16,11 @@ pub fn fetch_checkpoint() -> &'static str {
 /// The path of the "publish package record" API.
 pub fn publish_package_record(log_id: &LogId) -> String {
     format!("v1/package/{log_id}/record")
+}
+
+/// The path to request download of content digest.
+pub fn content_sources(digest: &AnyHash) -> String {
+    format!("v1/content/{digest}")
 }
 
 /// The path for a package record.

--- a/crates/client/src/api.rs
+++ b/crates/client/src/api.rs
@@ -194,7 +194,7 @@ impl Client {
         let url = self.url.join(&paths::publish_package_record(log_id));
         tracing::debug!(
             "appending record to package `{id}` at `{url}`",
-            id = request.id
+            id = request.package_id
         );
 
         let response = self.client.post(url).json(&request).send().await?;

--- a/crates/client/src/api.rs
+++ b/crates/client/src/api.rs
@@ -240,23 +240,11 @@ impl Client {
             .ok_or(ClientError::AllSourcesFailed(digest.clone()))?;
 
         for source in sources {
-            let ContentSource::HttpGet { url, headers, .. } = source;
-            let headers = headers
-                .iter()
-                .map(|(k, v)| {
-                    let name = HeaderName::try_from(k).map_err(|_| {
-                        ClientError::InvalidHttpHeader(k.to_string(), v.to_string())
-                    })?;
-                    let value = HeaderValue::try_from(k).map_err(|_| {
-                        ClientError::InvalidHttpHeader(k.to_string(), v.to_string())
-                    })?;
-                    Ok((name, value))
-                })
-                .collect::<Result<HeaderMap, ClientError>>()?;
+            let ContentSource::HttpGet { url, .. } = source;
 
             tracing::debug!("downloading content `{digest}` from `{url}`");
 
-            let response = self.client.get(url).headers(headers).send().await?;
+            let response = self.client.get(url).send().await?;
             if !response.status().is_success() {
                 tracing::debug!(
                     "failed to download content `{digest}` from `{url}`: {status}",

--- a/crates/client/src/api.rs
+++ b/crates/client/src/api.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Result};
 use bytes::Bytes;
 use futures_util::{Stream, TryStreamExt};
 use reqwest::{
-    header::{HeaderMap, HeaderName, HeaderValue},
+    header::{HeaderMap, HeaderValue},
     Body, IntoUrl, Method, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
@@ -347,8 +347,11 @@ impl Client {
         let headers = headers
             .iter()
             .map(|(k, v)| {
-                let name = HeaderName::try_from(k)
-                    .map_err(|_| ClientError::InvalidHttpHeader(k.to_string(), v.to_string()))?;
+                let name = match k.as_str() {
+                    "authorization" => reqwest::header::AUTHORIZATION,
+                    "content-type" => reqwest::header::CONTENT_TYPE,
+                    _ => return Err(ClientError::InvalidHttpHeader(k.to_string(), v.to_string())),
+                };
                 let value = HeaderValue::try_from(k)
                     .map_err(|_| ClientError::InvalidHttpHeader(k.to_string(), v.to_string()))?;
                 Ok((name, value))

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -162,7 +162,7 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
             .publish_package_record(
                 &log_id,
                 PublishRecordRequest {
-                    id: Cow::Borrowed(&package.id),
+                    package_id: Cow::Borrowed(&package.id),
                     record: Cow::Owned(record.into()),
                     content_sources: Default::default(),
                 },

--- a/crates/client/src/storage.rs
+++ b/crates/client/src/storage.rs
@@ -29,6 +29,9 @@ pub use fs::*;
 /// multiple threads and processes.
 #[async_trait]
 pub trait RegistryStorage: Send + Sync {
+    /// Reset registry local data
+    async fn reset(&self, all_registries: bool) -> Result<()>;
+
     /// Loads most recent checkpoint
     async fn load_checkpoint(&self) -> Result<Option<SerdeEnvelope<TimestampedCheckpoint>>>;
 
@@ -74,6 +77,9 @@ pub trait RegistryStorage: Send + Sync {
 /// multiple threads and processes.
 #[async_trait]
 pub trait ContentStorage: Send + Sync {
+    /// Clear content local data
+    async fn clear(&self) -> Result<()>;
+
     /// Gets the location of the content associated with the given digest if it
     /// exists as a file on disk.
     ///

--- a/crates/protocol/src/registry.rs
+++ b/crates/protocol/src/registry.rs
@@ -142,9 +142,9 @@ impl PackageId {
     pub fn new(id: impl Into<String>) -> anyhow::Result<Self> {
         let id = id.into();
 
-        if let Some(colon) = id.find(':') {
+        if let Some(colon) = id.rfind(':') {
             // Validate the namespace and name parts are valid kebab strings
-            if KebabStr::new(&id[..colon]).is_some() && KebabStr::new(&id[colon + 1..]).is_some() {
+            if KebabStr::new(&id[colon + 1..]).is_some() && Self::is_valid_namespace(&id[..colon]) {
                 return Ok(Self { id, colon });
             }
         }
@@ -160,6 +160,16 @@ impl PackageId {
     /// Gets the name part of the package identifier.
     pub fn name(&self) -> &str {
         &self.id[self.colon + 1..]
+    }
+
+    /// Check if string is a valid namespace.
+    pub fn is_valid_namespace(namespace: &str) -> bool {
+        const SUPPORTS_NESTED_NAMESPACES: bool = false;
+        if SUPPORTS_NESTED_NAMESPACES {
+            namespace.split(':').all(|s| KebabStr::new(s).is_some())
+        } else {
+            KebabStr::new(namespace).is_some()
+        }
     }
 }
 

--- a/crates/protocol/src/registry.rs
+++ b/crates/protocol/src/registry.rs
@@ -164,12 +164,7 @@ impl PackageId {
 
     /// Check if string is a valid namespace.
     pub fn is_valid_namespace(namespace: &str) -> bool {
-        const SUPPORTS_NESTED_NAMESPACES: bool = false;
-        if SUPPORTS_NESTED_NAMESPACES {
-            namespace.split(':').all(|s| KebabStr::new(s).is_some())
-        } else {
-            KebabStr::new(namespace).is_some()
-        }
+        KebabStr::new(namespace).is_some()
     }
 }
 

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -896,9 +896,9 @@ components:
         supportsRangeHeader:
           type: boolean
           description: Flag indicating if the server URL supports Range header.
-        size:
+        sizeHint:
           type: integer
-          description: Content size in bytes.
+          description: Content size hint in bytes.
           example: 1024
     PackageNotIncludedError:
       type: object

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -23,6 +23,8 @@ tags:
     description: API for fetching checkpoints and logs from the registry.
   - name: package
     description: API for managing package logs in the registry.
+  - name: content
+    description: API for content sources in the registry.
   - name: proof
     description: API for proving the integrity of the registry.
 
@@ -40,10 +42,6 @@ paths:
         - fetch
       description: |
         Fetch the operator and packages logs from the registry.
-
-        TODO: document operator record format.
-
-        TODO: document package record format.
       requestBody:
         required: true
         content:
@@ -94,7 +92,7 @@ paths:
                 $ref: "#/components/schemas/Error"
   /package/{logId}/record:
     post:
-      summary: Publish a new record to a package log.
+      summary: Publish package record
       operationId: publishPackageRecord
       security: []
       tags:
@@ -105,8 +103,6 @@ paths:
         Publishing package records is an asynchronous operation.
 
         The record must be signed by a key that is authorized to modify the package log.
-
-        TODO: document package record format.
       parameters:
         - name: logId
           in: path
@@ -150,21 +146,19 @@ paths:
                 $ref: "#/components/schemas/Error"
   /package/{logId}/record/{recordId}:
     get:
-      summary: Get a package record.
+      summary: Get package record status
       operationId: getPackageRecord
       security: []
       tags:
         - package
       description: |
-        Gets a package record from the registry.
+        Gets package record status from the registry.
 
         A package record is in one of the following states:
           * `sourcing`: The package record needs content sources.
           * `processing`: The package record is being processed.
           * `rejected`: The package record was rejected.
           * `published`: The package record was published to the log.
-
-        TODO: document package record format.
       parameters:
         - name: logId
           in: path
@@ -216,54 +210,35 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  /package/{logId}/record/{recordId}/content/{digest}:
-    post:
-      summary: Post content for a package record.
-      operationId: postPackageRecordContent
+  /content/{digest}:
+    get:
+      summary: Get content sources
+      operationId: getContentSources
       security: []
       tags:
-        - package
+        - content
       description: |
-        Posts package record content directly to the registry.
-
-        The package record must be in the `sourcing` state and the digest of the uploaded
-        content must match the digest parameter.
+        Gets a content sources for the given digest from the registry.
       parameters:
-        - name: logId
-          in: path
-          description: The package log identifier.
-          required: true
-          schema:
-            "$ref": "#/components/schemas/AnyHash"
-        - name: recordId
-          in: path
-          description: The record identifier.
-          required: true
-          schema:
-            "$ref": "#/components/schemas/AnyHash"
         - name: digest
           in: path
-          description: The digest of the content being uploaded.
+          description: The content digest.
           required: true
           schema:
             "$ref": "#/components/schemas/AnyHash"
-      requestBody:
-        content:
-          application/octet-stream:
-            schema:
-              type: string
-              format: binary
-              maxLength: 1073741824 # 1 GiB limit
+        - name: X-Proxy-Registry
+          in: header
+          description: The proxy registry URI Authority context to evaluate the request instead of the current registry.
+          required: false
+          schema:
+            type: string
       responses:
-        "201":
-          description: The content was successfully uploaded.
-          headers:
-            Location:
-              description: The URL for accessing the uploaded content.
+        "200":
+          description: The content digest sources.
+          content:
+            application/json:
               schema:
-                type: string
-                format: uri
-                example: https://example.com/content/sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
+                "$ref": "#/components/schemas/ContentSourcesResponse"
         "404":
           description: A requested entity was not found.
           content:
@@ -283,30 +258,12 @@ paths:
                   type:
                     type: string
                     description: The type of entity that was not found.
-                    enum: [log, record]
-                    example: log
+                    enum: [contentDigest]
+                    example: contentDigest
                   id:
                     "$ref": "#/components/schemas/AnyHash"
                     description: |
                       The identifier of the entity that was not found.
-        "405":
-          description: The package record is not in the `sourcing` state.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-              example:
-                status: 405
-                message: the package record is not in the `sourcing` state
-        "422":
-          description: The content was rejected by server policy.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-              example:
-                status: 422
-                message: the content is not valid WebAssembly
         default:
           description: An error occurred when processing the request.
           content:
@@ -315,7 +272,7 @@ paths:
                 $ref: "#/components/schemas/Error"
   /proof/consistency:
     post:
-      summary: Prove registry checkpoint consistency.
+      summary: Prove registry checkpoint consistency
       operationId: proveConsistency
       security: []
       tags:
@@ -377,7 +334,7 @@ paths:
                 $ref: "#/components/schemas/Error"
   /proof/inclusion:
     post:
-      summary: Prove log leaf inclusion.
+      summary: Prove log leaf inclusion
       operationId: proveInclusion
       security: []
       tags:
@@ -579,9 +536,9 @@ components:
       allOf:
         - type: object
           required:
-            - id
+            - recordId
           properties:
-            id:
+            recordId:
               "$ref": "#/components/schemas/AnyHash"
               description: The record identifier.
         - oneOf:
@@ -710,7 +667,6 @@ components:
       required:
         - state
         - registryIndex
-        - record
       properties:
         state:
           type: string
@@ -720,12 +676,6 @@ components:
         registryIndex:
           type: integer
           description: The index of the record in the registry log.
-        record:
-          "$ref": "#/components/schemas/EnvelopeBody"
-          description: The package record.
-        contentSources:
-          "$ref": "#/components/schemas/ContentSourceMap"
-          description: The content sources for the package record.
     Checkpoint:
       type: object
       description: |
@@ -847,8 +797,9 @@ components:
       example:
         ? "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded9773"
         : upload:
-            - type: httpPost
-              url: https://example.com/7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded9773
+            - type: http
+              method: "POST"
+              url: "https://example.com/7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded9773"
     MissingContent:
       description: Information about missing content.
       properties:
@@ -857,25 +808,51 @@ components:
           type: array 
           items:
             oneOf:
-              - "$ref": "#/components/schemas/HttpPostUpload"
+              - "$ref": "#/components/schemas/HttpUpload"
             discriminator:
               propertyName: type
               mapping:
-                httpPost: "#/components/schemas/HttpPostUpload"
-    HttpPostUpload:
+                httpPost: "#/components/schemas/HttpUpload"
+    HttpUpload:
       type: object
-      description: A HTTP POST upload endpoint.
+      description: A HTTP upload endpoint.
+      required:
+        - type
+        - method
+        - url
       properties:
         type:
           type: string
           description: The type of upload endpoint.
-          enum: [httpPost]
-          example: httpPost
+          enum: [http]
+          example: http
+        method:
+          type: string
+          description: The HTTP method for the upload request. Uppercase is required.
+          enum: [POST, PUT]
+          example: POST
         url:
           type: string
           description: The URL of the upload endpoint, which may be relative to the API base URL.
           example: https://example.com/contents.wasm
           format: uri
+        headers:
+          type: object
+          description: The HTTP headers for upload request.
+          additionalProperties:
+            type: string
+            description: The HTTP header value.
+          example:
+            authorization: Bearer asdf
+    ContentSourcesResponse:
+      type: object
+      description: Content digest sources for download.
+      required:
+        - contentSources
+      properties:
+        contentSources:
+          "$ref": "#/components/schemas/ContentSourceMap"
+          description: The content sources for the content digest.
     ContentSourceMap:
       type: object
       description: The map of content digest to sources.
@@ -894,14 +871,17 @@ components:
     ContentSource:
       description: A known content source.
       oneOf:
-        - "$ref": "#/components/schemas/HttpSource"
+        - "$ref": "#/components/schemas/HttpGet"
       discriminator:
         propertyName: type
         mapping:
-          http: "#/components/schemas/HttpSource"
-    HttpSource:
+          http: "#/components/schemas/HttpGet"
+    HttpGet:
       type: object
-      description: A known HTTP content source.
+      description: A known GET HTTP content source.
+      required:
+        - type
+        - url
       properties:
         type:
           type: string
@@ -913,6 +893,21 @@ components:
           description: The URL of the content.
           example: https://example.com/contents.wasm
           format: uri
+        headers:
+          type: object
+          description: The HTTP headers for upload request.
+          additionalProperties:
+            type: string
+            description: The HTTP header value.
+          example:
+            authorization: Bearer asdf
+        supportsRangeHeader:
+          type: boolean
+          description: Flag indicating if the server URL supports Range header.
+        size:
+          type: integer
+          description: Content size in bytes.
+          example: 1024
     PackageNotIncludedError:
       type: object
       additionalProperties: false

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -893,14 +893,6 @@ components:
           description: The URL of the content.
           example: https://example.com/contents.wasm
           format: uri
-        headers:
-          type: object
-          description: The HTTP headers for upload request.
-          additionalProperties:
-            type: string
-            description: The HTTP header value.
-          example:
-            authorization: Bearer asdf
         supportsRangeHeader:
           type: boolean
           description: Flag indicating if the server URL supports Range header.

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -866,7 +866,7 @@ components:
           maxItems: 128
       example:
         ? "sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded9773"
-        : - type: http
+        : - type: httpGet
             url: https://example.com/7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded9773
     ContentSource:
       description: A known content source.
@@ -875,7 +875,7 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          http: "#/components/schemas/HttpGet"
+          httpGet: "#/components/schemas/HttpGet"
     HttpGet:
       type: object
       description: A known GET HTTP content source.
@@ -886,8 +886,8 @@ components:
         type:
           type: string
           description: The type of content source.
-          enum: [http]
-          example: http
+          enum: [httpGet]
+          example: httpGet
         url:
           type: string
           description: The URL of the content.

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -900,9 +900,9 @@ components:
         supportsRangeHeader:
           type: boolean
           description: Flag indicating if the server URL supports Range header.
-        sizeHint:
+        size:
           type: integer
-          description: Content size hint in bytes.
+          description: Content size in bytes.
           example: 1024
     PackageNotIncludedError:
       type: object

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -812,7 +812,7 @@ components:
             discriminator:
               propertyName: type
               mapping:
-                httpPost: "#/components/schemas/HttpUpload"
+                http: "#/components/schemas/HttpUpload"
     HttpUpload:
       type: object
       description: A HTTP upload endpoint.

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -226,12 +226,6 @@ paths:
           required: true
           schema:
             "$ref": "#/components/schemas/AnyHash"
-        - name: X-Proxy-Registry
-          in: header
-          description: The proxy registry URI Authority context to evaluate the request instead of the current registry.
-          required: false
-          schema:
-            type: string
       responses:
         "200":
           description: The content digest sources.

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -505,10 +505,10 @@ components:
       description: A request to publish a record to a package log.
       additionalProperties: false
       required:
-        - id
+        - packageId
         - record
       properties:
-        id:
+        packageId:
           type: string
           description: The name of the package log being published to.
           maxLength: 128

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -838,12 +838,16 @@ components:
           format: uri
         headers:
           type: object
-          description: The HTTP headers for upload request.
-          additionalProperties:
-            type: string
-            description: The HTTP header value.
-          example:
-            authorization: Bearer asdf
+          description: The HTTP headers for upload request. Header name is required to be all lowercase.
+          properties:
+            authorization:
+              type: string
+              description: Authorization header.
+              example: "Bearer cn389ncoiwuencr"
+            "content-type":
+              type: string
+              description: Content type header.
+              example: "application/wasm"
     ContentSourcesResponse:
       type: object
       description: Content digest sources for download.

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -891,9 +891,9 @@ components:
           description: The URL of the content.
           example: https://example.com/contents.wasm
           format: uri
-        supportsRangeHeader:
+        acceptRanges:
           type: boolean
-          description: Flag indicating if the server URL supports Range header.
+          description: Flag indicating if the server accepts byte ranges with `Range` header.
         size:
           type: integer
           description: Content size in bytes.

--- a/crates/server/src/api/v1/content.rs
+++ b/crates/server/src/api/v1/content.rs
@@ -73,7 +73,7 @@ async fn get_content(
         vec![ContentSource::HttpGet {
             url,
             supports_range_header: false,
-            size: None,
+            size_hint: None,
         }],
     );
 

--- a/crates/server/src/api/v1/content.rs
+++ b/crates/server/src/api/v1/content.rs
@@ -1,0 +1,82 @@
+use super::{Json, Path};
+use axum::{
+    debug_handler, extract::State, http::StatusCode, response::IntoResponse, routing::get, Router,
+};
+use std::{collections::HashMap, path::PathBuf};
+use url::Url;
+use warg_api::v1::content::{ContentError, ContentSource, ContentSourcesResponse};
+use warg_crypto::hash::AnyHash;
+
+#[derive(Clone)]
+pub struct Config {
+    content_base_url: Url,
+    files_dir: PathBuf,
+}
+
+impl Config {
+    pub fn new(content_base_url: Url, files_dir: PathBuf) -> Self {
+        Self {
+            content_base_url,
+            files_dir,
+        }
+    }
+
+    pub fn into_router(self) -> Router {
+        Router::new()
+            .route("/:digest", get(get_content))
+            .with_state(self)
+    }
+
+    fn content_present(&self, digest: &AnyHash) -> bool {
+        self.content_path(digest).is_file()
+    }
+
+    fn content_file_name(&self, digest: &AnyHash) -> String {
+        digest.to_string().replace(':', "-")
+    }
+
+    fn content_path(&self, digest: &AnyHash) -> PathBuf {
+        self.files_dir.join(self.content_file_name(digest))
+    }
+
+    fn content_url(&self, digest: &AnyHash) -> String {
+        self.content_base_url
+            .join("content/")
+            .unwrap()
+            .join(&self.content_file_name(digest))
+            .unwrap()
+            .to_string()
+    }
+}
+
+struct ContentApiError(ContentError);
+
+impl IntoResponse for ContentApiError {
+    fn into_response(self) -> axum::response::Response {
+        (StatusCode::from_u16(self.0.status()).unwrap(), Json(self.0)).into_response()
+    }
+}
+
+#[debug_handler]
+async fn get_content(
+    State(config): State<Config>,
+    Path(digest): Path<AnyHash>,
+) -> Result<Json<ContentSourcesResponse>, ContentApiError> {
+    if !config.content_present(&digest) {
+        return Err(ContentApiError(ContentError::ContentDigestNotFound(digest)));
+    }
+
+    let mut content_sources = HashMap::with_capacity(1);
+    let url = config.content_url(&digest);
+    content_sources.insert(
+        digest,
+        vec![ContentSource::HttpGet {
+            url,
+            headers: HashMap::new(),
+            supports_range_header: false,
+            size: None,
+        }],
+    );
+
+    Ok(Json(ContentSourcesResponse { content_sources }))
+}

--- a/crates/server/src/api/v1/content.rs
+++ b/crates/server/src/api/v1/content.rs
@@ -72,7 +72,7 @@ async fn get_content(
         digest,
         vec![ContentSource::HttpGet {
             url,
-            supports_range_header: false,
+            accept_ranges: false,
             size: None,
         }],
     );

--- a/crates/server/src/api/v1/content.rs
+++ b/crates/server/src/api/v1/content.rs
@@ -73,7 +73,7 @@ async fn get_content(
         vec![ContentSource::HttpGet {
             url,
             supports_range_header: false,
-            size_hint: None,
+            size: None,
         }],
     );
 

--- a/crates/server/src/api/v1/content.rs
+++ b/crates/server/src/api/v1/content.rs
@@ -72,7 +72,6 @@ async fn get_content(
         digest,
         vec![ContentSource::HttpGet {
             url,
-            headers: HashMap::new(),
             supports_range_header: false,
             size: None,
         }],

--- a/crates/server/src/api/v1/mod.rs
+++ b/crates/server/src/api/v1/mod.rs
@@ -16,6 +16,7 @@ use serde::{Serialize, Serializer};
 use std::{path::PathBuf, sync::Arc};
 use url::Url;
 
+pub mod content;
 pub mod fetch;
 pub mod package;
 pub mod proof;
@@ -100,16 +101,17 @@ pub fn create_router(
     let proof_config = proof::Config::new(core.clone());
     let package_config = package::Config::new(
         core.clone(),
-        content_base_url,
-        files_dir,
+        files_dir.clone(),
         temp_dir,
         content_policy,
         record_policy,
     );
     let fetch_config = fetch::Config::new(core);
+    let content_config = content::Config::new(content_base_url, files_dir);
 
     Router::new()
         .nest("/package", package_config.into_router())
+        .nest("/content", content_config.into_router())
         .nest("/fetch", fetch_config.into_router())
         .nest("/proof", proof_config.into_router())
         .fallback(not_found)

--- a/crates/server/src/api/v1/package.rs
+++ b/crates/server/src/api/v1/package.rs
@@ -20,10 +20,9 @@ use std::sync::Arc;
 use std::{collections::HashMap, path::PathBuf};
 use tempfile::NamedTempFile;
 use tokio::io::AsyncWriteExt;
-use url::Url;
 use warg_api::v1::package::{
-    ContentSource, MissingContent, PackageError, PackageRecord, PackageRecordState,
-    PublishRecordRequest, UploadEndpoint,
+    MissingContent, PackageError, PackageRecord, PackageRecordState, PublishRecordRequest,
+    UploadEndpoint,
 };
 use warg_crypto::hash::{AnyHash, Sha256};
 use warg_protocol::{
@@ -35,7 +34,6 @@ use warg_protocol::{
 #[derive(Clone)]
 pub struct Config {
     core_service: CoreService,
-    content_base_url: Url,
     files_dir: PathBuf,
     temp_dir: PathBuf,
     content_policy: Option<Arc<dyn ContentPolicy>>,
@@ -45,7 +43,6 @@ pub struct Config {
 impl Config {
     pub fn new(
         core_service: CoreService,
-        content_base_url: Url,
         files_dir: PathBuf,
         temp_dir: PathBuf,
         content_policy: Option<Arc<dyn ContentPolicy>>,
@@ -53,7 +50,6 @@ impl Config {
     ) -> Self {
         Self {
             core_service,
-            content_base_url,
             files_dir,
             temp_dir,
             content_policy,
@@ -84,15 +80,6 @@ impl Config {
         self.files_dir.join(self.content_file_name(digest))
     }
 
-    fn content_url(&self, digest: &AnyHash) -> String {
-        self.content_base_url
-            .join("content/")
-            .unwrap()
-            .join(&self.content_file_name(digest))
-            .unwrap()
-            .to_string()
-    }
-
     fn build_missing_content<'a>(
         &self,
         log_id: &LogId,
@@ -106,7 +93,11 @@ impl Config {
                 (
                     digest.clone(),
                     MissingContent {
-                        upload: vec![UploadEndpoint::HttpPost { url }],
+                        upload: vec![UploadEndpoint::Http {
+                            method: "POST".to_string(),
+                            url,
+                            headers: HashMap::new(),
+                        }],
                     },
                 )
             })
@@ -246,7 +237,7 @@ async fn publish_record(
         return Ok((
             StatusCode::ACCEPTED,
             Json(PackageRecord {
-                id: record_id,
+                record_id,
                 state: PackageRecordState::Processing,
             }),
         ));
@@ -256,7 +247,7 @@ async fn publish_record(
     Ok((
         StatusCode::ACCEPTED,
         Json(PackageRecord {
-            id: record_id,
+            record_id,
             state: PackageRecordState::Sourcing { missing_content },
         }),
     ))
@@ -277,44 +268,25 @@ async fn get_record(
         RecordStatus::MissingContent(missing) => {
             let missing_content = config.build_missing_content(&log_id, &record_id, &missing);
             Ok(Json(PackageRecord {
-                id: record_id,
+                record_id,
                 state: PackageRecordState::Sourcing { missing_content },
             }))
         }
         // Validated is considered still processing until included in a checkpoint
         RecordStatus::Pending | RecordStatus::Validated => Ok(Json(PackageRecord {
-            id: record_id,
+            record_id,
             state: PackageRecordState::Processing,
         })),
         RecordStatus::Rejected(reason) => Ok(Json(PackageRecord {
-            id: record_id,
+            record_id,
             state: PackageRecordState::Rejected { reason },
         })),
         RecordStatus::Published => {
-            let content_sources = record
-                .envelope
-                .as_ref()
-                .contents()
-                .into_iter()
-                .map(|digest| {
-                    (
-                        digest.clone(),
-                        vec![ContentSource::Http {
-                            url: config.content_url(digest),
-                        }],
-                    )
-                })
-                .collect();
-
             let registry_index = record.registry_index.unwrap();
 
             Ok(Json(PackageRecord {
-                id: record_id,
-                state: PackageRecordState::Published {
-                    record: record.envelope.into(),
-                    registry_index,
-                    content_sources,
-                },
+                record_id,
+                state: PackageRecordState::Published { registry_index },
             }))
         }
     }
@@ -388,10 +360,7 @@ async fn upload_content(
             .await;
     }
 
-    Ok((
-        StatusCode::CREATED,
-        [(axum::http::header::LOCATION, config.content_url(&digest))],
-    ))
+    Ok(StatusCode::CREATED)
 }
 
 async fn process_content(

--- a/src/bin/warg.rs
+++ b/src/bin/warg.rs
@@ -3,8 +3,8 @@ use clap::Parser;
 use std::process::exit;
 use tracing_subscriber::EnvFilter;
 use warg_cli::commands::{
-    ConfigCommand, DownloadCommand, InfoCommand, KeyCommand, PublishCommand, RunCommand,
-    UpdateCommand,
+    ClearCommand, ConfigCommand, DownloadCommand, InfoCommand, KeyCommand, PublishCommand,
+    ResetCommand, RunCommand, UpdateCommand,
 };
 use warg_client::ClientError;
 
@@ -29,6 +29,8 @@ enum WargCli {
     Update(UpdateCommand),
     #[clap(subcommand)]
     Publish(PublishCommand),
+    Reset(ResetCommand),
+    Clear(ClearCommand),
     Run(RunCommand),
 }
 
@@ -45,6 +47,8 @@ async fn main() -> Result<()> {
         WargCli::Download(cmd) => cmd.exec().await,
         WargCli::Update(cmd) => cmd.exec().await,
         WargCli::Publish(cmd) => cmd.exec().await,
+        WargCli::Reset(cmd) => cmd.exec().await,
+        WargCli::Clear(cmd) => cmd.exec().await,
         WargCli::Run(cmd) => cmd.exec().await,
     } {
         if let Some(e) = e.downcast_ref::<ClientError>() {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -8,21 +8,25 @@ use warg_client::RegistryUrl;
 use warg_client::{ClientError, Config, FileSystemClient, StorageLockResult};
 use warg_crypto::signing::PrivateKey;
 
+mod clear;
 mod config;
 mod download;
 mod info;
 mod key;
 mod publish;
+mod reset;
 mod run;
 mod update;
 
 use crate::keyring::get_signing_key;
 
+pub use self::clear::*;
 pub use self::config::*;
 pub use self::download::*;
 pub use self::info::*;
 pub use self::key::*;
 pub use self::publish::*;
+pub use self::reset::*;
 pub use self::run::*;
 pub use self::update::*;
 

--- a/src/commands/clear.rs
+++ b/src/commands/clear.rs
@@ -1,0 +1,23 @@
+use super::CommonOptions;
+use anyhow::Result;
+use clap::Args;
+
+/// Deletes local content cache.
+#[derive(Args)]
+pub struct ClearCommand {
+    /// The common command options.
+    #[clap(flatten)]
+    pub common: CommonOptions,
+}
+
+impl ClearCommand {
+    /// Executes the command.
+    pub async fn exec(self) -> Result<()> {
+        let config = self.common.read_config()?;
+        let client = self.common.create_client(&config)?;
+
+        println!("clearing local content cache...");
+        client.clear_content_cache().await?;
+        Ok(())
+    }
+}

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -1,0 +1,32 @@
+use super::CommonOptions;
+use anyhow::Result;
+use clap::Args;
+
+/// Reset local data for registry.
+#[derive(Args)]
+pub struct ResetCommand {
+    /// The common command options.
+    #[clap(flatten)]
+    pub common: CommonOptions,
+    /// Whether to reset all registries.
+    #[clap(long)]
+    pub all: bool,
+}
+
+impl ResetCommand {
+    /// Executes the command.
+    pub async fn exec(self) -> Result<()> {
+        let config = self.common.read_config()?;
+        let client = self.common.create_client(&config)?;
+
+        if self.all {
+            println!("resetting local data for all registries...");
+            client.reset_registry(true).await?;
+        } else {
+            println!("resetting local data for registry `{}`...", client.url());
+            client.reset_registry(false).await?;
+        }
+
+        Ok(())
+    }
+}

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -355,7 +355,7 @@ async fn test_invalid_signature(config: &Config) -> Result<()> {
     )?;
 
     let body = PublishRecordRequest {
-        id: Cow::Borrowed(&id),
+        package_id: Cow::Borrowed(&id),
         record: Cow::Owned(ProtoEnvelopeBody::from(record)),
         content_sources: Default::default(),
     };


### PR DESCRIPTION
Proposed breaking changes to the API:
1. `GET /v1/content/{digest}` endpoint instead of `GET /v1/package/{logId}/record/{recordId}` for getting content source download URLs;
  Current API is not ideal, since records can have multiple releases which provides more download links than clients likely want. Also, when Wasm naked imports are implemented, this new endpoint could more cleanly be extended to provide the dependency URLs for each digest.
2. Upload HTTP URLs can now specific the `method` and `headers`, so that can use `POST` or `PUT` as well as `Authorization` and `Content-Type` headers; In the future, it would be helpful to add multipart upload support for large files as a new variant type;
3. Download HTTP URLs can specify whether the `Range` header is supported to download pieces of large files in parallel; Optional `sizeHint` field is provided to hint at the expected file size; (Although client doesn't yet take advantage of this functionality.)

Proposed additive changes:
4. Added `warg reset` command to reset local registry state (clearing package logs etc);
5. Added `warg clear` command to clear local cache of downloaded content;

Also, there's a fix so that the client CLI verifies the `TimestampedCheckpoint` signature when updating checkpoints. I'm pretty sure it was not verifying the signature before.