### PR TITLE
make better use of namespace storage

### DIFF
--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -10,7 +10,6 @@ use secrecy::Secret;
 use semver::{Version, VersionReq};
 use std::cmp::Ordering;
 use std::fs;
-use std::future::Future;
 use std::str::FromStr;
 use std::{borrow::Cow, path::PathBuf, time::Duration};
 use storage::{
@@ -121,13 +120,7 @@ impl<R: RegistryStorage, C: ContentStorage, N: NamespaceMapStorage> Client<R, C,
                 Ok(Some(warg_protocol::operator::NamespaceState::Defined)) => {
                     return Ok(None);
                 }
-                Ok(None) => return Ok(None),
-                Err(e) => {
-                    return Err(ClientError::SimilarNamespace {
-                        namespace: namespace.to_string(),
-                        e: e.to_string(),
-                    });
-                }
+                _ => (),
             }
         };
         let nm_map = self.namespace_map.load_namespace_map().await?;
@@ -1285,13 +1278,4 @@ impl Retry {
             .await?;
         Ok(())
     }
-}
-
-/// Interactively retry when hint header received from warg server
-pub async fn with_interactive_retry<F>(f: impl Fn(Option<Retry>) -> F) -> Result<()>
-where
-    F: Future<Output = Result<()>>,
-{
-    f(None).await?;
-    Ok(())
 }

--- a/crates/client/src/storage.rs
+++ b/crates/client/src/storage.rs
@@ -23,14 +23,8 @@ mod fs;
 pub use fs::*;
 
 /// Registry domain used for warg header values
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RegistryDomain(String);
-
-// impl From<String> for RegistryDomain {
-//     fn from(value: String) -> Self {
-//         RegistryDomain(value)
-//     }
-// }
 
 impl FromStr for RegistryDomain {
     type Err = Error;
@@ -46,13 +40,6 @@ impl ToString for RegistryDomain {
     }
 }
 
-// impl TryFrom<HeaderValue> for RegistryName ...
-
-// impl From<RegistryDomain> for HeaderValue {
-// fn from(value: RegistryDomain) -> Self {
-//     HeaderValue::to_str(&value.to_string())
-// }
-// }
 impl TryFrom<RegistryDomain> for HeaderValue {
     type Error = Error;
 
@@ -61,14 +48,6 @@ impl TryFrom<RegistryDomain> for HeaderValue {
     }
 }
 
-// impl TryInto<RegistryDomain> for HeaderValue {
-//     type Error = Error;
-
-//     fn try_into(self) -> std::result::Result<RegistryDomain, anyhow::Error> {
-//         // Ok(HeaderValue::from_str(&value.to_string())?)
-
-//     }
-// }
 /// Trait for registry storage implementations.
 ///
 /// Stores information such as package/operator logs and checkpoints
