### PR TITLE
login sets default url with arg and creates default key if absent

### DIFF
--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -76,8 +76,10 @@ pub fn get_signing_key_entry(
         }
     } else {
         if let Some(url) = &home_url {
-            return Entry::new("warg-signing-key", &RegistryUrl::new(url)?.safe_label())
-                .context("failed to get keyring entry");
+            if keys.contains(url) {
+                return Entry::new("warg-signing-key", &RegistryUrl::new(url)?.safe_label())
+                    .context("failed to get keyring entry");
+            }
         }
         if keys.contains("default") {
             Entry::new("warg-signing-key", "default").context("failed to get keyring entry")


### PR DESCRIPTION
Now `warg login` sets home url based on registry flag and generates a default key if one doesn't already exist.
Also contains a fix to only use home url if it has been explicitly set