### PR TITLE
Add progress bar to client downloads & uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1710,6 +1710,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
+dependencies = [
+ "console",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2258,6 +2271,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2613,6 +2632,12 @@ dependencies = [
  "tracing",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d30538d42559de6b034bc76fd6dd4c38961b1ee5c6c56e3808c50128fdbc22ce"
 
 [[package]]
 name = "postgres-protocol"
@@ -4240,6 +4265,7 @@ dependencies = [
  "dialoguer",
  "futures",
  "indexmap 2.2.6",
+ "indicatif",
  "itertools 0.12.1",
  "p256",
  "ptree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ wasmprinter = "0.2.78"
 dialoguer = { workspace = true }
 itertools = "0.12.1"
 secrecy = { workspace = true }
+indicatif = "0.17.8"
 
 [dev-dependencies]
 reqwest = { workspace = true }

--- a/crates/client/src/depsolve.rs
+++ b/crates/client/src/depsolve.rs
@@ -120,7 +120,7 @@ impl LockListBuilder {
                         }
                         self.lock_list.insert(import);
                     } else {
-                        client.download(&id, &VersionReq::STAR).await?;
+                        client.download(&id, &VersionReq::STAR, |_, _| ()).await?;
                         if let Some(info) = client
                             .registry()
                             .load_package(

--- a/src/commands/download.rs
+++ b/src/commands/download.rs
@@ -1,3 +1,5 @@
+use crate::progress::make_progress_handler;
+
 use super::CommonOptions;
 use anyhow::Result;
 use clap::Args;
@@ -30,8 +32,6 @@ impl DownloadCommand {
         let config = self.common.read_config()?;
         let client = self.common.create_client(&config).await?;
 
-        println!("Downloading `{name}`...", name = self.name);
-
         // if user specifies exact verion, then set the `VersionReq` to exact match
         let version = match &self.version {
             Some(version) => VersionReq::parse(&format!("={}", version))?,
@@ -39,7 +39,11 @@ impl DownloadCommand {
         };
 
         let download = client
-            .download(&self.name, &version)
+            .download(
+                &self.name,
+                &version,
+                make_progress_handler(format!("Downloading `{name}`...", name = self.name)),
+            )
             .await?
             .ok_or_else(|| ClientError::PackageVersionRequirementDoesNotExist {
                 name: self.name.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,4 @@
 #![deny(missing_docs)]
 
 pub mod commands;
+mod progress;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,60 @@
+use std::pin::Pin;
+use std::task::{ready, Poll};
+
+use indicatif::{ProgressBar, ProgressStyle};
+use tokio::io::AsyncRead;
+
+pub(crate) struct ProgressStream<R> {
+    bar: ProgressBar,
+    inner: R,
+}
+
+pub fn make_progress_handler(msg: String) -> impl FnMut(u64, u64) {
+    let bar = init_progress_bar();
+    bar.set_message(msg);
+    move |delta, total| {
+        bar.set_length(total);
+        bar.inc(delta);
+    }
+}
+
+fn init_progress_bar() -> ProgressBar {
+    let bar = indicatif::ProgressBar::new(0);
+    bar.set_style(
+        ProgressStyle::with_template(
+            "[{elapsed_precise}] {bar:30} {binary_bytes:.02}/{binary_total_bytes} {msg}",
+        )
+        .unwrap()
+        .progress_chars("##-"),
+    );
+
+    bar
+}
+
+impl<R> ProgressStream<R> {
+    pub fn new(inner: R, len: u64, msg: String) -> Self {
+        let bar = init_progress_bar();
+        bar.set_length(len);
+        bar.set_message(msg);
+
+        Self { bar, inner }
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for ProgressStream<R> {
+    fn poll_read(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        let initialized_before = buf.initialized().len() as u64;
+        match ready!(Pin::new(&mut self.inner).poll_read(cx, buf)) {
+            Ok(()) => {
+                self.bar
+                    .inc(buf.initialized().len() as u64 - initialized_before);
+                Poll::Ready(Ok(()))
+            }
+            Err(e) => Poll::Ready(Err(e)),
+        }
+    }
+}

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -84,7 +84,7 @@ async fn test_component_publishing(config: &Config) -> Result<()> {
     .await?;
 
     let download = client
-        .download(&name, &PACKAGE_VERSION.parse()?)
+        .download(&name, &PACKAGE_VERSION.parse()?, |_, _| ())
         .await?
         .context("failed to resolve package")?;
 
@@ -107,7 +107,7 @@ async fn test_component_publishing(config: &Config) -> Result<()> {
     }
 
     // Assert that a different version can't be downloaded
-    assert!(client.download(&name, &"0.2.0".parse()?).await?.is_none());
+    assert!(client.download(&name, &"0.2.0".parse()?,  |_, _| ()).await?.is_none());
 
     Ok(())
 }
@@ -147,7 +147,7 @@ async fn test_package_yanking(config: &Config) -> Result<()> {
         .wait_for_publish(&name, &record_id, Duration::from_millis(100))
         .await?;
 
-    let opt = client.download(&name, &PACKAGE_VERSION.parse()?).await?;
+    let opt = client.download(&name, &PACKAGE_VERSION.parse()?,  |_, _| ()).await?;
     assert!(opt.is_none(), "expected no download, got {opt:?}");
     Ok(())
 }
@@ -170,7 +170,7 @@ async fn test_wit_publishing(config: &Config) -> Result<()> {
     .await?;
 
     let download = client
-        .download(&name, &PACKAGE_VERSION.parse()?)
+        .download(&name, &PACKAGE_VERSION.parse()?,  |_, _| ())
         .await?
         .context("failed to resolve package")?;
 
@@ -193,7 +193,7 @@ async fn test_wit_publishing(config: &Config) -> Result<()> {
     }
 
     // Assert that a different version can't be downloaded
-    assert!(client.download(&name, &"0.2.0".parse()?).await?.is_none());
+    assert!(client.download(&name, &"0.2.0".parse()?,  |_, _| ()).await?.is_none());
 
     Ok(())
 }


### PR DESCRIPTION
This PR adds a progress bar to the cli when the user uploads or downloads files.

Passing the progress handler down to the client crate felt a bit clumsy, if anyone has suggestion on how to improve it.

closes #283
