### PR TITLE
Warg credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4648,7 +4648,6 @@ dependencies = [
  "futures",
  "indexmap 2.2.4",
  "itertools 0.12.1",
- "keyring",
  "p256",
  "ptree",
  "rand_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4665,6 +4665,7 @@ dependencies = [
  "url",
  "warg-api",
  "warg-client",
+ "warg-credentials",
  "warg-crypto",
  "warg-protocol",
  "warg-server",
@@ -4719,6 +4720,18 @@ dependencies = [
  "wasmparser 0.121.2",
  "wasmprinter",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "warg-credentials"
+version = "0.4.0-dev"
+dependencies = [
+ "anyhow",
+ "indexmap 2.2.4",
+ "keyring",
+ "secrecy",
+ "warg-client",
+ "warg-crypto",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ indexmap.workspace = true
 semver.workspace = true
 wat = "1.0.85"
 wasmprinter = "0.2.78"
-keyring = "2.3.0"
 dialoguer = "0.11.0"
 itertools = "0.12.1"
 secrecy= { workspace = true }
@@ -84,6 +83,7 @@ warg-transparency = { path = "crates/transparency", version = "0.4.0-dev" }
 warg-server = { path = "crates/server", version = "0.4.0-dev" }
 clap = { version = "4.3.24", features = ["derive", "env"] }
 thiserror = "1.0.56"
+keyring = "2.3.0"
 anyhow = "1.0.79"
 serde = { version = "1.0.196", features = ["derive", "rc"] }
 serde_json = "1.0.113"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ wasm-encoder = { workspace = true }
 wasmparser = { workspace = true }
 wasm-compose = { workspace = true }
 warg-crypto = { workspace = true }
+warg-credentials = { workspace = true }
 warg-protocol = { workspace = true }
 warg-client = { workspace = true }
 clap = { workspace = true }
@@ -74,6 +75,7 @@ repository = "https://github.com/bytecodealliance/registry"
 [workspace.dependencies]
 ptree = "0.4.0"
 warg-api = { path = "crates/api", version = "0.4.0-dev" }
+warg-credentials = { path = "crates/credentials", version = "0.4.0-dev" }
 warg-client = { path = "crates/client", version = "0.4.0-dev" }
 warg-crypto = { path = "crates/crypto", version = "0.4.0-dev" }
 warg-protobuf = { path = "proto", version = "0.4.0-dev" }

--- a/ci/publish.rs
+++ b/ci/publish.rs
@@ -4,7 +4,7 @@
 //! * `./publish verify` - verify crates can be published to crates.io
 //! * `./publish publish` - actually publish crates to crates.io
 
-use indexmap::{IndexMap};
+use indexmap::IndexMap;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -20,6 +20,7 @@ const CRATES_TO_PUBLISH: &[&str] = &[
     "warg-protocol",
     "warg-api",
     "warg-client",
+    "warg-credentials",
     "warg-server",
     "warg-cli",
 ];
@@ -35,6 +36,7 @@ const PUBLIC_CRATES: &[&str] = &[
     "warg-protocol",
     "warg-api",
     "warg-client",
+    "warg-credentials",
     "warg-server",
     "warg-cli",
 ];
@@ -161,7 +163,10 @@ fn read_crate(ws: Option<&Workspace>, manifest: &Path) -> Crate {
             );
         }
         if let Some(ws) = ws {
-            if version.is_none() && (line.starts_with("version.workspace = true") || line.starts_with("version = { workspace = true }")) {
+            if version.is_none()
+                && (line.starts_with("version.workspace = true")
+                    || line.starts_with("version = { workspace = true }"))
+            {
                 version = Some(ws.version.clone());
             }
         }

--- a/crates/client/src/api.rs
+++ b/crates/client/src/api.rs
@@ -216,7 +216,6 @@ impl Client {
     pub fn url(&self) -> &RegistryUrl {
         &self.url
     }
-
     /// Gets the latest checkpoint from the registry.
     pub async fn latest_checkpoint(
         &self,

--- a/crates/client/src/config.rs
+++ b/crates/client/src/config.rs
@@ -108,12 +108,12 @@ pub struct Config {
     pub namespace_map_path: Option<PathBuf>,
 
     /// List of creds availabe in keyring
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub keys: Option<IndexSet<String>>,
+    #[serde(default, skip_serializing_if = "IndexSet::is_empty")]
+    pub keys: IndexSet<String>,
 
     /// Whether or not an auth key should be retreived from keyring
     #[serde(default)]
-    pub auth: bool,
+    pub keyring_auth: bool,
 }
 
 impl Config {
@@ -191,7 +191,7 @@ impl Config {
                 pathdiff::diff_paths(&p, &parent).unwrap()
             }),
             keys: self.keys.clone(),
-            auth: false,
+            keyring_auth: false,
         };
 
         serde_json::to_writer_pretty(

--- a/crates/client/src/config.rs
+++ b/crates/client/src/config.rs
@@ -110,6 +110,10 @@ pub struct Config {
     /// List of creds availabe in keyring
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub keys: Option<IndexSet<String>>,
+
+    /// Whether or not an auth key should be retreived from keyring
+    #[serde(default)]
+    pub auth: bool,
 }
 
 impl Config {
@@ -187,6 +191,7 @@ impl Config {
                 pathdiff::diff_paths(&p, &parent).unwrap()
             }),
             keys: self.keys.clone(),
+            auth: false,
         };
 
         serde_json::to_writer_pretty(

--- a/crates/client/src/config.rs
+++ b/crates/client/src/config.rs
@@ -191,7 +191,7 @@ impl Config {
                 pathdiff::diff_paths(&p, &parent).unwrap()
             }),
             keys: self.keys.clone(),
-            keyring_auth: false,
+            keyring_auth: self.keyring_auth,
         };
 
         serde_json::to_writer_pretty(

--- a/crates/credentials/Cargo.toml
+++ b/crates/credentials/Cargo.toml
@@ -13,7 +13,7 @@ repository = { workspace = true}
 [dependencies]
 anyhow = { workspace = true}
 indexmap = { workspace = true}
-keyring = "2.3.2"
+keyring = { workspace = true }
 secrecy = { workspace = true}
 warg-client = { workspace = true}
 warg-crypto = { workspace = true}

--- a/crates/credentials/Cargo.toml
+++ b/crates/credentials/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "warg-credentials"
+version = { workspace = true}
+authors = { workspace = true}
+edition = { workspace = true}
+rust-version = { workspace = true}
+license = { workspace = true}
+homepage = { workspace = true}
+repository = { workspace = true}
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = { workspace = true}
+indexmap = { workspace = true}
+keyring = "2.3.2"
+secrecy = { workspace = true}
+warg-client = { workspace = true}
+warg-crypto = { workspace = true}

--- a/crates/credentials/src/keyring.rs
+++ b/crates/credentials/src/keyring.rs
@@ -64,18 +64,18 @@ pub fn set_auth_token(registry_url: &RegistryUrl, token: &str) -> Result<()> {
 
 /// Gets the signing key entry for the given registry and key name.
 pub fn get_signing_key_entry(
-    registry_url: &Option<String>,
-    keys: IndexSet<String>,
-    home_url: Option<String>,
+    registry_url: Option<&str>,
+    keys: &IndexSet<String>,
+    home_url: Option<&str>,
 ) -> Result<Entry> {
     if let Some(registry_url) = registry_url {
-        if keys.contains(&registry_url.clone()) {
+        if keys.contains(registry_url) {
             Entry::new("warg-signing-key", registry_url).context("failed to get keyring entry")
         } else {
             Entry::new("warg-signing-key", "default").context("failed to get keyring entry")
         }
     } else {
-        if let Some(url) = &home_url {
+        if let Some(url) = home_url {
             if keys.contains(url) {
                 return Entry::new("warg-signing-key", &RegistryUrl::new(url)?.safe_label())
                     .context("failed to get keyring entry");
@@ -95,9 +95,9 @@ pub fn get_signing_key_entry(
 pub fn get_signing_key(
     // If being called by a cli key command, this will always be a cli flag
     // If being called by a client publish command, this could also be supplied by namespace map config
-    registry_url: &Option<String>,
-    keys: IndexSet<String>,
-    home_url: Option<String>,
+    registry_url: Option<&str>,
+    keys: &IndexSet<String>,
+    home_url: Option<&str>,
 ) -> Result<PrivateKey> {
     let entry = get_signing_key_entry(registry_url, keys, home_url)?;
 
@@ -129,12 +129,12 @@ pub fn get_signing_key(
 
 /// Sets the signing key for the given registry host and key name.
 pub fn set_signing_key(
-    registry_url: &Option<String>,
+    registry_url: Option<&str>,
     key: &PrivateKey,
     keys: &mut IndexSet<String>,
-    home_url: Option<String>,
+    home_url: Option<&str>,
 ) -> Result<()> {
-    let entry = get_signing_key_entry(registry_url, keys.clone(), home_url.clone())?;
+    let entry = get_signing_key_entry(registry_url, keys, home_url)?;
     match entry.set_password(&key.encode()) {
         Ok(()) => Ok(()),
         Err(keyring::Error::NoEntry) => {
@@ -163,11 +163,11 @@ pub fn set_signing_key(
 
 /// Deletes the signing key for the given registry host and key name.
 pub fn delete_signing_key(
-    registry_url: &Option<String>,
-    keys: IndexSet<String>,
-    home_url: Option<String>,
+    registry_url: Option<&str>,
+    keys: &IndexSet<String>,
+    home_url: Option<&str>,
 ) -> Result<()> {
-    let entry = get_signing_key_entry(registry_url, keys, home_url.clone())?;
+    let entry = get_signing_key_entry(registry_url, keys, home_url)?;
 
     match entry.delete_password() {
         Ok(()) => Ok(()),

--- a/crates/credentials/src/lib.rs
+++ b/crates/credentials/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod keyring;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -12,6 +12,7 @@ use warg_client::storage::RegistryStorage;
 use warg_client::Client;
 use warg_client::RegistryUrl;
 use warg_client::{ClientError, Config, FileSystemClient, StorageLockResult};
+use warg_credentials::keyring::{get_auth_token, get_signing_key};
 use warg_crypto::signing::PrivateKey;
 
 mod bundle;
@@ -27,9 +28,6 @@ mod logout;
 mod publish;
 mod reset;
 mod update;
-
-use crate::keyring::get_auth_token;
-use crate::keyring::get_signing_key;
 
 pub use self::bundle::*;
 pub use self::clear::*;
@@ -117,9 +115,9 @@ impl CommonOptions {
         };
         let config = self.read_config()?;
         get_signing_key(
-            &registry_url.map(|reg| reg.safe_label()),
-            config.keys.expect("Please set a default signing key by typing `warg key set <alg:base64>` or `warg key new"),
-            config.home_url,
+            registry_url.map(|reg| reg.safe_label()).as_deref(),
+            &config.keys.expect("Please set a default signing key by typing `warg key set <alg:base64>` or `warg key new"),
+            config.home_url.as_deref(),
         )
     }
     /// Gets the auth token for the given registry URL.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -116,13 +116,13 @@ impl CommonOptions {
         let config = self.read_config()?;
         get_signing_key(
             registry_url.map(|reg| reg.safe_label()).as_deref(),
-            &config.keys.expect("Please set a default signing key by typing `warg key set <alg:base64>` or `warg key new"),
+            &config.keys,
             config.home_url.as_deref(),
         )
     }
     /// Gets the auth token for the given registry URL.
     pub fn auth_token(&self, config: &Config) -> Result<Option<Secret<String>>> {
-        if config.auth {
+        if config.keyring_auth {
             return if let Some(reg_url) = &self.registry {
                 Ok(get_auth_token(&RegistryUrl::new(reg_url)?)?)
             } else if let Some(url) = config.home_url.as_ref() {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -122,13 +122,16 @@ impl CommonOptions {
     }
     /// Gets the auth token for the given registry URL.
     pub fn auth_token(&self, config: &Config) -> Result<Option<Secret<String>>> {
-        if let Some(reg_url) = &self.registry {
-            Ok(get_auth_token(&RegistryUrl::new(reg_url)?)?)
-        } else if let Some(url) = config.home_url.as_ref() {
-            Ok(get_auth_token(&RegistryUrl::new(url)?)?)
-        } else {
-            Ok(None)
+        if config.auth {
+            return if let Some(reg_url) = &self.registry {
+                Ok(get_auth_token(&RegistryUrl::new(reg_url)?)?)
+            } else if let Some(url) = config.home_url.as_ref() {
+                Ok(get_auth_token(&RegistryUrl::new(url)?)?)
+            } else {
+                Ok(None)
+            };
         }
+        Ok(None)
     }
 }
 

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -69,7 +69,7 @@ impl ConfigCommand {
             content_dir: self.content_dir.map(|p| cwd.join(p)),
             namespace_map_path: self.namespace_path.map(|p| cwd.join(p)),
             keys: self.common.read_config()?.keys,
-            auth: false,
+            keyring_auth: false,
         };
 
         config.write_to_file(&path)?;

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -69,6 +69,7 @@ impl ConfigCommand {
             content_dir: self.content_dir.map(|p| cwd.join(p)),
             namespace_map_path: self.namespace_path.map(|p| cwd.join(p)),
             keys: self.common.read_config()?.keys,
+            auth: false,
         };
 
         config.write_to_file(&path)?;

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -79,6 +79,7 @@ impl LoginCommand {
             println!("Public Key: {public_key}");
             return Ok(());
         }
+        config.auth = true;
         config.write_to_file(&Config::default_config_path()?)?;
 
         let token = Password::with_theme(&ColorfulTheme::default())

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -6,7 +6,7 @@ use p256::ecdsa::SigningKey;
 use rand_core::OsRng;
 use warg_client::{Config, RegistryUrl};
 
-use crate::keyring::{set_auth_token, set_signing_key};
+use warg_credentials::keyring::{set_auth_token, set_signing_key};
 
 use super::CommonOptions;
 
@@ -62,10 +62,10 @@ impl LoginCommand {
             config.keys = Some(keys);
             let key = SigningKey::random(&mut OsRng).into();
             set_signing_key(
-                &None,
+                None,
                 &key,
                 config.keys.as_mut().unwrap(),
-                config.home_url.clone(),
+                config.home_url.as_deref(),
             )?;
             let public_key = key.public_key();
             let token = Password::with_theme(&ColorfulTheme::default())

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -66,13 +66,12 @@ impl LoginCommand {
                 .context("failed to read token")?;
             self.keyring_entry
                 .set_entry(self.common.read_config()?.home_url, &token)?;
+            config.keyring_auth = true;
             config.write_to_file(&Config::default_config_path()?)?;
             println!("auth token was set successfully, and generated default key",);
             println!("Public Key: {public_key}");
             return Ok(());
         }
-        config.keyring_auth = true;
-        config.write_to_file(&Config::default_config_path()?)?;
 
         let token = Password::with_theme(&ColorfulTheme::default())
             .with_prompt("Enter auth token")
@@ -80,6 +79,8 @@ impl LoginCommand {
             .context("failed to read token")?;
         self.keyring_entry
             .set_entry(self.common.read_config()?.home_url, &token)?;
+        config.keyring_auth = true;
+        config.write_to_file(&Config::default_config_path()?)?;
         println!("auth token was set successfully",);
         Ok(())
     }

--- a/src/commands/logout.rs
+++ b/src/commands/logout.rs
@@ -41,6 +41,8 @@ impl LogoutCommand {
     pub async fn exec(self) -> Result<()> {
         self.keyring_entry
             .delete_entry(self.common.read_config()?.home_url)?;
+        let mut config = self.common.read_config()?;
+        config.auth = false;
         println!("auth token was deleted successfully",);
         Ok(())
     }

--- a/src/commands/logout.rs
+++ b/src/commands/logout.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use clap::Args;
-use warg_client::RegistryUrl;
+use warg_client::{Config, RegistryUrl};
 
 use warg_credentials::keyring::delete_auth_token;
 
@@ -42,7 +42,8 @@ impl LogoutCommand {
         self.keyring_entry
             .delete_entry(self.common.read_config()?.home_url)?;
         let mut config = self.common.read_config()?;
-        config.auth = false;
+        config.keyring_auth = false;
+        config.write_to_file(&Config::default_config_path()?)?;
         println!("auth token was deleted successfully",);
         Ok(())
     }

--- a/src/commands/logout.rs
+++ b/src/commands/logout.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use clap::Args;
 use warg_client::RegistryUrl;
 
-use crate::keyring::delete_auth_token;
+use warg_credentials::keyring::delete_auth_token;
 
 use super::CommonOptions;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,3 @@
 #![deny(missing_docs)]
 
 pub mod commands;
-pub mod keyring;

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, Context, Result};
+use indexmap::IndexSet;
 use std::{
     env,
     path::{Path, PathBuf},
@@ -164,8 +165,8 @@ pub async fn spawn_server(
         registries_dir: Some(root.join("registries")),
         content_dir: Some(root.join("content")),
         namespace_map_path: Some(root.join("namespaces")),
-        keys: None,
-        auth: false,
+        keys: IndexSet::new(),
+        keyring_auth: false,
     };
 
     Ok((instance, config))

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -165,6 +165,7 @@ pub async fn spawn_server(
         content_dir: Some(root.join("content")),
         namespace_map_path: Some(root.join("namespaces")),
         keys: None,
+        auth: false,
     };
 
     Ok((instance, config))


### PR DESCRIPTION
Adds a new crate exposing methods for accessing credentials in the keyring so that consumers don't need to implement it too.

This also checks for auth tokens less eagerly, avoiding a keyring password if the user hasn't set an auth token.