### PR TITLE
Clean up some clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4092,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "warg-api"
-version = "0.5.0-dev"
+version = "0.7.0-dev"
 dependencies = [
  "indexmap 2.2.4",
  "itertools 0.12.1",
@@ -4105,7 +4105,7 @@ dependencies = [
 
 [[package]]
 name = "warg-cli"
-version = "0.5.0-dev"
+version = "0.7.0-dev"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "warg-client"
-version = "0.5.0-dev"
+version = "0.7.0-dev"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -4191,14 +4191,14 @@ dependencies = [
 
 [[package]]
 name = "warg-credentials"
-version = "0.5.0-dev"
+version = "0.7.0-dev"
 dependencies = [
  "warg-client",
 ]
 
 [[package]]
 name = "warg-crypto"
-version = "0.5.0-dev"
+version = "0.7.0-dev"
 dependencies = [
  "anyhow",
  "base64",
@@ -4218,7 +4218,7 @@ dependencies = [
 
 [[package]]
 name = "warg-protobuf"
-version = "0.5.0-dev"
+version = "0.7.0-dev"
 dependencies = [
  "anyhow",
  "pbjson",
@@ -4235,7 +4235,7 @@ dependencies = [
 
 [[package]]
 name = "warg-protocol"
-version = "0.5.0-dev"
+version = "0.7.0-dev"
 dependencies = [
  "anyhow",
  "base64",
@@ -4258,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "warg-server"
-version = "0.5.0-dev"
+version = "0.7.0-dev"
 dependencies = [
  "anyhow",
  "axum",
@@ -4294,7 +4294,7 @@ dependencies = [
 
 [[package]]
 name = "warg-transparency"
-version = "0.5.0-dev"
+version = "0.7.0-dev"
 dependencies = [
  "anyhow",
  "criterion",

--- a/crates/client/src/keyring.rs
+++ b/crates/client/src/keyring.rs
@@ -3,7 +3,7 @@
 use crate::RegistryUrl;
 use anyhow::{bail, Context, Result};
 use indexmap::IndexSet;
-use secrecy::{self, Secret};
+use secrecy::Secret;
 use warg_crypto::signing::PrivateKey;
 
 /// Gets the auth token entry for the given registry and key name.

--- a/crates/crypto/src/hash/static.rs
+++ b/crates/crypto/src/hash/static.rs
@@ -154,8 +154,7 @@ impl<'de, T: SupportedDigest> Deserialize<'de> for Hash<T> {
                 formatter.write_fmt(format_args!("{} bytes", self.0.as_ref().len()))
             }
 
-            #[cfg(feature = "alloc")]
-            fn visit_byte_buf<E: Error>(self, v: alloc::vec::Vec<u8>) -> Result<Self::Value, E> {
+            fn visit_byte_buf<E: Error>(self, v: Vec<u8>) -> Result<Self::Value, E> {
                 self.visit_bytes(&v)
             }
 

--- a/crates/crypto/src/signing/public_key.rs
+++ b/crates/crypto/src/signing/public_key.rs
@@ -1,7 +1,6 @@
 use super::{Signature, SignatureAlgorithm, SignatureAlgorithmParseError};
 use base64::{engine::general_purpose::STANDARD, Engine};
 use core::fmt;
-use p256;
 use serde::{Deserialize, Serialize};
 use signature::{Error as SignatureError, Verifier};
 use std::str::FromStr;

--- a/crates/protocol/tests/operator.rs
+++ b/crates/protocol/tests/operator.rs
@@ -39,7 +39,7 @@ fn validate_input(input: Vec<EnvelopeData>) -> Result<LogState> {
             let key = signing::PrivateKey::decode(e_data.key.clone()).unwrap();
             let mut record: operator::OperatorRecord = e_data.contents.try_into().unwrap();
 
-            record.prev = last.clone();
+            record.prev.clone_from(last);
 
             let envelope = ProtoEnvelope::signed_contents(&key, record).unwrap();
 

--- a/crates/protocol/tests/package.rs
+++ b/crates/protocol/tests/package.rs
@@ -38,7 +38,7 @@ fn validate_input(input: Vec<EnvelopeData>) -> Result<LogState> {
             let key = signing::PrivateKey::decode(e_data.key.clone()).unwrap();
             let mut record: package::PackageRecord = e_data.contents.try_into().unwrap();
 
-            record.prev = last.clone();
+            record.prev.clone_from(last);
 
             let envelope = ProtoEnvelope::signed_contents(&key, record).unwrap();
 

--- a/crates/server/src/datastore/postgres/models.rs
+++ b/crates/server/src/datastore/postgres/models.rs
@@ -91,6 +91,7 @@ pub struct NewCheckpoint<'a> {
 
 #[derive(Queryable)]
 #[diesel(table_name = checkpoints)]
+#[allow(dead_code)]
 pub struct CheckpointData {
     pub id: i32,
     pub checkpoint_id: ParsedText<AnyHash>,


### PR DESCRIPTION
Remove some unused imports, use `clone_from` where appropriate, allow unread fields on a Postgres-related structure, and fix a `#[cfg(feature = ...)]` referencing a non-existent feature.