### PR TITLE
Configurable keyring backends

### DIFF
--- a/crates/client/src/config.rs
+++ b/crates/client/src/config.rs
@@ -126,6 +126,10 @@ pub struct Config {
     /// Disable interactive prompts.
     #[serde(default)]
     pub disable_interactive: bool,
+
+    /// Use the specified backend for keyring access.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub keyring_backend: Option<String>,
 }
 
 impl Config {
@@ -207,6 +211,7 @@ impl Config {
             ignore_federation_hints: self.ignore_federation_hints,
             auto_accept_federation_hints: self.auto_accept_federation_hints,
             disable_interactive: self.disable_interactive,
+            keyring_backend: self.keyring_backend.clone(),
         };
 
         serde_json::to_writer_pretty(

--- a/crates/client/src/keyring.rs
+++ b/crates/client/src/keyring.rs
@@ -1,201 +1,331 @@
 //! Utilities for interacting with keyring and performing signing operations.
 
 use crate::RegistryUrl;
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context};
 use indexmap::IndexSet;
 use secrecy::Secret;
 use warg_crypto::signing::PrivateKey;
 
-/// Gets the auth token entry for the given registry and key name.
-pub fn get_auth_token_entry(registry_url: &RegistryUrl) -> Result<keyring::Entry> {
-    let label = format!("warg-auth-token:{}", registry_url.safe_label());
-    keyring::Entry::new(&label, &registry_url.safe_label()).context("failed to get keyring entry")
+/// Interface to a pluggable keyring backend
+#[derive(Debug)]
+pub struct Keyring {
+    imp: Box<keyring::CredentialBuilder>,
 }
 
-/// Gets the auth token
-pub fn get_auth_token(registry_url: &RegistryUrl) -> Result<Option<Secret<String>>> {
-    let entry = get_auth_token_entry(registry_url)?;
-    match entry.get_password() {
-        Ok(secret) => Ok(Some(Secret::from(secret))),
-        Err(keyring::Error::NoEntry) => Ok(None),
-        Err(keyring::Error::Ambiguous(_)) => {
-            bail!("more than one auth token for registry `{registry_url}`");
-        }
-        Err(e) => {
-            bail!("failed to get auth token for registry `{registry_url}`: {e}");
+/// The type of keyring errors.
+/// 
+/// Currently just a synonym for [`anyhow::Error`], but will change to
+/// something capable of more user-friendly diagnostics.
+pub type KeyringError = anyhow::Error;
+
+/// Result type for keyring errors.
+pub type Result<T, E = KeyringError> = std::result::Result<T, E>;
+
+impl Keyring {
+    #[cfg(target_os = "linux")]
+    /// List of supported credential store backends
+    pub const SUPPORTED_BACKENDS: &'static [&'static str] =
+        &["secret-service", "linux-keyutils", "mock"];
+    #[cfg(any(target_os = "freebsd", target_os = "openbsd"))]
+    /// List of supported credential store backends
+    pub const SUPPORTED_BACKENDS: &'static [&'static str] = &["secret-service", "mock"];
+    #[cfg(target_os = "windows")]
+    /// List of supported credential store backends
+    pub const SUPPORTED_BACKENDS: &'static [&'static str] = &["windows", "mock"];
+    #[cfg(target_os = "macos")]
+    /// List of supported credential store backends
+    pub const SUPPORTED_BACKENDS: &'static [&'static str] = &["macos", "mock"];
+    #[cfg(target_os = "ios")]
+    /// List of supported credential store backends
+    pub const SUPPORTED_BACKENDS: &'static [&'static str] = &["ios", "mock"];
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "windows",
+    )))]
+    /// List of supported credential store backends
+    pub const SUPPORTED_BACKENDS: &'static [&'static str] = &["mock"];
+
+    /// The default backend when no configuration option is set
+    pub const DEFAULT_BACKEND: &'static str = Self::SUPPORTED_BACKENDS[0];
+
+    /// Returns a human-readable description of a keyring backend.
+    pub fn describe_backend(backend: &str) -> &'static str {
+        match backend {
+            "secret-service" => "Freedesktop.org secret service (GNOME Keyring or KWallet)",
+            "linux-keyutils" => "Linux kernel memory-based keystore (lacks persistence, not suitable for desktop use)",
+            "windows" => "Windows Credential Manager",
+            "macos" => "MacOS Keychain",
+            "ios" => "Apple iOS Keychain",
+            "mock" => "Mock credential store with no persistence (for testing only)",
+            _ => "(no description available)"
         }
     }
-}
 
