### PR TITLE
chore: Bump ptree 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,17 +272,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,15 +1436,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -2813,12 +2793,11 @@ dependencies = [
 
 [[package]]
 name = "ptree"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709c3b241d6a6ccc1933b1c6d7d997fae2b3dff8981f6780eac67df03c32f3ef"
+checksum = "e98cc9b19fef1b3e9d04e52df8a5b2a521e44d488cb3162bcd0bba3b5f0c35a4"
 dependencies = [
  "ansi_term",
- "atty",
  "config",
  "directories",
  "petgraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ repository = "https://github.com/bytecodealliance/registry"
 
 [workspace.dependencies]
 dialoguer = "0.11.0"
-ptree = "0.5.0"
+ptree = "0.5.1"
 warg-api = { path = "crates/api", version = "0.9.0-dev" }
 warg-credentials = { path = "crates/credentials", version = "0.9.0-dev" }
 warg-client = { path = "crates/client", version = "0.9.0-dev" }


### PR DESCRIPTION
This brings in changes from [ptree#10](https://gitlab.com/Noughmad/ptree/-/merge_requests/10), which addresses [RUSTSEC-2021-0145](https://rustsec.org/advisories/RUSTSEC-2021-0145.html).

Please note that there's [another change pending for `ptree`](https://gitlab.com/Noughmad/ptree/-/merge_requests/11) to address [RUSTSEC-2021-0139](https://rustsec.org/advisories/RUSTSEC-2021-0139.html), but since that hasn't yet been merged, I figured it was worth going ahead and getting at least this bump in.