### PR TITLE
Fix transaction implementation in `LogState::validate`.

### DIFF
--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -432,7 +432,7 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
                 if operator.head_registry_index.is_none()
                     || proto_envelope.registry_index > operator.head_registry_index.unwrap()
                 {
-                    operator
+                    operator.state = operator
                         .state
                         .validate(&proto_envelope.envelope)
                         .map_err(|inner| ClientError::OperatorValidationFailed { inner })?;
@@ -454,12 +454,13 @@ impl<R: RegistryStorage, C: ContentStorage> Client<R, C> {
                     if package.head_registry_index.is_none()
                         || proto_envelope.registry_index > package.head_registry_index.unwrap()
                     {
-                        package
-                            .state
-                            .validate(&proto_envelope.envelope)
-                            .map_err(|inner| ClientError::PackageValidationFailed {
-                                name: package.name.clone(),
-                                inner,
+                        let state = std::mem::take(&mut package.state);
+                        package.state =
+                            state.validate(&proto_envelope.envelope).map_err(|inner| {
+                                ClientError::PackageValidationFailed {
+                                    name: package.name.clone(),
+                                    inner,
+                                }
                             })?;
                         package.head_registry_index = Some(proto_envelope.registry_index);
                         package.head_fetch_token = Some(record.fetch_token);

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -22,7 +22,7 @@ pub trait Record: Clone + Decode + Send + Sync {
     fn contents(&self) -> HashSet<&AnyHash>;
 }
 
-/// Trait implemented by the validator types.
+/// Trait implemented by the log state types.
 pub trait Validator:
     std::fmt::Debug + Serialize + DeserializeOwned + Default + Send + Sync
 {
@@ -33,7 +33,7 @@ pub trait Validator:
     type Error: Send;
 
     /// Validates the given record.
-    fn validate(&mut self, record: &ProtoEnvelope<Self::Record>) -> Result<(), Self::Error>;
+    fn validate(self, record: &ProtoEnvelope<Self::Record>) -> Result<Self, Self::Error>;
 }
 
 /// Helpers for converting to and from protobuf

--- a/crates/protocol/src/package/state.rs
+++ b/crates/protocol/src/package/state.rs
@@ -143,7 +143,7 @@ pub struct LogState {
     /// This is `None` until the first (i.e. init) record is validated.
     #[serde(skip_serializing_if = "Option::is_none")]
     algorithm: Option<HashAlgorithm>,
-    /// The current head of the validator.
+    /// The current head of the state.
     #[serde(skip_serializing_if = "Option::is_none")]
     head: Option<Head>,
     /// The permissions of each key.
@@ -152,18 +152,18 @@ pub struct LogState {
     /// The releases in the package log.
     #[serde(skip_serializing_if = "IndexMap::is_empty")]
     releases: IndexMap<Version, Release>,
-    /// The keys known to the validator.
+    /// The keys known to the state.
     #[serde(skip_serializing_if = "IndexMap::is_empty")]
     keys: IndexMap<signing::KeyID, signing::PublicKey>,
 }
 
 impl LogState {
-    /// Create a new package log validator.
+    /// Create a new package log state.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Gets the current head of the validator.
+    /// Gets the current head of the state.
     ///
     /// Returns `None` if no records have been validated yet.
     pub fn head(&self) -> &Option<Head> {
@@ -175,23 +175,17 @@ impl LogState {
     /// It is expected that `validate` is called in order of the
     /// records in the log.
     ///
-    /// This operation is transactional: if any entry in the record
-    /// fails to validate, the validator state will remain unchanged.
+    /// Note that on failure, the log state is consumed to prevent
+    /// invalid state from being used in future validations.
     pub fn validate(
-        &mut self,
+        mut self,
         record: &ProtoEnvelope<model::PackageRecord>,
-    ) -> Result<(), ValidationError> {
-        let snapshot = self.snapshot();
-
-        let result = self.validate_record(record);
-        if result.is_err() {
-            self.rollback(snapshot);
-        }
-
-        result
+    ) -> Result<Self, ValidationError> {
+        self.validate_record(record)?;
+        Ok(self)
     }
 
-    /// Gets the releases known to the validator.
+    /// Gets the releases known to the state.
     ///
     /// The releases are returned in package log order.
     ///
@@ -268,7 +262,7 @@ impl LogState {
         // Validate the envelope signature
         model::PackageRecord::verify(key, envelope.content_bytes(), envelope.signature())?;
 
-        // Update the validator head
+        // Update the state head
         self.head = Some(Head {
             digest: record_id,
             timestamp: record.timestamp,
@@ -527,57 +521,15 @@ impl LogState {
         }
         Ok(())
     }
-
-    fn snapshot(&self) -> Snapshot {
-        let Self {
-            algorithm,
-            head,
-            releases,
-            permissions,
-            keys,
-        } = self;
-
-        Snapshot {
-            algorithm: *algorithm,
-            head: head.clone(),
-            releases: releases.len(),
-            permissions: permissions.len(),
-            keys: keys.len(),
-        }
-    }
-
-    fn rollback(&mut self, snapshot: Snapshot) {
-        let Snapshot {
-            algorithm,
-            head,
-            releases,
-            permissions,
-            keys,
-        } = snapshot;
-
-        self.algorithm = algorithm;
-        self.head = head;
-        self.releases.truncate(releases);
-        self.permissions.truncate(permissions);
-        self.keys.truncate(keys);
-    }
 }
 
 impl crate::Validator for LogState {
     type Record = model::PackageRecord;
     type Error = ValidationError;
 
-    fn validate(&mut self, record: &ProtoEnvelope<Self::Record>) -> Result<(), Self::Error> {
+    fn validate(self, record: &ProtoEnvelope<Self::Record>) -> Result<Self, Self::Error> {
         self.validate(record)
     }
-}
-
-struct Snapshot {
-    algorithm: Option<HashAlgorithm>,
-    head: Option<Head>,
-    releases: usize,
-    permissions: usize,
-    keys: usize,
 }
 
 #[cfg(test)]
@@ -605,11 +557,11 @@ mod tests {
         };
 
         let envelope = ProtoEnvelope::signed_contents(&alice_priv, record).unwrap();
-        let mut validator = LogState::default();
-        validator.validate(&envelope).unwrap();
+        let state = LogState::default();
+        let state = state.validate(&envelope).unwrap();
 
         assert_eq!(
-            validator,
+            state,
             LogState {
                 head: Some(Head {
                     digest: RecordId::package_record::<Sha256>(&envelope),
@@ -634,7 +586,7 @@ mod tests {
         let bob_id = bob_pub.fingerprint();
 
         let hash_algo = HashAlgorithm::Sha256;
-        let mut validator = LogState::default();
+        let state = LogState::default();
 
         // In envelope 0: alice inits and grants bob release
         let timestamp0 = SystemTime::now();
@@ -654,7 +606,7 @@ mod tests {
             ],
         };
         let envelope0 = ProtoEnvelope::signed_contents(&alice_priv, record0).unwrap();
-        validator.validate(&envelope0).unwrap();
+        let state = state.validate(&envelope0).unwrap();
 
         // In envelope 1: bob releases 1.1.0
         let timestamp1 = timestamp0 + Duration::from_secs(1);
@@ -671,11 +623,11 @@ mod tests {
 
         let envelope1 = ProtoEnvelope::signed_contents(&bob_priv, record1).unwrap();
         let record_id1 = RecordId::package_record::<Sha256>(&envelope1);
-        validator.validate(&envelope1).unwrap();
+        let state = state.validate(&envelope1).unwrap();
 
-        // At this point, the validator should consider 1.1.0 released
+        // At this point, the state should consider 1.1.0 released
         assert_eq!(
-            validator.find_latest_release(&"~1".parse().unwrap()),
+            state.find_latest_release(&"~1".parse().unwrap()),
             Some(&Release {
                 record_id: record_id1.clone(),
                 version: Version::new(1, 1, 0),
@@ -686,11 +638,11 @@ mod tests {
                 }
             })
         );
-        assert!(validator
+        assert!(state
             .find_latest_release(&"~1.2".parse().unwrap())
             .is_none());
         assert_eq!(
-            validator.releases().collect::<Vec<_>>(),
+            state.releases().collect::<Vec<_>>(),
             vec![&Release {
                 record_id: record_id1.clone(),
                 version: Version::new(1, 1, 0),
@@ -717,14 +669,12 @@ mod tests {
             ],
         };
         let envelope2 = ProtoEnvelope::signed_contents(&alice_priv, record2).unwrap();
-        validator.validate(&envelope2).unwrap();
+        let state = state.validate(&envelope2).unwrap();
 
-        // At this point, the validator should consider 1.1.0 yanked
-        assert!(validator
-            .find_latest_release(&"~1".parse().unwrap())
-            .is_none());
+        // At this point, the state should consider 1.1.0 yanked
+        assert!(state.find_latest_release(&"~1".parse().unwrap()).is_none());
         assert_eq!(
-            validator.releases().collect::<Vec<_>>(),
+            state.releases().collect::<Vec<_>>(),
             vec![&Release {
                 record_id: record_id1.clone(),
                 version: Version::new(1, 1, 0),
@@ -738,7 +688,7 @@ mod tests {
         );
 
         assert_eq!(
-            validator,
+            state,
             LogState {
                 algorithm: Some(HashAlgorithm::Sha256),
                 head: Some(Head {
@@ -789,8 +739,8 @@ mod tests {
 
         let envelope =
             ProtoEnvelope::signed_contents(&alice_priv, record).expect("failed to sign envelope");
-        let mut validator = LogState::default();
-        validator.validate(&envelope).unwrap();
+        let state = LogState::default();
+        let state = state.validate(&envelope).unwrap();
 
         let expected = LogState {
             head: Some(Head {
@@ -806,7 +756,7 @@ mod tests {
             keys: IndexMap::from([(alice_id, alice_pub)]),
         };
 
-        assert_eq!(validator, expected);
+        assert_eq!(state, expected);
 
         let record = model::PackageRecord {
             prev: Some(RecordId::package_record::<Sha256>(&envelope)),
@@ -829,13 +779,10 @@ mod tests {
         let envelope =
             ProtoEnvelope::signed_contents(&alice_priv, record).expect("failed to sign envelope");
 
-        // This validation should fail and the validator state should remain unchanged
-        match validator.validate(&envelope).unwrap_err() {
+        // This validation should fail
+        match state.validate(&envelope).unwrap_err() {
             ValidationError::PermissionNotFoundToRevoke { .. } => {}
             _ => panic!("expected a different error"),
         }
-
-        // The validator should not have changed
-        assert_eq!(validator, expected);
     }
 }

--- a/crates/protocol/tests/operator.rs
+++ b/crates/protocol/tests/operator.rs
@@ -47,9 +47,9 @@ fn validate_input(input: Vec<EnvelopeData>) -> Result<LogState> {
 
             Some(envelope)
         })
-        .try_fold(LogState::new(), |mut validator, record| {
-            validator.validate(&record)?;
-            Ok(validator)
+        .try_fold(LogState::new(), |state, record| {
+            let state = state.validate(&record)?;
+            Ok(state)
         })
 }
 
@@ -81,7 +81,7 @@ fn execute_test(input_path: &Path) {
     .unwrap();
 
     let output = match validate_input(input) {
-        Ok(validator) => Output::Valid(validator),
+        Ok(state) => Output::Valid(state),
         Err(e) => Output::Error(e.to_string()),
     };
 

--- a/crates/protocol/tests/package.rs
+++ b/crates/protocol/tests/package.rs
@@ -46,9 +46,9 @@ fn validate_input(input: Vec<EnvelopeData>) -> Result<LogState> {
 
             Some(envelope)
         })
-        .try_fold(LogState::new(), |mut validator, record| {
-            validator.validate(&record)?;
-            Ok(validator)
+        .try_fold(LogState::new(), |state, record| {
+            let state = state.validate(&record)?;
+            Ok(state)
         })
 }
 
@@ -77,7 +77,7 @@ fn execute_test(input_path: &Path) {
     .unwrap();
 
     let output = match validate_input(input) {
-        Ok(validator) => Output::Valid(validator),
+        Ok(state) => Output::Valid(state),
         Err(e) => Output::Error(e.to_string()),
     };
 

--- a/crates/server/src/api/debug/mod.rs
+++ b/crates/server/src/api/debug/mod.rs
@@ -109,9 +109,8 @@ async fn get_package_info(
     let records = records
         .into_iter()
         .map(|record| {
-            package_state
-                .validate(&record.envelope)
-                .context("validate")?;
+            let state = std::mem::take(&mut package_state);
+            package_state = state.validate(&record.envelope).context("validate")?;
             let record_id = RecordId::package_record::<Sha256>(&record.envelope);
             let timestamp = record
                 .envelope

--- a/crates/server/src/datastore/postgres/mod.rs
+++ b/crates/server/src/datastore/postgres/mod.rs
@@ -224,7 +224,7 @@ where
     conn.transaction::<_, DataStoreError, _>(|conn| {
         async move {
             // Get the record content and validator
-            let (id, content, mut validator) = schema::records::table
+            let (id, content, validator) = schema::records::table
                 .inner_join(schema::logs::table)
                 .select((
                     schema::records::id,
@@ -251,12 +251,12 @@ where
             })?;
 
             // Validate the record
-            validator.validate(&record).map_err(Into::into)?;
+            let validator = validator.0.validate(&record).map_err(Into::into)?;
 
             // Store the updated validation state
             diesel::update(schema::logs::table)
                 .filter(schema::logs::id.eq(log_id))
-                .set(schema::logs::validator.eq(validator))
+                .set(schema::logs::validator.eq(Json(validator)))
                 .execute(conn)
                 .await?;
 


### PR DESCRIPTION
This PR removes the incorrect transaction implementation for `LogState::validate`.

Now `validate` takes ownership of `self` and returns `Result<Self, ValidationError>`.

This means that callers that expect to keep the log state following an invalid log entry must clone the state prior to validation.

As the in-memory data store is the only store that persists the log state in memory, it now clones the state before validation and updates the log state upon successful validation.

For the postgres data store, the log state was loaded from the database and is discarded on error, so no clone is necessary.

Fixes #242.