### PR TITLE
fix missing arg in README command

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ default.
 Next, create a new signing key to publish packages with:
 
 ```
-warg key new 127.0.0.1:8090
+warg key new --registry 127.0.0.1:8090
 ```
 
 The new signing key will be stored in your operating system's key store and


### PR DESCRIPTION
The getting started in the readme is missing an argument :)
