### PR TITLE
added missing serde `rename_all` on enum variants

### DIFF
--- a/crates/api/src/v1/mod.rs
+++ b/crates/api/src/v1/mod.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum ContentSource {
     /// The content can be retrieved with an HTTP GET.
+    #[serde(rename_all = "camelCase")]
     HttpGet {
         /// The URL of the content.
         url: String,

--- a/crates/api/src/v1/package.rs
+++ b/crates/api/src/v1/package.rs
@@ -16,6 +16,7 @@ use warg_protocol::{
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum UploadEndpoint {
     /// Content may be uploaded via HTTP request to the given URL.
+    #[serde(rename_all = "camelCase")]
     Http {
         /// The http method for the upload request.
         /// Only `POST` and `PUT` methods are supported.


### PR DESCRIPTION
`rename_all` as an attribute on an enum is renaming all the variants of the enum, not all the fields of those variants