### PR TITLE
Add warning field to fetch logs response.

### DIFF
--- a/crates/api/src/v1/fetch.rs
+++ b/crates/api/src/v1/fetch.rs
@@ -52,6 +52,9 @@ pub struct FetchLogsResponse {
     /// The package records appended since last known package record ids.
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub packages: IndexMap<LogId, Vec<PublishedRecord>>,
+    /// An optional list of warnings.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<FetchWarning>,
 }
 
 /// Represents a fetch package names request.
@@ -70,6 +73,13 @@ pub struct FetchPackageNamesRequest<'a> {
 pub struct FetchPackageNamesResponse {
     /// The log ID hash mapping to a package name. If `None`, the package name cannot be provided.
     pub packages: IndexMap<LogId, Option<PackageName>>,
+}
+
+/// A warning message.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct FetchWarning {
+    /// The warning message itself
+    pub message: String,
 }
 
 /// Represents a fetch API error.

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -629,6 +629,11 @@ impl<R: RegistryStorage, C: ContentStorage, N: NamespaceMapStorage> Client<R, C,
                     packages: Cow::Borrowed(&last_known),
                 })
                 .await
+                .inspect(|res| {
+                    for warning in res.warnings.iter() {
+                        tracing::warn!("WARNING: {}", warning.message);
+                    }
+                })
                 .map_err(|e| {
                     ClientError::translate_log_not_found(e, |id| {
                         packages.get(id).map(|p| p.name.clone())

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -631,7 +631,7 @@ impl<R: RegistryStorage, C: ContentStorage, N: NamespaceMapStorage> Client<R, C,
                 .await
                 .inspect(|res| {
                     for warning in res.warnings.iter() {
-                        tracing::warn!("WARNING: {}", warning.message);
+                        tracing::warn!("Fetch warning from registry: {}", warning.message);
                     }
                 })
                 .map_err(|e| {

--- a/crates/server/openapi.yaml
+++ b/crates/server/openapi.yaml
@@ -808,6 +808,12 @@ components:
           maxItems: 1000
           items:
             $ref: "#/components/schemas/PublishedRecordEnvelope"
+        warnings:
+          type: array
+          description: An optional list of warnings.
+          maxItems: 1000
+          items:
+            $ref: "#/components/schemas/FetchWarning"
         packages:
           type: object
           description: The map of package log identifier to package records.
@@ -1085,6 +1091,12 @@ components:
               maxLength: 1048576
               example: "ZXhhbXBsZQ=="
         - $ref: "#/components/schemas/Signature"
+    FetchWarning:
+      description: A warning message
+      properties:
+        message:
+          description: The warning message itself.
+          type: string 
     PublishedRecordEnvelope:
       description: A signed envelope body with the published registry log index.
       allOf:

--- a/crates/server/src/api/v1/fetch.rs
+++ b/crates/server/src/api/v1/fetch.rs
@@ -160,6 +160,7 @@ async fn fetch_logs(
         more,
         operator,
         packages: map,
+        warnings: Vec::default(),
     }))
 }
 


### PR DESCRIPTION
The intention of adding this field is to handle moved repositories. When a repository is moved, Warg will use the new repository name instead, but the users must be alerted so they can update their dependency list.

Closes https://github.com/bytecodealliance/registry/issues/261