### PR TITLE
removed temporary aliases in struct fields with serde

### DIFF
--- a/crates/api/src/v1/mod.rs
+++ b/crates/api/src/v1/mod.rs
@@ -28,13 +28,7 @@ pub enum ContentSource {
         /// The URL of the content.
         url: String,
         /// Optional, server accepts for HTTP Range header.
-        /// TODO remove rename, see issue: https://github.com/bytecodealliance/registry/issues/221
-        #[serde(
-            default,
-            skip_serializing_if = "is_false",
-            rename = "accept_ranges",
-            alias = "acceptRanges"
-        )]
+        #[serde(default, skip_serializing_if = "is_false")]
         accept_ranges: bool,
         /// Optional, provides content size in bytes.
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/api/src/v1/mod.rs
+++ b/crates/api/src/v1/mod.rs
@@ -28,7 +28,7 @@ pub enum ContentSource {
         /// The URL of the content.
         url: String,
         /// Optional, server accepts for HTTP Range header.
-        #[serde(default, skip_serializing_if = "is_false")]
+        #[serde(default, skip_serializing_if = "is_false", alias = "accept_ranges")]
         accept_ranges: bool,
         /// Optional, provides content size in bytes.
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/api/src/v1/package.rs
+++ b/crates/api/src/v1/package.rs
@@ -43,8 +43,6 @@ pub struct MissingContent {
 #[serde(rename_all = "camelCase")]
 pub struct PublishRecordRequest<'a> {
     /// The package name being published.
-    /// TODO: Remove the alias for `packageId` according to compatibility release schedule.
-    #[serde(alias = "packageId")]
     pub package_name: Cow<'a, PackageName>,
     /// The publish record to add to the package log.
     pub record: Cow<'a, ProtoEnvelopeBody>,

--- a/crates/client/src/storage.rs
+++ b/crates/client/src/storage.rs
@@ -219,8 +219,6 @@ pub struct OperatorInfo {
 #[serde(rename_all = "camelCase")]
 pub struct PackageInfo {
     /// The package name to publish.
-    /// TODO: drop alias after sufficient time according to release policy.
-    #[serde(alias = "id")]
     pub name: PackageName,
     /// The last known checkpoint of the package.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -288,8 +286,6 @@ pub enum PublishEntry {
 #[serde(rename_all = "camelCase")]
 pub struct PublishInfo {
     /// The package name being published.
-    /// TODO: drop alias after sufficient time according to release policy.
-    #[serde(alias = "id")]
     pub name: PackageName,
     /// The last known head of the package log to use.
     ///


### PR DESCRIPTION
Drop temporary aliasing, per release policy  #221 