### PR TITLE
missing serde rename for camelCase on the enum variants

### DIFF
--- a/crates/api/src/v1/mod.rs
+++ b/crates/api/src/v1/mod.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum ContentSource {
     /// The content can be retrieved with an HTTP GET.
+    #[serde(rename_all = "camelCase")]
     HttpGet {
         /// The URL of the content.
         url: String,

--- a/crates/api/src/v1/mod.rs
+++ b/crates/api/src/v1/mod.rs
@@ -18,7 +18,13 @@ pub enum ContentSource {
         /// The URL of the content.
         url: String,
         /// Optional, server accepts for HTTP Range header.
-        #[serde(default, skip_serializing_if = "is_false")]
+        /// TODO remove rename, see issue: https://github.com/bytecodealliance/registry/issues/221
+        #[serde(
+            default,
+            skip_serializing_if = "is_false",
+            rename = "accept_ranges",
+            alias = "acceptRanges"
+        )]
         accept_ranges: bool,
         /// Optional, provides content size in bytes.
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/api/src/v1/package.rs
+++ b/crates/api/src/v1/package.rs
@@ -16,6 +16,7 @@ use warg_protocol::{
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum UploadEndpoint {
     /// Content may be uploaded via HTTP request to the given URL.
+    #[serde(rename_all = "camelCase")]
     Http {
         /// The http method for the upload request.
         /// Only `POST` and `PUT` methods are supported.


### PR DESCRIPTION
`rename_all` as an attribute on an enum is renaming all the variants of the enum, not all the fields of those variants

https://github.com/bytecodealliance/registry/issues/221