@@ -86,13 +65,13 @@ pub trait RegistryStorage: Send + Sync {
     /// Loads most recent checkpoint
     async fn load_checkpoint(
         &self,
-        namespace_registry: &Option<RegistryDomain>,
+        namespace_registry: Option<&RegistryDomain>,
     ) -> Result<Option<SerdeEnvelope<TimestampedCheckpoint>>>;
 
     /// Stores most recent checkpoint
     async fn store_checkpoint(
         &self,
-        namespace_registry: &Option<RegistryDomain>,
+        namespace_registry: Option<&RegistryDomain>,
         ts_checkpoint: &SerdeEnvelope<TimestampedCheckpoint>,
     ) -> Result<()>;
 
@@ -101,13 +80,13 @@ pub trait RegistryStorage: Send + Sync {
     /// Returns `Ok(None)` if the information is not present.
     async fn load_operator(
         &self,
-        namespace_registry: &Option<RegistryDomain>,
+        namespace_registry: Option<&RegistryDomain>,
     ) -> Result<Option<OperatorInfo>>;
 
     /// Stores the operator information in the storage.
     async fn store_operator(
         &self,
-        namespace_registry: &Option<RegistryDomain>,
+        namespace_registry: Option<&RegistryDomain>,
         operator: OperatorInfo,
     ) -> Result<()>;
 
@@ -122,14 +101,14 @@ pub trait RegistryStorage: Send + Sync {
     /// Returns `Ok(None)` if the information is not present.
     async fn load_package(
         &self,
-        namespace_registry: &Option<RegistryDomain>,
+        namespace_registry: Option<&RegistryDomain>,
         package: &PackageName,
     ) -> Result<Option<PackageInfo>>;
 
     /// Stores the package information in the storage.
     async fn store_package(
         &self,
-        namespace_registry: &Option<RegistryDomain>,
+        namespace_registry: Option<&RegistryDomain>,
         info: &PackageInfo,
     ) -> Result<()>;
 

--- a/crates/client/src/storage/fs.rs
+++ b/crates/client/src/storage/fs.rs
@@ -81,7 +81,7 @@ impl FileSystemRegistryStorage {
         })
     }
 
-    fn operator_path(&self, namespace_registry: &Option<RegistryDomain>) -> PathBuf {
+    fn operator_path(&self, namespace_registry: Option<&RegistryDomain>) -> PathBuf {
         if let Some(nm) = namespace_registry {
             return self
                 .registries_dir
@@ -93,7 +93,7 @@ impl FileSystemRegistryStorage {
 
     fn package_path(
         &self,
-        namespace_registry: &Option<RegistryDomain>,
+        namespace_registry: Option<&RegistryDomain>,
         name: &PackageName,
     ) -> PathBuf {
         if let Some(nm) = namespace_registry {
@@ -131,7 +131,7 @@ impl RegistryStorage for FileSystemRegistryStorage {
 
     async fn load_checkpoint(
         &self,
-        namespace_registry: &Option<RegistryDomain>,
+        namespace_registry: Option<&RegistryDomain>,
     ) -> Result<Option<SerdeEnvelope<TimestampedCheckpoint>>> {
         if let Some(nm) = namespace_registry {
             return load(&self.registries_dir.join(nm.to_string()).join("checkpoint")).await;
@@ -141,7 +141,7 @@ impl RegistryStorage for FileSystemRegistryStorage {
 
     async fn store_checkpoint(
         &self,
-        namespace_registry: &Option<RegistryDomain>,
+        namespace_registry: Option<&RegistryDomain>,
         ts_checkpoint: &SerdeEnvelope<TimestampedCheckpoint>,
     ) -> Result<()> {
         if let Some(nm) = namespace_registry {
@@ -231,14 +231,14 @@ impl RegistryStorage for FileSystemRegistryStorage {
 
     async fn load_operator(
         &self,
-        namespace_registry: &Option<RegistryDomain>,
+        namespace_registry: Option<&RegistryDomain>,
     ) -> Result<Option<OperatorInfo>> {
         Ok(load(&self.operator_path(namespace_registry)).await?)
     }
 
     async fn store_operator(
         &self,
-        namespace_registry: &Option<RegistryDomain>,
+        namespace_registry: Option<&RegistryDomain>,
         info: OperatorInfo,
     ) -> Result<()> {
         store(&self.operator_path(namespace_registry), info).await
@@ -246,7 +246,7 @@ impl RegistryStorage for FileSystemRegistryStorage {
 
     async fn load_package(
         &self,
-        namespace_registry: &Option<RegistryDomain>,
+        namespace_registry: Option<&RegistryDomain>,
         package: &PackageName,
     ) -> Result<Option<PackageInfo>> {
         Ok(load(&self.package_path(namespace_registry, package)).await?)
@@ -254,7 +254,7 @@ impl RegistryStorage for FileSystemRegistryStorage {
 
     async fn store_package(
         &self,
-        namespace_registry: &Option<RegistryDomain>,
+        namespace_registry: Option<&RegistryDomain>,
         info: &PackageInfo,
     ) -> Result<()> {
         store(&self.package_path(namespace_registry, &info.name), info).await

--- a/src/commands/clear.rs
+++ b/src/commands/clear.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use clap::Args;
 
 /// Deletes local content cache.
-#[derive(Args)]
+#[derive(Args, Clone)]
 pub struct ClearCommand {
     /// The common command options.
     #[clap(flatten)]

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use warg_client::{Config, RegistryUrl};
 
 /// Creates a new warg configuration file.
-#[derive(Args)]
+#[derive(Args, Clone)]
 pub struct ConfigCommand {
     /// The common command options.
     #[clap(flatten)]

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -10,7 +10,7 @@ use warg_crypto::signing::PrivateKey;
 use super::CommonOptions;
 
 /// Manage signing keys for interacting with a registry.
-#[derive(Args)]
+#[derive(Args, Clone)]
 pub struct KeyCommand {
     /// The subcommand to execute.
     #[clap(subcommand)]
@@ -30,7 +30,7 @@ impl KeyCommand {
 }
 
 /// The subcommand to execute.
-#[derive(Subcommand)]
+#[derive(Subcommand, Clone)]
 pub enum KeySubcommand {
     /// Creates a new signing key for a registry in the local keyring.
     New(KeyNewCommand),
@@ -43,7 +43,7 @@ pub enum KeySubcommand {
 }
 
 /// Creates a new signing key for a registry in the local keyring.
-#[derive(Args)]
+#[derive(Args, Clone)]
 pub struct KeyNewCommand {
     /// The common command options.
     #[clap(flatten)]
@@ -75,7 +75,7 @@ impl KeyNewCommand {
 }
 
 /// Shows information about the signing key for a registry in the local keyring.
-#[derive(Args)]
+#[derive(Args, Clone)]
 pub struct KeyInfoCommand {
     /// The common command options.
     #[clap(flatten)]
@@ -99,7 +99,7 @@ impl KeyInfoCommand {
 }
 
 /// Sets the signing key for a registry in the local keyring.
-#[derive(Args)]
+#[derive(Args, Clone)]
 pub struct KeySetCommand {
     /// The common command options.
     #[clap(flatten)]
@@ -132,7 +132,7 @@ impl KeySetCommand {
 }
 
 /// Deletes the signing key for a registry from the local keyring.
-#[derive(Args)]
+#[derive(Args, Clone)]
 pub struct KeyDeleteCommand {
     /// The common command options.
     #[clap(flatten)]

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -10,7 +10,7 @@ use warg_credentials::keyring::{set_auth_token, set_signing_key};
 use super::CommonOptions;
 
 /// Manage auth tokens for interacting with a registry.
-#[derive(Args)]
+#[derive(Args, Clone)]
 pub struct LoginCommand {
     /// The common command options.
     #[clap(flatten)]
@@ -21,7 +21,7 @@ pub struct LoginCommand {
     keyring_entry: KeyringEntryArgs,
 }
 
-#[derive(Args)]
+#[derive(Args, Clone)]
 struct KeyringEntryArgs {
     /// The URL of the registry to store an auth token for.
     #[clap(value_name = "URL")]

--- a/src/commands/logout.rs
+++ b/src/commands/logout.rs
@@ -7,7 +7,7 @@ use warg_credentials::keyring::delete_auth_token;
 use super::CommonOptions;
 
 /// Manage auth tokens for interacting with a registry.
-#[derive(Args)]
+#[derive(Args, Clone)]
 pub struct LogoutCommand {
     /// The common command options.
     #[clap(flatten)]
@@ -17,7 +17,7 @@ pub struct LogoutCommand {
     keyring_entry: KeyringEntryArgs,
 }
 
-#[derive(Args)]
+#[derive(Args, Clone)]
 struct KeyringEntryArgs {
     /// The URL of the registry to delete an auth token for.
     #[clap(value_name = "URL")]

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use clap::Args;
 
 /// Reset local data for registry.
-#[derive(Args)]
+#[derive(Args, Clone)]
 pub struct ResetCommand {
     /// The common command options.
     #[clap(flatten)]

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use clap::{ArgAction, Args};
 
 /// Update all local package logs for a registry.
-#[derive(Args)]
+#[derive(Args, Clone)]
 pub struct UpdateCommand {
     /// The common command options.
     #[clap(flatten)]

--- a/tests/depsolve.rs
+++ b/tests/depsolve.rs
@@ -17,7 +17,7 @@ pub mod support;
 async fn depsolve() -> Result<()> {
     let (_server, config) = spawn_server(&root().await?, None, None, None).await?;
 
-    let client = create_client(&config)?;
+    let client = create_client(&config).await?;
     let signing_key = support::test_signing_key();
 
     let mut head = publish_package(
@@ -89,7 +89,10 @@ async fn depsolve() -> Result<()> {
 
     let info = client
         .registry()
-        .load_package(client.get_warg_registry(), &PackageName::new("test:meet")?)
+        .load_package(
+            client.get_warg_registry("test").await?.as_ref(),
+            &PackageName::new("test:meet")?,
+        )
         .await?
         .context("package does not exist in client storage")?;
 
@@ -147,7 +150,7 @@ async fn publish_package(
                 name: name.clone(),
                 head: Some(head),
                 entries: vec![PublishEntry::Release {
-                    version: format!("1.0.0").parse().unwrap(),
+                    version: "1.0.0".to_string().parse().unwrap(),
                     content: add_digest.clone(),
                 }],
             },

--- a/tests/memory/mod.rs
+++ b/tests/memory/mod.rs
@@ -17,7 +17,7 @@ async fn it_publishes_a_component() -> Result<()> {
 
     // There should be two log entries in the registry
     let client = api::Client::new(config.home_url.as_ref().unwrap(), None)?;
-    let ts_checkpoint = client.latest_checkpoint().await?;
+    let ts_checkpoint = client.latest_checkpoint(None).await?;
     assert_eq!(
         ts_checkpoint.as_ref().checkpoint.log_length,
         2,
@@ -36,7 +36,7 @@ async fn it_yanks_a_package() -> Result<()> {
 
     // There should be three entries in the registry
     let client = api::Client::new(config.home_url.as_ref().unwrap(), None)?;
-    let ts_checkpoint = client.latest_checkpoint().await?;
+    let ts_checkpoint = client.latest_checkpoint(None).await?;
     assert_eq!(
         ts_checkpoint.as_ref().checkpoint.log_length,
         3,
@@ -53,7 +53,7 @@ async fn it_publishes_a_wit_package() -> Result<()> {
 
     // There should be two log entries in the registry
     let client = api::Client::new(config.home_url.as_ref().unwrap(), None)?;
-    let ts_checkpoint = client.latest_checkpoint().await?;
+    let ts_checkpoint = client.latest_checkpoint(None).await?;
     assert_eq!(
         ts_checkpoint.as_ref().checkpoint.log_length,
         2,

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -67,7 +67,7 @@ async fn it_works_with_postgres() -> TestResult {
 
     // There should be two log entries in the registry
     let client = api::Client::new(config.home_url.as_ref().unwrap(), None)?;
-    let ts_checkpoint = client.latest_checkpoint().await?;
+    let ts_checkpoint = client.latest_checkpoint(None).await?;
     assert_eq!(
         ts_checkpoint.as_ref().checkpoint.log_length,
         packages.len() as RegistryLen + 2, /* publishes + initial checkpoint + yank */
@@ -85,7 +85,7 @@ async fn it_works_with_postgres() -> TestResult {
     packages.push(PackageName::new("test:unknown-key")?);
 
     let client = api::Client::new(config.home_url.as_ref().unwrap(), None)?;
-    let ts_checkpoint = client.latest_checkpoint().await?;
+    let ts_checkpoint = client.latest_checkpoint(None).await?;
     assert_eq!(
         ts_checkpoint.as_ref().checkpoint.log_length,
         packages.len() as RegistryLen + 2, /* publishes + initial checkpoint + yank*/
@@ -97,7 +97,7 @@ async fn it_works_with_postgres() -> TestResult {
     fs::remove_dir_all(root.join("content"))?;
     fs::remove_dir_all(root.join("registries"))?;
 
-    let client = create_client(&config)?;
+    let client = create_client(&config).await?;
     client.upsert(packages.iter()).await?;
 
     // Finally, after a restart, ensure the packages can be downloaded
@@ -106,7 +106,7 @@ async fn it_works_with_postgres() -> TestResult {
             continue;
         }
         client
-            .download(&package, &"0.1.0".parse()?)
+            .download(None, &package, &"0.1.0".parse()?)
             .await?
             .context("failed to resolve package")?;
     }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -43,8 +43,8 @@ pub fn test_signing_key() -> PrivateKey {
     PrivateKey::decode(key.to_string()).unwrap()
 }
 
-pub fn create_client(config: &warg_client::Config) -> Result<FileSystemClient> {
-    match FileSystemClient::try_new_with_config(None, config, None)? {
+pub async fn create_client(config: &warg_client::Config) -> Result<FileSystemClient> {
+    match FileSystemClient::try_new_with_config(None, config, None).await? {
         StorageLockResult::Acquired(client) => Ok(client),
         _ => bail!("failed to acquire storage lock"),
     }


### PR DESCRIPTION
Rather than updating the state at the beginning of a client interaction to use a specific url, the client expects to check the namespace storage for a url and pass it as an arg, better enabling consumers to fetch packages across multiple namespaces.

There is also updated logic for encouraging standard ways of retrying with `Warg-Hint-Header` responses from the registry after using the hint to update local namespace mappings.