### PR TITLE
Well known config

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -5,6 +5,22 @@ pub mod v1;
 
 use serde::{de::Unexpected, Deserialize, Serialize};
 
+/// Relative URL path for the `WellKnownConfig`.
+pub const WELL_KNOWN_PATH: &str = ".well-known/wasm-pkg/registry.json";
+
+/// This config allows a domain to point to another URL where the registry
+/// API is hosted.
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WellKnownConfig {
+    /// For OCI registries, the domain name where the registry is hosted.
+    pub oci_registry: Option<String>,
+    /// For OCI registries, a name prefix to use before the namespace.
+    pub oci_namespace_prefix: Option<String>,
+    /// For Warg registries, the URL where the registry is hosted.
+    pub warg_url: Option<String>,
+}
+
 /// A utility type for serializing and deserializing constant status codes.
 struct Status<const CODE: u16>;
 

--- a/crates/client/src/api.rs
+++ b/crates/client/src/api.rs
@@ -231,7 +231,7 @@ impl Client {
         let res = self.client.get(url).send().await?;
 
         if !res.status().is_success() {
-            tracing::debug!("the `.well-known` config was not found");
+            tracing::debug!("the `.well-known` config request returned HTTP status `{status}`", status = res.status());
             return Ok(None);
         }
 

--- a/crates/client/src/api.rs
+++ b/crates/client/src/api.rs
@@ -231,7 +231,10 @@ impl Client {
         let res = self.client.get(url).send().await?;
 
         if !res.status().is_success() {
-            tracing::debug!("the `.well-known` config request returned HTTP status `{status}`", status = res.status());
+            tracing::debug!(
+                "the `.well-known` config request returned HTTP status `{status}`",
+                status = res.status()
+            );
             return Ok(None);
         }
 

--- a/crates/client/src/api.rs
+++ b/crates/client/src/api.rs
@@ -112,7 +112,7 @@ pub enum ClientError {
     #[error("log `{0}` was not found in this registry, but the registry provided the hint header: `{1:?}`")]
     LogNotFoundWithHint(LogId, HeaderValue),
     /// Invalid well-known config.
-    #[error("server returned an invalid well-known config: `{0}`")]
+    #[error("registry `{0}` returned an invalid well-known config")]
     InvalidWellKnownConfig(String),
     /// An other error occurred during the requested operation.
     #[error(transparent)]
@@ -234,7 +234,9 @@ impl Client {
             if let Some(warg_url) = res
                 .json::<WellKnownConfig>()
                 .await
-                .map_err(|e| ClientError::InvalidWellKnownConfig(e.to_string()))?
+                .map_err(|_| {
+                    ClientError::InvalidWellKnownConfig(self.url.registry_domain().to_string())
+                })?
                 .warg_url
             {
                 Ok(Some(RegistryUrl::new(warg_url)?))

--- a/crates/client/src/config.rs
+++ b/crates/client/src/config.rs
@@ -300,13 +300,8 @@ impl Config {
 
     pub(crate) fn storage_paths_for_url(
         &self,
-        url: Option<&str>,
+        registry_url: RegistryUrl,
     ) -> Result<StoragePaths, ClientError> {
-        let registry_url = RegistryUrl::new(
-            url.or(self.home_url.as_deref())
-                .ok_or(ClientError::NoHomeRegistryUrl)?,
-        )?;
-
         let label = registry_url.safe_label();
         let registries_dir = self.registries_dir()?.join(label);
         let content_dir = self.content_dir()?;

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -57,6 +57,10 @@ pub use self::registry_url::RegistryUrl;
 
 const DEFAULT_WAIT_INTERVAL: Duration = Duration::from_secs(1);
 
+/// For Bytecode Alliance projects, the default registry is set to `bytecodealliance.org`.
+/// The `.well-known` config path may resolve to another domain where the registry is hosted.
+pub const DEFAULT_REGISTRY: &str = "bytecodealliance.org";
+
 /// A client for a Warg registry.
 pub struct Client<R, C, N>
 where
@@ -1366,30 +1370,45 @@ impl FileSystemClient {
     /// If a lock cannot be acquired for a storage directory, then
     /// `NewClientResult::Blocked` is returned with the path to the
     /// directory that could not be locked.
-    pub fn try_new_with_config(
+    pub async fn try_new_with_config(
         url: Option<&str>,
         config: &Config,
         mut auth_token: Option<Secret<String>>,
     ) -> Result<StorageLockResult<Self>, ClientError> {
+        let disable_interactive =
+            cfg!(not(feature = "cli-interactive")) || config.disable_interactive;
+
+        let checking_url_for_well_known = RegistryUrl::new(
+            url.or(config.home_url.as_deref())
+                .unwrap_or(DEFAULT_REGISTRY),
+        )?;
+
+        let url = if let Some(warg_url) =
+            api::Client::new(checking_url_for_well_known.to_string(), None)?
+                .well_known_config()
+                .await?
+        {
+            if !disable_interactive && warg_url != checking_url_for_well_known {
+                println!(
+                    "Resolved `{well_known}` to registry hosted on `{registry}`",
+                    well_known = checking_url_for_well_known.registry_domain(),
+                    registry = warg_url.registry_domain(),
+                );
+            }
+            warg_url
+        } else {
+            RegistryUrl::new(
+                url.or(config.home_url.as_deref())
+                    .ok_or(ClientError::NoHomeRegistryUrl)?,
+            )?
+        };
+
         let StoragePaths {
             registry_url: url,
             registries_dir,
             content_dir,
             namespace_map_path,
         } = config.storage_paths_for_url(url)?;
-
-        let (packages, content, namespace_map) = match (
-            FileSystemRegistryStorage::try_lock(registries_dir.clone())?,
-            FileSystemContentStorage::try_lock(content_dir.clone())?,
-            FileSystemNamespaceMapStorage::new(namespace_map_path.clone()),
-        ) {
-            (Some(packages), Some(content), namespace_map) => (packages, content, namespace_map),
-            (None, _, _) => return Ok(StorageLockResult::NotAcquired(registries_dir)),
-            (_, None, _) => return Ok(StorageLockResult::NotAcquired(content_dir)),
-        };
-
-        let disable_interactive =
-            cfg!(not(feature = "cli-interactive")) || config.disable_interactive;
 
         let (keyring_backend, keys) = if cfg!(feature = "keyring") {
             (config.keyring_backend.clone(), config.keys.clone())
@@ -1401,6 +1420,16 @@ impl FileSystemClient {
         if auth_token.is_none() && config.keyring_auth {
             auth_token = crate::keyring::Keyring::from_config(config)?.get_auth_token(&url)?
         }
+
+        let (packages, content, namespace_map) = match (
+            FileSystemRegistryStorage::try_lock(registries_dir.clone())?,
+            FileSystemContentStorage::try_lock(content_dir.clone())?,
+            FileSystemNamespaceMapStorage::new(namespace_map_path.clone()),
+        ) {
+            (Some(packages), Some(content), namespace_map) => (packages, content, namespace_map),
+            (None, _, _) => return Ok(StorageLockResult::NotAcquired(registries_dir)),
+            (_, None, _) => return Ok(StorageLockResult::NotAcquired(content_dir)),
+        };
 
         Ok(StorageLockResult::Acquired(Self::new(
             url.into_url(),
@@ -1427,10 +1456,11 @@ impl FileSystemClient {
     ///
     /// Same as calling `try_new_with_config` with
     /// `Config::from_default_file()?.unwrap_or_default()`.
-    pub fn try_new_with_default_config(
+    pub async fn try_new_with_default_config(
         url: Option<&str>,
     ) -> Result<StorageLockResult<Self>, ClientError> {
         Self::try_new_with_config(url, &Config::from_default_file()?.unwrap_or_default(), None)
+            .await
     }
 
     /// Creates a client for the given registry URL.
@@ -1439,20 +1469,45 @@ impl FileSystemClient {
     /// URL, an error is returned.
     ///
     /// This method blocks if storage locks cannot be acquired.
-    pub fn new_with_config(
+    pub async fn new_with_config(
         url: Option<&str>,
         config: &Config,
         mut auth_token: Option<Secret<String>>,
     ) -> Result<Self, ClientError> {
+        let disable_interactive =
+            cfg!(not(feature = "cli-interactive")) || config.disable_interactive;
+
+        let checking_url_for_well_known = RegistryUrl::new(
+            url.or(config.home_url.as_deref())
+                .unwrap_or(DEFAULT_REGISTRY),
+        )?;
+
+        let url = if let Some(warg_url) =
+            api::Client::new(checking_url_for_well_known.to_string(), None)?
+                .well_known_config()
+                .await?
+        {
+            if !disable_interactive && warg_url != checking_url_for_well_known {
+                println!(
+                    "Resolved `{well_known}` to registry hosted on `{registry}`",
+                    well_known = checking_url_for_well_known.registry_domain(),
+                    registry = warg_url.registry_domain(),
+                );
+            }
+            warg_url
+        } else {
+            RegistryUrl::new(
+                url.or(config.home_url.as_deref())
+                    .ok_or(ClientError::NoHomeRegistryUrl)?,
+            )?
+        };
+
         let StoragePaths {
             registry_url,
             registries_dir,
             content_dir,
             namespace_map_path,
         } = config.storage_paths_for_url(url)?;
-
-        let disable_interactive =
-            cfg!(not(feature = "cli-interactive")) || config.disable_interactive;
 
         let (keyring_backend, keys) = if cfg!(feature = "keyring") {
             (config.keyring_backend.clone(), config.keys.clone())
@@ -1489,8 +1544,8 @@ impl FileSystemClient {
     ///
     /// Same as calling `new_with_config` with
     /// `Config::from_default_file()?.unwrap_or_default()`.
-    pub fn new_with_default_config(url: Option<&str>) -> Result<Self, ClientError> {
-        Self::new_with_config(url, &Config::from_default_file()?.unwrap_or_default(), None)
+    pub async fn new_with_default_config(url: Option<&str>) -> Result<Self, ClientError> {
+        Self::new_with_config(url, &Config::from_default_file()?.unwrap_or_default(), None).await
     }
 }
 

--- a/crates/client/src/registry_url.rs
+++ b/crates/client/src/registry_url.rs
@@ -5,7 +5,7 @@ use url::{Host, Url};
 
 /// The base URL of a registry server.
 // Note: The inner Url always has a scheme and host.
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct RegistryUrl(Url);
 
 impl RegistryUrl {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -66,9 +66,11 @@ impl CommonOptions {
     }
 
     /// Creates the warg client to use.
-    pub fn create_client(&self, config: &Config) -> Result<FileSystemClient, ClientError> {
+    pub async fn create_client(&self, config: &Config) -> Result<FileSystemClient, ClientError> {
         let client =
-            match FileSystemClient::try_new_with_config(self.registry.as_deref(), config, None)? {
+            match FileSystemClient::try_new_with_config(self.registry.as_deref(), config, None)
+                .await?
+            {
                 StorageLockResult::Acquired(client) => Ok(client),
                 StorageLockResult::NotAcquired(path) => {
                     println!(
@@ -76,7 +78,7 @@ impl CommonOptions {
                         path = path.display()
                     );
 
-                    FileSystemClient::new_with_config(self.registry.as_deref(), config, None)
+                    FileSystemClient::new_with_config(self.registry.as_deref(), config, None).await
                 }
             }?;
         Ok(client)

--- a/src/commands/bundle.rs
+++ b/src/commands/bundle.rs
@@ -19,7 +19,7 @@ impl BundleCommand {
     /// Executes the command.
     pub async fn exec(self) -> Result<()> {
         let config = self.common.read_config()?;
-        let client = self.common.create_client(&config)?;
+        let client = self.common.create_client(&config).await?;
 
         let info = client.package(&self.package).await?;
         client.bundle_component(&info).await?;

--- a/src/commands/clear.rs
+++ b/src/commands/clear.rs
@@ -14,7 +14,7 @@ impl ClearCommand {
     /// Executes the command.
     pub async fn exec(self) -> Result<()> {
         let config = self.common.read_config()?;
-        let client = self.common.create_client(&config)?;
+        let client = self.common.create_client(&config).await?;
 
         println!("clearing local content cache...");
         client.clear_content_cache().await?;

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -139,7 +139,7 @@ impl ConfigCommand {
 
         // reset when changing home registry
         if changing_home_registry {
-            let client = self.common.create_client(&config)?;
+            let client = self.common.create_client(&config).await?;
             client.reset_namespaces().await?;
             client.reset_registry().await?;
         }

--- a/src/commands/dependencies.rs
+++ b/src/commands/dependencies.rs
@@ -31,7 +31,7 @@ impl DependenciesCommand {
     /// Executes the command.
     pub async fn exec(self) -> Result<()> {
         let config = self.common.read_config()?;
-        let client = self.common.create_client(&config)?;
+        let client = self.common.create_client(&config).await?;
 
         let info = client.package(&self.package).await?;
         Self::print_package_info(&client, &info).await?;

--- a/src/commands/download.rs
+++ b/src/commands/download.rs
@@ -28,7 +28,7 @@ impl DownloadCommand {
     /// Executes the command.
     pub async fn exec(self) -> Result<()> {
         let config = self.common.read_config()?;
-        let client = self.common.create_client(&config)?;
+        let client = self.common.create_client(&config).await?;
 
         println!("Downloading `{name}`...", name = self.name);
 

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -29,9 +29,9 @@ impl InfoCommand {
     /// Executes the command.
     pub async fn exec(self) -> Result<()> {
         let config = self.common.read_config()?;
-        let client = self.common.create_client(&config)?;
+        let client = self.common.create_client(&config).await?;
 
-        println!("\nRegistry: {url}", url = client.url());
+        print!("\nRegistry: {url} ", url = client.url().registry_domain());
         if config.keyring_auth
             && Keyring::from_config(&config)?
                 .get_auth_token(client.url())?

--- a/src/commands/lock.rs
+++ b/src/commands/lock.rs
@@ -19,7 +19,7 @@ impl LockCommand {
     /// Executes the command.
     pub async fn exec(self) -> Result<()> {
         let config = self.common.read_config()?;
-        let client = self.common.create_client(&config)?;
+        let client = self.common.create_client(&config).await?;
 
         let info = client.package(&self.package).await?;
         client.lock_component(&info).await?;

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -16,6 +16,10 @@ pub struct LoginCommand {
     #[clap(flatten)]
     pub common: CommonOptions,
 
+    /// The URL of the registry to use.
+    #[clap(value_name = "URL")]
+    pub registry_url: Option<String>,
+
     /// Ignore federation hints.
     #[clap(long)]
     pub ignore_federation_hints: bool,
@@ -31,7 +35,13 @@ pub struct LoginCommand {
 
 impl LoginCommand {
     /// Executes the command.
-    pub async fn exec(self) -> Result<()> {
+    pub async fn exec(mut self) -> Result<()> {
+        if self.registry_url.is_some() {
+            if self.common.registry.is_some() {
+                bail!("Registry URL provided in two different arguments. Use only one.");
+            }
+            self.common.registry = self.registry_url;
+        }
         let mut config = self.common.read_config()?;
         let mut registry_url = &self
             .common

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -18,6 +18,7 @@ pub struct LoginCommand {
 
     /// The URL of the registry to use.
     #[clap(value_name = "URL")]
+    #[arg(hide = true)]
     pub registry_url: Option<String>,
 
     /// Ignore federation hints.

--- a/src/commands/logout.rs
+++ b/src/commands/logout.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use clap::Args;
 use warg_client::{keyring::Keyring, Config, RegistryUrl};
 
@@ -10,11 +10,21 @@ pub struct LogoutCommand {
     /// The common command options.
     #[clap(flatten)]
     pub common: CommonOptions,
+
+    /// The URL of the registry to use.
+    #[clap(value_name = "URL")]
+    pub registry_url: Option<String>,
 }
 
 impl LogoutCommand {
     /// Executes the command.
-    pub async fn exec(self) -> Result<()> {
+    pub async fn exec(mut self) -> Result<()> {
+        if self.registry_url.is_some() {
+            if self.common.registry.is_some() {
+                bail!("Registry URL provided in two different arguments. Use only one.");
+            }
+            self.common.registry = self.registry_url;
+        }
         let mut config = self.common.read_config()?;
         let registry_url = &self
             .common

--- a/src/commands/logout.rs
+++ b/src/commands/logout.rs
@@ -13,6 +13,7 @@ pub struct LogoutCommand {
 
     /// The URL of the registry to use.
     #[clap(value_name = "URL")]
+    #[arg(hide = true)]
     pub registry_url: Option<String>,
 }
 

--- a/src/commands/logout.rs
+++ b/src/commands/logout.rs
@@ -39,7 +39,7 @@ impl LogoutCommand {
         }
         println!(
             "Logged out of registry: {registry}",
-            registry = registry_url_str
+            registry = registry_url.registry_domain(),
         );
         Ok(())
     }

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -119,7 +119,7 @@ impl PublishInitCommand {
     /// Executes the command.
     pub async fn exec(self) -> Result<()> {
         let config = self.common.read_config()?;
-        let client = self.common.create_client(&config)?;
+        let client = self.common.create_client(&config).await?;
         let registry_domain = client.get_warg_registry(self.name.namespace()).await?;
 
         let signing_key = self.common.signing_key(registry_domain.as_ref()).await?;
@@ -190,7 +190,7 @@ impl PublishReleaseCommand {
     /// Executes the command.
     pub async fn exec(self) -> Result<()> {
         let config = self.common.read_config()?;
-        let client = self.common.create_client(&config)?;
+        let client = self.common.create_client(&config).await?;
         let registry_domain = client.get_warg_registry(self.name.namespace()).await?;
         let signing_key = self.common.signing_key(registry_domain.as_ref()).await?;
 
@@ -291,7 +291,7 @@ Yank `{version}` of `{package}`?",
         }
 
         let config = self.common.read_config()?;
-        let client = self.common.create_client(&config)?;
+        let client = self.common.create_client(&config).await?;
         let registry_domain = client.get_warg_registry(self.name.namespace()).await?;
         let signing_key = self.common.signing_key(registry_domain.as_ref()).await?;
 
@@ -369,7 +369,7 @@ impl PublishGrantCommand {
     /// Executes the command.
     pub async fn exec(self) -> Result<()> {
         let config = self.common.read_config()?;
-        let client = self.common.create_client(&config)?;
+        let client = self.common.create_client(&config).await?;
         let registry_domain = client.get_warg_registry(self.name.namespace()).await?;
         let signing_key = self.common.signing_key(registry_domain.as_ref()).await?;
 
@@ -451,7 +451,7 @@ impl PublishRevokeCommand {
     /// Executes the command.
     pub async fn exec(self) -> Result<()> {
         let config = self.common.read_config()?;
-        let client = self.common.create_client(&config)?;
+        let client = self.common.create_client(&config).await?;
         let registry_domain = client.get_warg_registry(self.name.namespace()).await?;
         let signing_key = self.common.signing_key(registry_domain.as_ref()).await?;
 
@@ -520,7 +520,7 @@ impl PublishStartCommand {
     /// Executes the command.
     pub async fn exec(self) -> Result<()> {
         let config = self.common.read_config()?;
-        let client = self.common.create_client(&config)?;
+        let client = self.common.create_client(&config).await?;
 
         match client.registry().load_publish().await? {
             Some(info) => bail!("a publish is already in progress for package `{name}`; use `publish abort` to abort the current publish", name = info.name),
@@ -554,7 +554,7 @@ impl PublishListCommand {
     /// Executes the command.
     pub async fn exec(self) -> Result<()> {
         let config = self.common.read_config()?;
-        let client = self.common.create_client(&config)?;
+        let client = self.common.create_client(&config).await?;
 
         match client.registry().load_publish().await? {
             Some(info) => {
@@ -610,7 +610,7 @@ impl PublishAbortCommand {
     /// Executes the command.
     pub async fn exec(self) -> Result<()> {
         let config = self.common.read_config()?;
-        let client = self.common.create_client(&config)?;
+        let client = self.common.create_client(&config).await?;
 
         match client.registry().load_publish().await? {
             Some(info) => {
@@ -642,7 +642,7 @@ impl PublishSubmitCommand {
     /// Executes the command.
     pub async fn exec(self) -> Result<()> {
         let config = self.common.read_config()?;
-        let client = self.common.create_client(&config)?;
+        let client = self.common.create_client(&config).await?;
 
         match client.registry().load_publish().await? {
             Some(info) => {
@@ -720,7 +720,7 @@ impl PublishWaitCommand {
     /// Executes the command.
     pub async fn exec(self) -> Result<()> {
         let config = self.common.read_config()?;
-        let client = self.common.create_client(&config)?;
+        let client = self.common.create_client(&config).await?;
         let record_id = RecordId::from(self.record_id);
 
         println!(

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -14,7 +14,7 @@ impl ResetCommand {
     /// Executes the command.
     pub async fn exec(self) -> Result<()> {
         let config = self.common.read_config()?;
-        let client = self.common.create_client(&config)?;
+        let client = self.common.create_client(&config).await?;
 
         println!("resetting local registry data...");
         client.reset_registry().await?;

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -14,7 +14,7 @@ impl UpdateCommand {
     /// Executes the command.
     pub async fn exec(self) -> Result<()> {
         let config = self.common.read_config()?;
-        let client = self.common.create_client(&config)?;
+        let client = self.common.create_client(&config).await?;
 
         println!("updating package logs to the latest available versions...");
         client.update().await?;

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -9,8 +9,8 @@ use warg_protocol::registry::PackageName;
 
 pub mod support;
 
-fn create_client(config: &Config) -> Result<FileSystemClient> {
-    match FileSystemClient::try_new_with_config(None, config, None)? {
+async fn create_client(config: &Config) -> Result<FileSystemClient> {
+    match FileSystemClient::try_new_with_config(None, config, None).await? {
         StorageLockResult::Acquired(client) => Ok(client),
         _ => bail!("failed to acquire storage lock"),
     }
@@ -23,7 +23,7 @@ async fn client_incrementally_fetches() -> Result<()> {
 
     let (_server, config) = spawn_server(&root().await?, None, None, None).await?;
 
-    let client = create_client(&config)?;
+    let client = create_client(&config).await?;
     let signing_key = support::test_signing_key();
 
     // Store a single component that will be used for every release
@@ -83,7 +83,7 @@ async fn client_incrementally_fetches() -> Result<()> {
         .context("failed to remove registries directory")?;
 
     // Recreate the client with the same config
-    let client = create_client(&config)?;
+    let client = create_client(&config).await?;
 
     // Regression test: update on empty registry storage
     client.update().await?;

--- a/tests/depsolve.rs
+++ b/tests/depsolve.rs
@@ -17,7 +17,7 @@ pub mod support;
 async fn depsolve() -> Result<()> {
     let (_server, config) = spawn_server(&root().await?, None, None, None).await?;
 
-    let client = create_client(&config)?;
+    let client = create_client(&config).await?;
     let signing_key = support::test_signing_key();
 
     let mut head = publish_package(

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -95,7 +95,7 @@ async fn it_works_with_postgres() -> TestResult {
     fs::remove_dir_all(root.join("content"))?;
     fs::remove_dir_all(root.join("registries"))?;
 
-    let client = create_client(&config)?;
+    let client = create_client(&config).await?;
     client.fetch_packages(packages.iter()).await?;
 
     // Finally, after a restart, ensure the packages can be downloaded

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -71,7 +71,7 @@ async fn test_component_publishing(config: &Config) -> Result<()> {
     const PACKAGE_VERSION: &str = "0.1.0";
 
     let name = PackageName::new(PACKAGE_NAME)?;
-    let client = create_client(config)?;
+    let client = create_client(config).await?;
     let signing_key = test_signing_key();
     let digest = publish_component(
         &client,
@@ -118,7 +118,7 @@ async fn test_package_yanking(config: &Config) -> Result<()> {
 
     // Publish release
     let name = PackageName::new(PACKAGE_NAME)?;
-    let client = create_client(config)?;
+    let client = create_client(config).await?;
     let signing_key = test_signing_key();
     publish(
         &client,
@@ -157,7 +157,7 @@ async fn test_wit_publishing(config: &Config) -> Result<()> {
     const PACKAGE_VERSION: &str = "0.1.0";
 
     let name = PackageName::new(PACKAGE_NAME)?;
-    let client = create_client(config)?;
+    let client = create_client(config).await?;
     let signing_key = test_signing_key();
     let digest = publish_wit(
         &client,
@@ -205,7 +205,7 @@ async fn test_wasm_content_policy(config: &Config) -> Result<()> {
     // Publish empty content to the server
     // This should be rejected by policy because it is not valid WebAssembly
     let name = PackageName::new(PACKAGE_NAME)?;
-    let client = create_client(config)?;
+    let client = create_client(config).await?;
     let signing_key = test_signing_key();
     match publish(
         &client,
@@ -263,7 +263,7 @@ async fn test_unauthorized_signing_key(config: &Config) -> Result<()> {
 
     // Start by publishing a new component package
     let name = PackageName::new(PACKAGE_NAME)?;
-    let client = create_client(config)?;
+    let client = create_client(config).await?;
     let signing_key = test_signing_key();
     publish_component(
         &client,
@@ -299,7 +299,7 @@ async fn test_unknown_signing_key(config: &Config) -> Result<()> {
 
     // Start by publishing a new component package
     let name = PackageName::new(PACKAGE_NAME)?;
-    let client = create_client(config)?;
+    let client = create_client(config).await?;
     let signing_key = test_signing_key();
     publish_component(
         &client,
@@ -391,7 +391,7 @@ async fn test_custom_content_url(config: &Config) -> Result<()> {
     const PACKAGE_VERSION: &str = "0.1.0";
 
     let name = PackageName::new(PACKAGE_NAME)?;
-    let client = create_client(config)?;
+    let client = create_client(config).await?;
     let signing_key = test_signing_key();
     let digest = publish_component(
         &client,

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -43,8 +43,8 @@ pub fn test_signing_key() -> PrivateKey {
     PrivateKey::decode(key.to_string()).unwrap()
 }
 
-pub fn create_client(config: &warg_client::Config) -> Result<FileSystemClient> {
-    match FileSystemClient::try_new_with_config(None, config, None)? {
+pub async fn create_client(config: &warg_client::Config) -> Result<FileSystemClient> {
+    match FileSystemClient::try_new_with_config(None, config, None).await? {
         StorageLockResult::Acquired(client) => Ok(client),
         _ => bail!("failed to acquire storage lock"),
     }


### PR DESCRIPTION
- Added Warg client support for `.well-known` path, which required the `warg_client::FileSystemClient::new_with_config()` methods to be `async`;
- Support both `warg login <registry-url>` and `warg login --registry <registry-url>` (also for `warg logout`);
- Sets the default registry, without configuration, to be `bytecodealliance.org`; [See discussions](https://github.com/bytecodealliance/wasm-pkg-tools/discussions/3#discussioncomment-9359731)

Follow on work to respect HTTP cache headers.