### PR TITLE
chore: add capability to use vendored openssl

### DIFF
--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -9,6 +9,10 @@ license = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true}
 
+[features]
+default = []
+native-tls-vendored = ["reqwest/native-tls-vendored"]
+
 [dependencies]
 warg-crypto = { workspace = true }
 warg-protocol = { workspace = true }


### PR DESCRIPTION
Adding this in order to be able to cross-compile `cargo-component` and publishing more arch binaries on releases