### PR TITLE
rename `PackageId` to `PackageName` on issue #229

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,15 +108,15 @@ A new package can be initialized by running:
 warg publish init example:hello
 ```
 
-This creates a new package in the `example` namespace with the package ID `hello`.
+This creates a new package in the `example` namespace with the name `hello`.
 
 A version of the package can be published by running:
 
 ```
-warg publish release --id example:hello --version 0.1.0 hello.wasm
+warg publish release --name example:hello --version 0.1.0 hello.wasm
 ```
 
-This publishes a package named `hello` in the `example` namespace with version `0.1.0` and content from 
+This publishes a package named `example:hello` with version `0.1.0` and content from 
 `hello.wasm`.
 
 Alternatively, the above can be batched into a single publish operation:
@@ -124,7 +124,7 @@ Alternatively, the above can be batched into a single publish operation:
 ```
 warg publish start example:hello
 warg publish init example:hello
-warg publish release --id example:hello --version 0.1.0 hello.wasm
+warg publish release --name example:hello --version 0.1.0 hello.wasm
 warg publish submit
 ```
 
@@ -140,7 +140,7 @@ Use `warg publish abort` to abort a pending publish operation.
 You can grant permissions to another public key with the `warg publish grant` subcommand:
 
 ```
-warg publish grant --id example:hello ecdsa-p256:ABC...
+warg publish grant --name example:hello ecdsa-p256:ABC...
 ```
 
 > You can get your own public key with the `warg key info` subcommand.
@@ -151,7 +151,7 @@ Similarly, permissions may be revoked via `warg publish revoke`. Note that
 keys are identified by ID (fingerprint) for revocation:
 
 ```
-warg publish revoke --id example:hello sha256:abc...
+warg publish revoke --name example:hello sha256:abc...
 ```
 
 ### Running a package
@@ -168,7 +168,7 @@ To publish the demo module:
 ```
 warg publish start demo:simple-grep
 warg publish init demo:simple-grep
