### PR TITLE
Client publish improvement and yank confirmation

### DIFF
--- a/crates/client/src/config.rs
+++ b/crates/client/src/config.rs
@@ -107,7 +107,7 @@ pub struct Config {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub namespace_map_path: Option<PathBuf>,
 
-    /// List of creds availabe in keyring
+    /// List of creds available in keyring
     #[serde(default, skip_serializing_if = "IndexSet::is_empty")]
     pub keys: IndexSet<String>,
 


### PR DESCRIPTION
- added a client method `sign_with_keyring_and_publish` ("keyring" feature required), making it easier for other crates that use the `warg-client` enable publishing
- when `warg publish yank`, adds a confirmation and more description #289 #264 