-/// Deletes the auth token
-pub fn delete_auth_token(registry_url: &RegistryUrl) -> Result<()> {
-    let entry = get_auth_token_entry(registry_url)?;
-    match entry.delete_password() {
-        Ok(()) => Ok(()),
-        Err(keyring::Error::NoEntry) => {
-            bail!("no auth token found for registry `{registry_url}`");
+    fn load_backend(backend: &str) -> Option<Box<keyring::CredentialBuilder>> {
+        if !Self::SUPPORTED_BACKENDS.contains(&backend) {
+            return None;
         }
-        Err(keyring::Error::Ambiguous(_)) => {
-            bail!("more than one auth token found for registry `{registry_url}`");
+
+        #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
+        if backend == "secret-service" {
+            return Some(keyring::secret_service::default_credential_builder());
         }
-        Err(e) => {
-            bail!("failed to delete auth torkn for registry `{registry_url}`: {e}");
+
+        #[cfg(target_os = "linux")]
+        if backend == "linux-keyutils" {
+            return Some(keyring::keyutils::default_credential_builder());
+        }
+
+        #[cfg(target_os = "macos")]
+        if backend == "macos" {
+            return Some(keyring::macos::default_credential_builder());
+        }
+
+        #[cfg(target_os = "ios")]
+        if backend == "ios" {
+            return Some(keyring::ios::default_credential_builder());
+        }
+
+        #[cfg(target_os = "windows")]
+        if backend == "windows" {
+            return Some(keyring::windows::default_credential_builder());
+        }
+
+        if backend == "mock" {
+            return Some(keyring::mock::default_credential_builder());
+        }
+
+        unreachable!("missing logic for backend {backend}")
+    }
+
+    /// Instantiate a new keyring.
+    ///
+    /// The argument should be an element of [Self::SUPPORTED_BACKENDS].
+    pub fn new(backend: &str) -> Result<Self> {
+        Self::load_backend(backend)
+            .ok_or_else(|| anyhow!("failed to initialize keyring: unsupported backend {backend}"))
+            .map(|imp| Self { imp })
+    }
+
+    /// Gets the auth token entry for the given registry and key name.
+    pub fn get_auth_token_entry(&self, registry_url: &RegistryUrl) -> Result<keyring::Entry> {
+        let label = format!("warg-auth-token:{}", registry_url.safe_label());
+        let cred = self
+            .imp
+            .build(None, &label, &registry_url.safe_label())
+            .context("failed to get keyring entry")?;
+        Ok(keyring::Entry::new_with_credential(cred))
+    }
+
+    /// Gets the auth token
+    pub fn get_auth_token(&self, registry_url: &RegistryUrl) -> Result<Option<Secret<String>>> {
+        let entry = self.get_auth_token_entry(registry_url)?;
+        match entry.get_password() {
+            Ok(secret) => Ok(Some(Secret::from(secret))),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(keyring::Error::Ambiguous(_)) => {
+                bail!("more than one auth token for registry `{registry_url}`");
+            }
+            Err(e) => {
+                bail!("failed to get auth token for registry `{registry_url}`: {e}");
+            }
         }
     }
-}
 
-/// Sets the auth token
-pub fn set_auth_token(registry_url: &RegistryUrl, token: &str) -> Result<()> {
-    let entry = get_auth_token_entry(registry_url)?;
-    match entry.set_password(token) {
-        Ok(()) => Ok(()),
-        Err(keyring::Error::NoEntry) => {
-            bail!("no auth token found for registry `{registry_url}`");
-        }
-        Err(keyring::Error::Ambiguous(_)) => {
-            bail!("more than one auth token for registry `{registry_url}`");
-        }
-        Err(e) => {
-            bail!("failed to set auth token for registry `{registry_url}`: {e}");
+    /// Deletes the auth token
+    pub fn delete_auth_token(&self, registry_url: &RegistryUrl) -> Result<()> {
+        let entry = self.get_auth_token_entry(registry_url)?;
+        match entry.delete_password() {
+            Ok(()) => Ok(()),
+            Err(keyring::Error::NoEntry) => {
+                bail!("no auth token found for registry `{registry_url}`");
+            }
+            Err(keyring::Error::Ambiguous(_)) => {
+                bail!("more than one auth token found for registry `{registry_url}`");
+            }
+            Err(e) => {
+                bail!("failed to delete auth token for registry `{registry_url}`: {e}");
+            }
         }
     }
-}
 
-/// Gets the signing key entry for the given registry and key name.
-pub fn get_signing_key_entry(
-    registry_url: Option<&str>,
-    keys: &IndexSet<String>,
-    home_url: Option<&str>,
-) -> Result<keyring::Entry> {
-    if let Some(registry_url) = registry_url {
-        if keys.contains(registry_url) {
-            keyring::Entry::new("warg-signing-key", registry_url)
-                .context("failed to get keyring entry")
+    /// Sets the auth token
+    pub fn set_auth_token(&self, registry_url: &RegistryUrl, token: &str) -> Result<()> {
+        let entry = self.get_auth_token_entry(registry_url)?;
+        match entry.set_password(token) {
+            Ok(()) => Ok(()),
+            Err(keyring::Error::NoEntry) => {
+                bail!("no auth token found for registry `{registry_url}`");
+            }
+            Err(keyring::Error::Ambiguous(_)) => {
+                bail!("more than one auth token for registry `{registry_url}`");
+            }
+            Err(e) => {
+                bail!("failed to set auth token for registry `{registry_url}`: {e}");
+            }
+        }
+    }
+
+    /// Gets the signing key entry for the given registry and key name.
+    pub fn get_signing_key_entry(
+        &self,
+        registry_url: Option<&str>,
+        keys: &IndexSet<String>,
+        home_url: Option<&str>,
+    ) -> Result<keyring::Entry> {
+        if let Some(registry_url) = registry_url {
+            let user = if keys.contains(registry_url) {
+                registry_url
+            } else {
+                "default"
+            };
+            let cred = self
+                .imp
+                .build(None, "warg-signing-key", user)
+                .context("failed to get keyring entry")?;
+            Ok(keyring::Entry::new_with_credential(cred))
         } else {
-            keyring::Entry::new("warg-signing-key", "default")
-                .context("failed to get keyring entry")
+            if let Some(url) = home_url {
+                if keys.contains(url) {
+                    let cred = self
+                        .imp
+                        .build(
+                            None,
+                            "warg-signing-key",
+                            &RegistryUrl::new(url)?.safe_label(),
+                        )
+                        .context("failed to get keyring entry")?;
+                    return Ok(keyring::Entry::new_with_credential(cred));
+                }
+            }
+
+            if keys.contains("default") {
+                let cred = self
+                    .imp
+                    .build(None, "warg-signing-key", "default")
+                    .context("failed to get keyring entry")?;
+                return Ok(keyring::Entry::new_with_credential(cred));
+            }
+
+            bail!("error: Please set a default signing key by typing `warg key set <alg:base64>` or `warg key new`");
         }
-    } else {
-        if let Some(url) = home_url {
-            if keys.contains(url) {
-                return keyring::Entry::new(
-                    "warg-signing-key",
-                    &RegistryUrl::new(url)?.safe_label(),
-                )
-                .context("failed to get keyring entry");
+    }
+
+    /// Gets the signing key for the given registry registry_label and key name.
+    pub fn get_signing_key(
+        &self,
+        // If being called by a cli key command, this will always be a cli flag
+        // If being called by a client publish command, this could also be supplied by namespace map config
+        registry_url: Option<&str>,
+        keys: &IndexSet<String>,
+        home_url: Option<&str>,
+    ) -> Result<PrivateKey> {
+        let entry = self.get_signing_key_entry(registry_url, keys, home_url)?;
+
+        match entry.get_password() {
+            Ok(secret) => PrivateKey::decode(secret).context("failed to parse signing key"),
+            Err(keyring::Error::NoEntry) => {
+                if let Some(registry_url) = registry_url {
+                    bail!("no signing key found for registry `{registry_url}`");
+                } else {
+                    bail!("no signing key found");
+                }
+            }
+            Err(keyring::Error::Ambiguous(_)) => {
+                if let Some(registry_url) = registry_url {
+                    bail!("more than one signing key found for registry `{registry_url}`");
+                } else {
+                    bail!("more than one signing key found");
+                }
+            }
+            Err(e) => {
+                if let Some(registry_url) = registry_url {
+                    bail!("failed to get signing key for registry `{registry_url}`: {e}");
+                } else {
+                    bail!("failed to get signing key`");
+                }
             }
         }
-        if keys.contains("default") {
-            keyring::Entry::new("warg-signing-key", "default")
-                .context("failed to get keyring entry")
-        } else {
-            bail!(
-                        "error: Please set a default signing key by typing `warg key set <alg:base64>` or `warg key new`"
-                    )
+    }
+
+    /// Sets the signing key for the given registry host and key name.
+    pub fn set_signing_key(
+        &self,
+        registry_url: Option<&str>,
+        key: &PrivateKey,
+        keys: &mut IndexSet<String>,
+        home_url: Option<&str>,
+    ) -> Result<()> {
+        let entry = self.get_signing_key_entry(registry_url, keys, home_url)?;
+        match entry.set_password(&key.encode()) {
+            Ok(()) => Ok(()),
+            Err(keyring::Error::NoEntry) => {
+                if let Some(registry_url) = registry_url {
+                    bail!("no signing key found for registry `{registry_url}`");
+                } else {
+                    bail!("no signing key found`");
+                }
+            }
+            Err(keyring::Error::Ambiguous(_)) => {
+                if let Some(registry_url) = registry_url {
+                    bail!("more than one signing key found for registry `{registry_url}`");
+                } else {
+                    bail!("more than one signing key found");
+                }
+            }
+            Err(e) => {
+                if let Some(registry_url) = registry_url {
+                    bail!("failed to get signing key for registry `{registry_url}`: {e}");
+                } else {
+                    bail!("failed to get signing: {e}");
+                }
+            }
+        }
+    }
+
+    /// Deletes the signing key for the given registry host and key name.
+    pub fn delete_signing_key(
+        &self,
+        registry_url: Option<&str>,
+        keys: &IndexSet<String>,
+        home_url: Option<&str>,
+    ) -> Result<()> {
+        let entry = self.get_signing_key_entry(registry_url, keys, home_url)?;
+
+        match entry.delete_password() {
+            Ok(()) => Ok(()),
+            Err(keyring::Error::NoEntry) => {
+                if let Some(registry_url) = registry_url {
+                    bail!("no signing key found for registry `{registry_url}`");
+                } else {
+                    bail!("no signing key found");
+                }
+            }
+            Err(keyring::Error::Ambiguous(_)) => {
+                if let Some(registry_url) = registry_url {
+                    bail!("more than one signing key found for registry `{registry_url}`");
+                } else {
+                    bail!("more than one signing key found`");
+                }
+            }
+            Err(e) => {
+                if let Some(registry_url) = registry_url {
+                    bail!("failed to delete signing key for registry `{registry_url}`: {e}");
+                } else {
+                    bail!("failed to delete signing key");
+                }
+            }
         }
     }
 }
 
-/// Gets the signing key for the given registry registry_label and key name.
-pub fn get_signing_key(
-    // If being called by a cli key command, this will always be a cli flag
-    // If being called by a client publish command, this could also be supplied by namespace map config
-    registry_url: Option<&str>,
-    keys: &IndexSet<String>,
-    home_url: Option<&str>,
-) -> Result<PrivateKey> {
-    let entry = get_signing_key_entry(registry_url, keys, home_url)?;
-
-    match entry.get_password() {
-        Ok(secret) => PrivateKey::decode(secret).context("failed to parse signing key"),
-        Err(keyring::Error::NoEntry) => {
-            if let Some(registry_url) = registry_url {
-                bail!("no signing key found for registry `{registry_url}`");
-            } else {
-                bail!("no signing key found");
-            }
-        }
-        Err(keyring::Error::Ambiguous(_)) => {
-            if let Some(registry_url) = registry_url {
-                bail!("more than one signing key found for registry `{registry_url}`");
-            } else {
-                bail!("more than one signing key found");
-            }
-        }
-        Err(e) => {
-            if let Some(registry_url) = registry_url {
-                bail!("failed to get signing key for registry `{registry_url}`: {e}");
-            } else {
-                bail!("failed to get signing key`");
-            }
-        }
-    }
-}
-
-/// Sets the signing key for the given registry host and key name.
-pub fn set_signing_key(
-    registry_url: Option<&str>,
-    key: &PrivateKey,
-    keys: &mut IndexSet<String>,
-    home_url: Option<&str>,
-) -> Result<()> {
-    let entry = get_signing_key_entry(registry_url, keys, home_url)?;
-    match entry.set_password(&key.encode()) {
-        Ok(()) => Ok(()),
-        Err(keyring::Error::NoEntry) => {
-            if let Some(registry_url) = registry_url {
-                bail!("no signing key found for registry `{registry_url}`");
-            } else {
-                bail!("no signing key found`");
-            }
-        }
-        Err(keyring::Error::Ambiguous(_)) => {
-            if let Some(registry_url) = registry_url {
-                bail!("more than one signing key found for registry `{registry_url}`");
-            } else {
-                bail!("more than one signing key found");
-            }
-        }
-        Err(e) => {
-            if let Some(registry_url) = registry_url {
-                bail!("failed to get signing key for registry `{registry_url}`: {e}");
-            } else {
-                bail!("failed to get signing: {e}");
-            }
-        }
-    }
-}
-
-/// Deletes the signing key for the given registry host and key name.
-pub fn delete_signing_key(
-    registry_url: Option<&str>,
-    keys: &IndexSet<String>,
-    home_url: Option<&str>,
-) -> Result<()> {
-    let entry = get_signing_key_entry(registry_url, keys, home_url)?;
-
-    match entry.delete_password() {
-        Ok(()) => Ok(()),
-        Err(keyring::Error::NoEntry) => {
-            if let Some(registry_url) = registry_url {
-                bail!("no signing key found for registry `{registry_url}`");
-            } else {
-                bail!("no signing key found");
-            }
-        }
-        Err(keyring::Error::Ambiguous(_)) => {
-            if let Some(registry_url) = registry_url {
-                bail!("more than one signing key found for registry `{registry_url}`");
-            } else {
-                bail!("more than one signing key found`");
-            }
-        }
-        Err(e) => {
-            if let Some(registry_url) = registry_url {
-                bail!("failed to delete signing key for registry `{registry_url}`: {e}");
-            } else {
-                bail!("failed to delete signing key");
-            }
-        }
+impl std::default::Default for Keyring {
+    fn default() -> Self {
+        Self::new(Self::DEFAULT_BACKEND)
+            .expect("loading the default keyring backend should never fail")
     }
 }

--- a/crates/client/src/keyring/error.rs
+++ b/crates/client/src/keyring/error.rs
@@ -1,0 +1,176 @@
+use std::fmt::Display;
+
+/// Error returned when a keyring operation fails.
+#[derive(Debug)]
+pub struct KeyringError(KeyringErrorImpl);
+
+#[derive(Debug)]
+enum KeyringErrorImpl {
+    UnknownBackend {
+        backend: String,
+    },
+    NoDefaultSigningKey {
+        backend: &'static str,
+    },
+    AccessError {
+        backend: &'static str,
+        entry: KeyringEntry,
+        action: KeyringAction,
+        cause: KeyringErrorCause,
+    },
+}
+
+#[derive(Debug)]
+pub(super) enum KeyringErrorCause {
+    Backend(keyring::Error),
+    Other(anyhow::Error),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum KeyringEntry {
+    AuthToken { registry: String },
+    SigningKey { registry: Option<String> },
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(super) enum KeyringAction {
+    Open,
+    Get,
+    Set,
+    Delete,
+}
+
+impl From<keyring::Error> for KeyringErrorCause {
+    fn from(error: keyring::Error) -> Self {
+        KeyringErrorCause::Backend(error)
+    }
+}
+
+impl From<anyhow::Error> for KeyringErrorCause {
+    fn from(error: anyhow::Error) -> Self {
+        KeyringErrorCause::Other(error)
+    }
+}
+
+impl KeyringError {
+    pub(super) fn unknown_backend(backend: String) -> Self {
+        KeyringError(KeyringErrorImpl::UnknownBackend { backend })
+    }
+
+    pub(super) fn no_default_signing_key(backend: &'static str) -> Self {
+        KeyringError(KeyringErrorImpl::NoDefaultSigningKey { backend })
+    }
+
+    pub(super) fn auth_token_access_error(
+        backend: &'static str,
+        registry: &(impl Display + ?Sized),
+        action: KeyringAction,
+        cause: impl Into<KeyringErrorCause>,
+    ) -> Self {
+        KeyringError(KeyringErrorImpl::AccessError {
+            backend,
+            entry: KeyringEntry::AuthToken {
+                registry: registry.to_string(),
+            },
+            action,
+            cause: cause.into(),
+        })
+    }
+
+    pub(super) fn signing_key_access_error(
+        backend: &'static str,
+        registry: Option<&(impl Display + ?Sized)>,
+        action: KeyringAction,
+        cause: impl Into<KeyringErrorCause>,
+    ) -> Self {
+        KeyringError(KeyringErrorImpl::AccessError {
+            backend,
+            entry: KeyringEntry::SigningKey {
+                registry: registry.map(|s| s.to_string()),
+            },
+            action,
+            cause: cause.into(),
+        })
+    }
+}
+
+impl std::fmt::Display for KeyringErrorCause {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            KeyringErrorCause::Backend(e) => e.fmt(f),
+            KeyringErrorCause::Other(e) => e.fmt(f),
+        }
+    }
+}
+
+impl std::fmt::Display for KeyringError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "keyring error: ")?;
+        match &self.0 {
+            KeyringErrorImpl::UnknownBackend { backend } => {
+                write!(f, "unknown backend '{backend}'. Run `warg config --keyring_backend <backend>` to configure a keyring backend supported on this platform.")
+            }
+            KeyringErrorImpl::NoDefaultSigningKey { backend } => {
+                let _ = backend;
+                write!(f, "no default signing key is set. Please create one by running `warg key set <alg:base64>` or `warg key new`")
+            }
+            KeyringErrorImpl::AccessError {
+                backend,
+                entry,
+                action,
+                cause,
+            } => {
+                match *action {
+                    KeyringAction::Open => write!(f, "failed to open ")?,
+                    KeyringAction::Get => write!(f, "failed to read ")?,
+                    KeyringAction::Set => write!(f, "failed to set ")?,
+                    KeyringAction::Delete => write!(f, "failed to delete ")?,
+                };
+                match entry {
+                    KeyringEntry::AuthToken { registry } => {
+                        write!(f, "auth token for registry <{registry}>.")?
+                    }
+                    KeyringEntry::SigningKey {
+                        registry: Some(registry),
+                    } => write!(f, "signing key for registry <{registry}>.")?,
+                    KeyringEntry::SigningKey { registry: None } => {
+                        write!(f, "default signing key.")?
+                    }
+                };
+
+                if *backend == "secret-service"
+                    && matches!(
+                        cause,
+                        KeyringErrorCause::Backend(keyring::Error::PlatformFailure(_))
+                    )
+                {
+                    write!(
+                        f,
+                        concat!(" Since you are using the 'secret-service' backend, ",
+                        "the likely cause of this error is that no secret service ",
+                        "implementation, such as GNOME Keyring or KWallet, is installed, ",
+                        "or one is installed but not correctly configured. Consult your OS ",
+                        "distribution's documentation for instructions on setting it up, or run ",
+                        "`warg config --keyring_backend <backend>` to use a different backend.")
+                    )?;
+                }
+
+                // The above will be followed by further information returned
+                // from `self.source()`.
+                Ok(())
+            }
+        }
+    }
+}
+
+impl std::error::Error for KeyringError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.0 {
+            KeyringErrorImpl::AccessError { cause, .. } => match cause {
+                KeyringErrorCause::Backend(e) => Some(e),
+                KeyringErrorCause::Other(e) => Some(e.as_ref()),
+            },
+            _ => None,
+        }
+    }
+}

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1346,7 +1346,7 @@ impl FileSystemClient {
 
         #[cfg(feature = "keyring")]
         if auth_token.is_none() && config.keyring_auth {
-            auth_token = crate::keyring::get_auth_token(&url)?
+            auth_token = crate::keyring::Keyring::default().get_auth_token(&url)?
         }
 
         Ok(StorageLockResult::Acquired(Self::new(
@@ -1401,7 +1401,7 @@ impl FileSystemClient {
 
         #[cfg(feature = "keyring")]
         if auth_token.is_none() && config.keyring_auth {
-            auth_token = crate::keyring::get_auth_token(&registry_url)?
+            auth_token = crate::keyring::Keyring::default().get_auth_token(&registry_url)?
         }
 
         Self::new(

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1346,7 +1346,7 @@ impl FileSystemClient {
 
         #[cfg(feature = "keyring")]
         if auth_token.is_none() && config.keyring_auth {
-            auth_token = crate::keyring::Keyring::default().get_auth_token(&url)?
+            auth_token = crate::keyring::Keyring::from_config(config)?.get_auth_token(&url)?
         }
 
         Ok(StorageLockResult::Acquired(Self::new(
@@ -1401,7 +1401,8 @@ impl FileSystemClient {
 
         #[cfg(feature = "keyring")]
         if auth_token.is_none() && config.keyring_auth {
-            auth_token = crate::keyring::Keyring::default().get_auth_token(&registry_url)?
+            auth_token =
+                crate::keyring::Keyring::from_config(config)?.get_auth_token(&registry_url)?
         }
 
         Self::new(

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1636,6 +1636,10 @@ pub enum ClientError {
         log_length: RegistryLen,
     },
 
+    /// An error occurred while accessing the keyring.
+    #[error(transparent)]
+    Keyring(#[from] crate::keyring::KeyringError),
+
     /// An error occurred during an API operation.
     #[error(transparent)]
     Api(#[from] api::ClientError),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 use clap::Args;
 use std::path::PathBuf;
-use warg_client::keyring::get_signing_key;
+use warg_client::keyring::Keyring;
 use warg_client::storage::RegistryDomain;
 use warg_client::{ClientError, Config, FileSystemClient, StorageLockResult};
 use warg_crypto::signing::PrivateKey;
@@ -88,7 +88,7 @@ impl CommonOptions {
         registry_domain: Option<&RegistryDomain>,
     ) -> Result<PrivateKey> {
         let config = self.read_config()?;
-        get_signing_key(
+        Keyring::default().get_signing_key(
             registry_domain.map(|domain| domain.to_string()).as_deref(),
             &config.keys,
             config.home_url.as_deref(),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -88,7 +88,7 @@ impl CommonOptions {
         registry_domain: Option<&RegistryDomain>,
     ) -> Result<PrivateKey> {
         let config = self.read_config()?;
-        Keyring::default().get_signing_key(
+        Keyring::from_config(&config)?.get_signing_key(
             registry_domain.map(|domain| domain.to_string()).as_deref(),
             &config.keys,
             config.home_url.as_deref(),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -88,10 +88,11 @@ impl CommonOptions {
         registry_domain: Option<&RegistryDomain>,
     ) -> Result<PrivateKey> {
         let config = self.read_config()?;
-        Keyring::from_config(&config)?.get_signing_key(
+        let key = Keyring::from_config(&config)?.get_signing_key(
             registry_domain.map(|domain| domain.to_string()).as_deref(),
             &config.keys,
             config.home_url.as_deref(),
-        )
+        )?;
+        Ok(key)
     }
 }

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -60,7 +60,7 @@ impl KeyNewCommand {
         } else {
             config.keys.insert("default".to_string());
         }
-        Keyring::default().set_signing_key(
+        Keyring::from_config(config)?.set_signing_key(
             self.common.registry.as_deref(),
             &key,
             &mut config.keys,
@@ -86,7 +86,7 @@ impl KeyInfoCommand {
     /// Executes the command.
     pub async fn exec(self) -> Result<()> {
         let config = &self.common.read_config()?;
-        let private_key = Keyring::default().get_signing_key(
+        let private_key = Keyring::from_config(config)?.get_signing_key(
             self.common.registry.as_deref(),
             &config.keys,
             config.home_url.as_deref(),
@@ -117,7 +117,7 @@ impl KeySetCommand {
             PrivateKey::decode(key_str).context("signing key is not in the correct format")?;
         let config = &mut self.common.read_config()?;
 
-        Keyring::default().set_signing_key(
+        Keyring::from_config(config)?.set_signing_key(
             self.common.registry.as_deref(),
             &key,
             &mut config.keys,
@@ -148,7 +148,7 @@ impl KeyDeleteCommand {
             .with_prompt("are you sure you want to delete your signing key")
             .interact()?
         {
-            Keyring::default().delete_signing_key(
+            Keyring::from_config(config)?.delete_signing_key(
                 self.common.registry.as_deref(),
                 &config.keys,
                 config.home_url.as_deref(),

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -3,10 +3,8 @@ use clap::{Args, Subcommand};
 use dialoguer::{theme::ColorfulTheme, Confirm, Password};
 use p256::ecdsa::SigningKey;
 use rand_core::OsRng;
-use warg_client::{
-    keyring::{delete_signing_key, get_signing_key, set_signing_key},
-    Config,
-};
+use warg_client::keyring::Keyring;
+use warg_client::Config;
 use warg_crypto::signing::PrivateKey;
 
 use super::CommonOptions;
@@ -62,7 +60,7 @@ impl KeyNewCommand {
         } else {
             config.keys.insert("default".to_string());
         }
-        set_signing_key(
+        Keyring::default().set_signing_key(
             self.common.registry.as_deref(),
             &key,
             &mut config.keys,
@@ -88,7 +86,7 @@ impl KeyInfoCommand {
     /// Executes the command.
     pub async fn exec(self) -> Result<()> {
         let config = &self.common.read_config()?;
-        let private_key = get_signing_key(
+        let private_key = Keyring::default().get_signing_key(
             self.common.registry.as_deref(),
             &config.keys,
             config.home_url.as_deref(),
@@ -119,7 +117,7 @@ impl KeySetCommand {
             PrivateKey::decode(key_str).context("signing key is not in the correct format")?;
         let config = &mut self.common.read_config()?;
 
-        set_signing_key(
+        Keyring::default().set_signing_key(
             self.common.registry.as_deref(),
             &key,
             &mut config.keys,
@@ -150,7 +148,7 @@ impl KeyDeleteCommand {
             .with_prompt("are you sure you want to delete your signing key")
             .interact()?
         {
-            delete_signing_key(
+            Keyring::default().delete_signing_key(
                 self.common.registry.as_deref(),
                 &config.keys,
                 config.home_url.as_deref(),

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -38,12 +38,13 @@ struct KeyringEntryArgs {
 impl KeyringEntryArgs {
     fn set_entry(&self, keyring: &Keyring, home_url: Option<String>, token: &str) -> Result<()> {
         if let Some(url) = &self.url {
-            keyring.set_auth_token(url, token)
+            keyring.set_auth_token(url, token)?;
         } else if let Some(url) = &home_url {
-            keyring.set_auth_token(&RegistryUrl::new(url)?, token)
+            keyring.set_auth_token(&RegistryUrl::new(url)?, token)?;
         } else {
             bail!("Please configure your home registry: warg config --registry <registry-url>")
         }
+        Ok(())
     }
 }
 

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -60,7 +60,7 @@ impl LoginCommand {
         let mut config = self.common.read_config()?;
         config.ignore_federation_hints = self.ignore_federation_hints;
         config.auto_accept_federation_hints = self.auto_accept_federation_hints;
-        let keyring = Keyring::default();
+        let keyring = Keyring::from_config(&config)?;
 
         if home_url.is_some() {
             config.home_url.clone_from(home_url);

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -3,10 +3,8 @@ use clap::Args;
 use dialoguer::{theme::ColorfulTheme, Password};
 use p256::ecdsa::SigningKey;
 use rand_core::OsRng;
-use warg_client::{
-    keyring::{set_auth_token, set_signing_key},
-    Config, RegistryUrl,
-};
+use warg_client::keyring::Keyring;
+use warg_client::{Config, RegistryUrl};
 
 use super::CommonOptions;
 
@@ -38,11 +36,11 @@ struct KeyringEntryArgs {
 }
 
 impl KeyringEntryArgs {
-    fn set_entry(&self, home_url: Option<String>, token: &str) -> Result<()> {
+    fn set_entry(&self, keyring: &Keyring, home_url: Option<String>, token: &str) -> Result<()> {
         if let Some(url) = &self.url {
-            set_auth_token(url, token)
+            keyring.set_auth_token(url, token)
         } else if let Some(url) = &home_url {
-            set_auth_token(&RegistryUrl::new(url)?, token)
+            keyring.set_auth_token(&RegistryUrl::new(url)?, token)
         } else {
             bail!("Please configure your home registry: warg config --registry <registry-url>")
         }
@@ -62,6 +60,7 @@ impl LoginCommand {
         let mut config = self.common.read_config()?;
         config.ignore_federation_hints = self.ignore_federation_hints;
         config.auto_accept_federation_hints = self.auto_accept_federation_hints;
+        let keyring = Keyring::default();
 
         if home_url.is_some() {
             config.home_url.clone_from(home_url);
@@ -78,14 +77,14 @@ impl LoginCommand {
         if config.keys.is_empty() {
             config.keys.insert("default".to_string());
             let key = SigningKey::random(&mut OsRng).into();
-            set_signing_key(None, &key, &mut config.keys, config.home_url.as_deref())?;
+            keyring.set_signing_key(None, &key, &mut config.keys, config.home_url.as_deref())?;
             let public_key = key.public_key();
             let token = Password::with_theme(&ColorfulTheme::default())
                 .with_prompt("Enter auth token")
                 .interact()
                 .context("failed to read token")?;
             self.keyring_entry
-                .set_entry(self.common.read_config()?.home_url, &token)?;
+                .set_entry(&keyring, self.common.read_config()?.home_url, &token)?;
             config.write_to_file(&Config::default_config_path()?)?;
             println!("auth token was set successfully, and generated default key",);
             println!("Public Key: {public_key}");
@@ -97,7 +96,7 @@ impl LoginCommand {
             .interact()
             .context("failed to read token")?;
         self.keyring_entry
-            .set_entry(self.common.read_config()?.home_url, &token)?;
+            .set_entry(&keyring, self.common.read_config()?.home_url, &token)?;
         config.write_to_file(&Config::default_config_path()?)?;
         println!("auth token was set successfully",);
         Ok(())

--- a/src/commands/logout.rs
+++ b/src/commands/logout.rs
@@ -26,12 +26,13 @@ struct KeyringEntryArgs {
 impl KeyringEntryArgs {
     fn delete_entry(&self, keyring: &Keyring, home_url: Option<String>) -> Result<()> {
         if let Some(url) = &self.url {
-            keyring.delete_auth_token(url)
+            keyring.delete_auth_token(url)?;
         } else if let Some(url) = &home_url {
-            keyring.delete_auth_token(&RegistryUrl::new(url)?)
+            keyring.delete_auth_token(&RegistryUrl::new(url)?)?;
         } else {
             bail!("Please configure your home registry: warg config --registry <registry-url>")
         }
+        Ok(())
     }
 }
 

--- a/src/commands/logout.rs
+++ b/src/commands/logout.rs
@@ -38,10 +38,10 @@ impl KeyringEntryArgs {
 impl LogoutCommand {
     /// Executes the command.
     pub async fn exec(self) -> Result<()> {
-        let keyring = Keyring::default();
-        self.keyring_entry
-            .delete_entry(&keyring, self.common.read_config()?.home_url)?;
         let mut config = self.common.read_config()?;
+        let keyring = Keyring::from_config(&config)?;
+        self.keyring_entry
+            .delete_entry(&keyring, config.home_url.clone())?;
         config.keyring_auth = false;
         config.write_to_file(&Config::default_config_path()?)?;
         println!("auth token was deleted successfully",);

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -170,6 +170,7 @@ pub async fn spawn_server(
         ignore_federation_hints: false,
         auto_accept_federation_hints: false,
         disable_interactive: true,
+        keyring_backend: None,
     };
 
     Ok((instance, config))


### PR DESCRIPTION
Makes keyring backends user-selectable, as discussed in https://github.com/bytecodealliance/registry/issues/271#issuecomment-2100908799.

- [x] Refactor `client::keyring` functions into a `Keyring` struct which can be instantiated with a backend selection.
- [x] Add a config option to control what backend is used.
- [x] Improve error reporting when the `secret-service` backend isn't working.
- [ ] Add a `flat-file` backend that stores keys in plaintext alongside the config file.