-warg publish release --id demo:simple-grep --version 1.0.0 demo/simple-grep-1.0.0.wasm
+warg publish release --name demo:simple-grep --version 1.0.0 demo/simple-grep-1.0.0.wasm
 warg publish submit
 ```
 

--- a/crates/api/src/v1/fetch.rs
+++ b/crates/api/src/v1/fetch.rs
@@ -6,7 +6,7 @@ use std::{borrow::Cow, collections::HashMap};
 use thiserror::Error;
 use warg_crypto::hash::AnyHash;
 use warg_protocol::{
-    registry::{LogId, PackageId, RegistryLen},
+    registry::{LogId, PackageName, RegistryLen},
     PublishedProtoEnvelopeBody,
 };
 
@@ -67,8 +67,8 @@ pub struct FetchPackageNamesRequest<'a> {
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FetchPackageNamesResponse {
-    /// The log ID hash mapping to a package ID. If `None`, the package name cannot be provided.
-    pub packages: HashMap<LogId, Option<PackageId>>,
+    /// The log ID hash mapping to a package name. If `None`, the package name cannot be provided.
+    pub packages: HashMap<LogId, Option<PackageName>>,
 }
 
 /// Represents a fetch API error.

--- a/crates/api/src/v1/package.rs
+++ b/crates/api/src/v1/package.rs
@@ -7,7 +7,7 @@ use std::{borrow::Cow, collections::HashMap};
 use thiserror::Error;
 use warg_crypto::hash::AnyHash;
 use warg_protocol::{
-    registry::{LogId, PackageId, RecordId, RegistryIndex},
+    registry::{LogId, PackageName, RecordId, RegistryIndex},
     ProtoEnvelopeBody,
 };
 
@@ -42,8 +42,9 @@ pub struct MissingContent {
 #[serde(rename_all = "camelCase")]
 pub struct PublishRecordRequest<'a> {
     /// The package name being published.
-    #[serde(alias = "packageName")]
-    pub package_id: Cow<'a, PackageId>,
+    /// TODO: Remove the alias for `packageId` according to compatibility release schedule.
+    #[serde(alias = "packageId")]
+    pub package_name: Cow<'a, PackageName>,
     /// The publish record to add to the package log.
     pub record: Cow<'a, ProtoEnvelopeBody>,
     /// The complete set of content sources for the record.
@@ -132,7 +133,7 @@ pub enum PackageError {
     NamespaceConflict(String),
     /// The provided package name conflicts with an existing package where the name only differs by case.
     #[error("the package conflicts with existing package name `{0}`; package names must be unique in a case insensitive way")]
-    PackageNameConflict(PackageId),
+    PackageNameConflict(PackageName),
     /// The operation was not authorized by the registry.
     #[error("unauthorized operation: {0}")]
     Unauthorized(String),
@@ -325,7 +326,7 @@ impl<'de> Deserialize<'de> for PackageError {
                 EntityType::Namespace => Ok(Self::NamespaceConflict(id.into_owned())),
                 EntityType::NamespaceImport => Ok(Self::NamespaceImported(id.into_owned())),
                 EntityType::Name => Ok(Self::PackageNameConflict(
-                    PackageId::new(id.into_owned()).unwrap(),
+                    PackageName::new(id.into_owned()).unwrap(),
                 )),
                 _ => Err(serde::de::Error::invalid_value(
                     Unexpected::Enum,

--- a/crates/client/src/api.rs
+++ b/crates/client/src/api.rs
@@ -237,8 +237,8 @@ impl Client {
     ) -> Result<PackageRecord, ClientError> {
         let url = self.url.join(&paths::publish_package_record(log_id));
         tracing::debug!(
-            "appending record to package `{id}` at `{url}`",
-            id = request.package_id
+            "appending record to package `{name}` at `{url}`",
+            name = request.package_name
         );
 
         let response = self.client.post(url).json(&request).send().await?;

--- a/crates/client/src/storage.rs
+++ b/crates/client/src/storage.rs
@@ -13,7 +13,7 @@ use warg_crypto::{
 use warg_protocol::{
     operator,
     package::{self, PackageRecord, Permission, PACKAGE_RECORD_VERSION},
-    registry::{Checkpoint, PackageId, RecordId, RegistryIndex, TimestampedCheckpoint},
+    registry::{Checkpoint, PackageName, RecordId, RegistryIndex, TimestampedCheckpoint},
     ProtoEnvelope, SerdeEnvelope, Version,
 };
 
@@ -55,7 +55,7 @@ pub trait RegistryStorage: Send + Sync {
     /// Loads the package information from the storage.
     ///
     /// Returns `Ok(None)` if the information is not present.
-    async fn load_package(&self, package: &PackageId) -> Result<Option<PackageInfo>>;
+    async fn load_package(&self, package: &PackageName) -> Result<Option<PackageInfo>>;
 
     /// Stores the package information in the storage.
     async fn store_package(&self, info: &PackageInfo) -> Result<()>;
@@ -127,8 +127,10 @@ pub struct OperatorInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PackageInfo {
-    /// The id of the package to publish.
-    pub id: PackageId,
+    /// The package name to publish.
+    /// TODO: drop alias after sufficient time according to release policy.
+    #[serde(alias = "id")]
+    pub name: PackageName,
     /// The last known checkpoint of the package.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub checkpoint: Option<Checkpoint>,
@@ -144,10 +146,10 @@ pub struct PackageInfo {
 }
 
 impl PackageInfo {
-    /// Creates a new package info for the given package id.
-    pub fn new(id: impl Into<PackageId>) -> Self {
+    /// Creates a new package info for the given package name.
+    pub fn new(name: impl Into<PackageName>) -> Self {
         Self {
-            id: id.into(),
+            name: name.into(),
             checkpoint: None,
             state: package::LogState::default(),
             head_registry_index: None,
@@ -194,8 +196,10 @@ pub enum PublishEntry {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PublishInfo {
-    /// The id of the package being published.
-    pub id: PackageId,
+    /// The package name being published.
+    /// TODO: drop alias after sufficient time according to release policy.
+    #[serde(alias = "id")]
+    pub name: PackageName,
     /// The last known head of the package log to use.
     ///
     /// If `None` and the package is not being initialized,

--- a/crates/client/src/storage/fs.rs
+++ b/crates/client/src/storage/fs.rs
@@ -19,7 +19,7 @@ use tokio_util::io::ReaderStream;
 use walkdir::WalkDir;
 use warg_crypto::hash::{AnyHash, Digest, Hash, Sha256};
 use warg_protocol::{
-    registry::{LogId, PackageId, TimestampedCheckpoint},
+    registry::{LogId, PackageName, TimestampedCheckpoint},
     SerdeEnvelope,
 };
 
@@ -70,9 +70,9 @@ impl FileSystemRegistryStorage {
         self.base_dir.join("operator.log")
     }
 
-    fn package_path(&self, id: &PackageId) -> PathBuf {
+    fn package_path(&self, name: &PackageName) -> PathBuf {
         self.base_dir.join(PACKAGE_LOGS_DIR).join(
-            LogId::package_log::<Sha256>(id)
+            LogId::package_log::<Sha256>(name)
                 .to_string()
                 .replace(':', "/"),
         )
@@ -150,12 +150,12 @@ impl RegistryStorage for FileSystemRegistryStorage {
         store(&self.operator_path(), info).await
     }
 
-    async fn load_package(&self, package: &PackageId) -> Result<Option<PackageInfo>> {
+    async fn load_package(&self, package: &PackageName) -> Result<Option<PackageInfo>> {
         Ok(load(&self.package_path(package)).await?)
     }
 
     async fn store_package(&self, info: &PackageInfo) -> Result<()> {
-        store(&self.package_path(&info.id), info).await
+        store(&self.package_path(&info.name), info).await
     }
 
     async fn load_publish(&self) -> Result<Option<PublishInfo>> {

--- a/crates/protocol/src/operator/state.rs
+++ b/crates/protocol/src/operator/state.rs
@@ -1,5 +1,5 @@
 use super::{model, OPERATOR_RECORD_VERSION};
-use crate::registry::PackageId;
+use crate::registry::PackageName;
 use crate::registry::RecordId;
 use crate::ProtoEnvelope;
 use indexmap::{IndexMap, IndexSet};
@@ -411,7 +411,7 @@ impl LogState {
         namespace: &str,
         state: NamespaceState,
     ) -> Result<(), ValidationError> {
-        if !PackageId::is_valid_namespace(namespace) {
+        if !PackageName::is_valid_namespace(namespace) {
             return Err(ValidationError::InvalidNamespace {
                 namespace: namespace.to_string(),
             });

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -841,10 +841,10 @@ components:
       description: A request to publish a record to a package log.
       additionalProperties: false
       required:
-        - packageId
+        - packageName
         - record
       properties:
-        packageId:
+        packageName:
           type: string
           description: The name of the package log being published to.
           maxLength: 128

--- a/crates/server/src/datastore/mod.rs
+++ b/crates/server/src/datastore/mod.rs
@@ -11,7 +11,7 @@ use warg_crypto::{
 use warg_protocol::{
     operator, package,
     registry::{
-        LogId, LogLeaf, PackageId, RecordId, RegistryIndex, RegistryLen, TimestampedCheckpoint,
+        LogId, LogLeaf, PackageName, RecordId, RegistryIndex, RegistryLen, TimestampedCheckpoint,
     },
     ProtoEnvelope, PublishedProtoEnvelope, SerdeEnvelope,
 };
@@ -58,8 +58,8 @@ pub enum DataStoreError {
 
     #[error("the package `{name}` conflicts with package `{existing}`; package names must be unique in a case insensitive way")]
     PackageNameConflict {
-        name: PackageId,
-        existing: PackageId,
+        name: PackageName,
+        existing: PackageName,
     },
 
     #[error("the package namespace `{namespace}` conflicts with existing namespace `{existing}`; package namespaces must be unique in a case insensitive way")]
@@ -187,7 +187,7 @@ pub trait DataStore: Send + Sync {
     async fn store_package_record(
         &self,
         log_id: &LogId,
-        package_id: &PackageId,
+        package_name: &PackageName,
         record_id: &RecordId,
         record: &ProtoEnvelope<package::PackageRecord>,
         missing: &HashSet<&AnyHash>,
@@ -262,7 +262,7 @@ pub trait DataStore: Send + Sync {
     async fn get_package_names(
         &self,
         log_ids: &[LogId],
-    ) -> Result<HashMap<LogId, Option<PackageId>>, DataStoreError>;
+    ) -> Result<HashMap<LogId, Option<PackageName>>, DataStoreError>;
 
     /// Gets a batch of log leafs starting with a registry log index.  
     async fn get_log_leafs_starting_with_registry_index(
@@ -321,7 +321,7 @@ pub trait DataStore: Send + Sync {
     async fn verify_can_publish_package(
         &self,
         operator_log_id: &LogId,
-        package_id: &PackageId,
+        package_name: &PackageName,
     ) -> Result<(), DataStoreError>;
 
     /// Verifies the TimestampedCheckpoint signature.
@@ -334,7 +334,7 @@ pub trait DataStore: Send + Sync {
     // Returns a list of package names, for debugging only.
     #[cfg(feature = "debug")]
     #[doc(hidden)]
-    async fn debug_list_package_ids(&self) -> anyhow::Result<Vec<PackageId>> {
+    async fn debug_list_package_names(&self) -> anyhow::Result<Vec<PackageName>> {
         anyhow::bail!("not implemented")
     }
 }

--- a/crates/server/src/policy/record/mod.rs
+++ b/crates/server/src/policy/record/mod.rs
@@ -1,6 +1,6 @@
 //! Module for server record policy implementations.
 use thiserror::Error;
-use warg_protocol::{package::PackageRecord, registry::PackageId, ProtoEnvelope};
+use warg_protocol::{package::PackageRecord, registry::PackageName, ProtoEnvelope};
 
 mod authorization;
 pub use authorization::*;
@@ -27,7 +27,7 @@ pub trait RecordPolicy: Send + Sync {
     /// Checks the record against the policy.
     fn check(
         &self,
-        id: &PackageId,
+        name: &PackageName,
         record: &ProtoEnvelope<PackageRecord>,
     ) -> RecordPolicyResult<()>;
 }
@@ -56,11 +56,11 @@ impl RecordPolicyCollection {
 impl RecordPolicy for RecordPolicyCollection {
     fn check(
         &self,
-        id: &PackageId,
+        name: &PackageName,
         record: &ProtoEnvelope<PackageRecord>,
     ) -> RecordPolicyResult<()> {
         for policy in &self.policies {
-            policy.check(id, record)?;
+            policy.check(name, record)?;
         }
 
         Ok(())

--- a/src/bin/warg.rs
+++ b/src/bin/warg.rs
@@ -67,11 +67,11 @@ fn describe_client_error(e: &ClientError) {
         ClientError::NoDefaultUrl => {
             eprintln!("error: {e}; use the `config` subcommand to set a default URL");
         }
-        ClientError::PackageValidationFailed { id, inner } => {
-            eprintln!("error: the log for package `{id}` is invalid: {inner}")
+        ClientError::PackageValidationFailed { name, inner } => {
+            eprintln!("error: the log for package `{name}` is invalid: {inner}")
         }
-        ClientError::PackageLogEmpty { id } => {
-            eprintln!("error: the log for package `{id}` is empty (the registry could be lying)");
+        ClientError::PackageLogEmpty { name } => {
+            eprintln!("error: the log for package `{name}` is empty (the registry could be lying)");
             eprintln!("see issue https://github.com/bytecodealliance/registry/issues/66");
         }
         _ => eprintln!("error: {e}"),

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use clap::Args;
 use warg_client::storage::{PackageInfo, RegistryStorage};
 use warg_crypto::hash::AnyHash;
-use warg_protocol::{registry::PackageId, Version};
+use warg_protocol::{registry::PackageName, Version};
 
 /// Display client storage information.
 #[derive(Args)]
@@ -14,7 +14,7 @@ pub struct InfoCommand {
 
     /// Only show information for the specified package.
     #[clap(value_name = "PACKAGE")]
-    pub package: Option<PackageId>,
+    pub package: Option<PackageName>,
 }
 
 impl InfoCommand {
@@ -45,7 +45,7 @@ impl InfoCommand {
     }
 
     fn print_package_info(info: &PackageInfo) {
-        println!("  id: {id}", id = info.id);
+        println!("  name: {name}", name = info.name);
         println!("  versions:");
         info.state.releases().for_each(|r| {
             if let Some(content) = r.content() {

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -58,11 +58,11 @@ async fn it_works_with_postgres() -> TestResult {
     test_get_ledger(&config).await?;
 
     let mut packages = vec![
-        PackageId::new("test:component")?,
-        PackageId::new("test:yankee")?,
-        PackageId::new("test:wit-package")?,
-        PackageId::new("test:unauthorized-key")?,
-        PackageId::new("test:name")?,
+        PackageName::new("test:component")?,
+        PackageName::new("test:yankee")?,
+        PackageName::new("test:wit-package")?,
+        PackageName::new("test:unauthorized-key")?,
+        PackageName::new("test:name")?,
     ];
 
     // There should be two log entries in the registry
@@ -82,7 +82,7 @@ async fn it_works_with_postgres() -> TestResult {
 
     test_unknown_signing_key(&config).await?;
 
-    packages.push(PackageId::new("test:unknown-key")?);
+    packages.push(PackageName::new("test:unknown-key")?);
 
     let client = api::Client::new(config.default_url.as_ref().unwrap())?;
     let ts_checkpoint = client.latest_checkpoint().await?;

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -17,7 +17,7 @@ use warg_crypto::{
     hash::AnyHash,
     signing::{KeyID, PrivateKey},
 };
-use warg_protocol::{operator, registry::PackageId};
+use warg_protocol::{operator, registry::PackageName};
 use warg_server::{
     datastore::DataStore,
     policy::{content::WasmContentPolicy, record::AuthorizedKeyPolicy},
@@ -170,7 +170,7 @@ pub async fn spawn_server(
 
 pub async fn publish(
     client: &FileSystemClient,
-    id: &PackageId,
+    name: &PackageName,
     version: &str,
     content: Vec<u8>,
     init: bool,
@@ -197,7 +197,7 @@ pub async fn publish(
         .publish_with_info(
             signing_key,
             PublishInfo {
-                id: id.clone(),
+                name: name.clone(),
                 head: None,
                 entries,
             },
@@ -205,7 +205,7 @@ pub async fn publish(
         .await?;
 
     client
-        .wait_for_publish(id, &record_id, Duration::from_millis(100))
+        .wait_for_publish(name, &record_id, Duration::from_millis(100))
         .await?;
 
     Ok(digest)
@@ -213,18 +213,26 @@ pub async fn publish(
 
 pub async fn publish_component(
     client: &FileSystemClient,
-    id: &PackageId,
+    name: &PackageName,
     version: &str,
     wat: &str,
     init: bool,
     signing_key: &PrivateKey,
 ) -> Result<AnyHash> {
-    publish(client, id, version, wat::parse_str(wat)?, init, signing_key).await
+    publish(
+        client,
+        name,
+        version,
+        wat::parse_str(wat)?,
+        init,
+        signing_key,
+    )
+    .await
 }
 
 pub async fn publish_wit(
     client: &FileSystemClient,
-    id: &PackageId,
+    name: &PackageName,
     version: &str,
     wit: &str,
     init: bool,
@@ -235,7 +243,7 @@ pub async fn publish_wit(
 
     publish(
         client,
-        id,
+        name,
         version,
         wit_component::encode(&resolve, pkg)?,
         init,


### PR DESCRIPTION
Implements #229 

Should not have breaking changes. Using `serde` alias for both the API schema change for the publish package record endpoint as well as the client storage JSON objects.