### PR TITLE
improved `login` and `config` subcommands

### DIFF
--- a/src/commands/download.rs
+++ b/src/commands/download.rs
@@ -30,7 +30,7 @@ impl DownloadCommand {
         let config = self.common.read_config()?;
         let client = self.common.create_client(&config)?;
 
-        println!("downloading package `{name}`...", name = self.name);
+        println!("Downloading `{name}`...", name = self.name);
 
         // if user specifies exact verion, then set the `VersionReq` to exact match
         let version = match &self.version {
@@ -47,8 +47,7 @@ impl DownloadCommand {
             })?;
 
         println!(
-            "Downloaded version {version} of package `{name}` ({digest}) to local cache",
-            name = self.name,
+            "Downloaded version: {version}\nDigest: {digest}\n",
             version = download.version,
             digest = download.digest
         );

--- a/src/commands/logout.rs
+++ b/src/commands/logout.rs
@@ -1,7 +1,6 @@
-use anyhow::{bail, Result};
+use anyhow::Result;
 use clap::Args;
-use warg_client::{Config, RegistryUrl};
-use warg_credentials::keyring::Keyring;
+use warg_client::{keyring::Keyring, Config, RegistryUrl};
 
 use super::CommonOptions;
 
@@ -11,41 +10,37 @@ pub struct LogoutCommand {
     /// The common command options.
     #[clap(flatten)]
     pub common: CommonOptions,
-    /// The subcommand to execute.
-    #[clap(flatten)]
-    keyring_entry: KeyringEntryArgs,
-}
-
-#[derive(Args)]
-struct KeyringEntryArgs {
-    /// The URL of the registry to delete an auth token for.
-    #[clap(value_name = "URL")]
-    pub url: Option<RegistryUrl>,
-}
-
-impl KeyringEntryArgs {
-    fn delete_entry(&self, keyring: &Keyring, home_url: Option<String>) -> Result<()> {
-        if let Some(url) = &self.url {
-            keyring.delete_auth_token(url)?;
-        } else if let Some(url) = &home_url {
-            keyring.delete_auth_token(&RegistryUrl::new(url)?)?;
-        } else {
-            bail!("Please configure your home registry: warg config --registry <registry-url>")
-        }
-        Ok(())
-    }
 }
 
 impl LogoutCommand {
     /// Executes the command.
     pub async fn exec(self) -> Result<()> {
         let mut config = self.common.read_config()?;
+        let registry_url = &self
+            .common
+            .registry
+            .as_deref()
+            .or(config.home_url.as_deref())
+            .map(RegistryUrl::new)
+            .transpose()?
+            .ok_or(anyhow::anyhow!(
+                "Registry is not specified, so nothing to logout."
+            ))?;
         let keyring = Keyring::from_config(&config)?;
-        self.keyring_entry
-            .delete_entry(&keyring, config.home_url.clone())?;
-        config.keyring_auth = false;
-        config.write_to_file(&Config::default_config_path()?)?;
-        println!("auth token was deleted successfully",);
+        keyring.delete_auth_token(registry_url)?;
+        let registry_url_str = registry_url.to_string();
+        if config
+            .home_url
+            .as_deref()
+            .is_some_and(|home_url| home_url == registry_url_str)
+        {
+            config.keyring_auth = false;
+            config.write_to_file(&Config::default_config_path()?)?;
+        }
+        println!(
+            "Logged out of registry: {registry}",
+            registry = registry_url_str
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
- `warg config` now lets you modify your current settings instead of forcing an overwrite
- `warg login --registry` asks you if you want to set that registry as your home / default registry
- Clearer messaging on the CLI on what registry is being used