### PR TITLE
Make `download_content` public in `Client`.

### DIFF
--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -601,7 +601,11 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
         Ok(record)
     }
 
-    async fn download_content(&self, digest: &AnyHash) -> Result<PathBuf, ClientError> {
+    /// Downloads the content for the specified digest into client storage.
+    ///
+    /// If the content already exists in client storage, the existing path
+    /// is returned.
+    pub async fn download_content(&self, digest: &AnyHash) -> Result<PathBuf, ClientError> {
         match self.content.content_location(digest) {
             Some(path) => {
                 tracing::info!("content for digest `{digest}` already exists in storage");


### PR DESCRIPTION
This PR makes `download_content` a public function from `Client`.

It turns out that this is a useful function to have for clients that can determine missing content hashes from the client storage and instruct the client to download just the content.