### PR TITLE
chore: Bump ptree 0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,15 +59,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2793,11 +2784,11 @@ dependencies = [
 
 [[package]]
 name = "ptree"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98cc9b19fef1b3e9d04e52df8a5b2a521e44d488cb3162bcd0bba3b5f0c35a4"
+checksum = "289cfd20ebec0e7ff2572e370dd7a1c9973ba666d3c38c5e747de0a4ada21f17"
 dependencies = [
- "ansi_term",
+ "anstyle",
  "config",
  "directories",
  "petgraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ repository = "https://github.com/bytecodealliance/registry"
 
 [workspace.dependencies]
 dialoguer = "0.11.0"
-ptree = "0.5.1"
+ptree = "0.5.2"
 warg-api = { path = "crates/api", version = "0.9.0-dev" }
 warg-credentials = { path = "crates/credentials", version = "0.9.0-dev" }
 warg-client = { path = "crates/client", version = "0.9.0-dev" }


### PR DESCRIPTION
This addresses [`RUSTSEC-2021-0139`](https://rustsec.org/advisories/RUSTSEC-2021-0139.html)