### PR TITLE
chore(ci): Update wasm32-wasi reference for Rust 1.84

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust
-      run: rustup update stable --no-self-update && rustup default stable && rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknown
       shell: bash
+      run: |
+        rustup update stable --no-self-update
+        rustup default stable
+        rustup target add wasm32-wasip2
+        rustup target add wasm32-unknown-unknown
     - name: Build all crates
       run: cargo build --all --features warg-server/debug
     - name: Run all tests
@@ -35,8 +39,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust
-      run: rustup update stable --no-self-update && rustup default stable && rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknown
       shell: bash
+      run: |
+        rustup update stable --no-self-update
+        rustup default stable
+        rustup target add wasm32-wasip2
+        rustup target add wasm32-unknown-unknown
     - name: Install diesel-cli
       run: cargo install diesel_cli
     - name: Build all crates
@@ -50,7 +58,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust
-      run: rustup update stable --no-self-update && rustup default stable
+      run: |
+        rustup update stable --no-self-update
+        rustup default stable
     - name: Install warg CLI
       run: cargo install --locked --path .
 
@@ -60,6 +70,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust
-      run: rustup update stable && rustup default stable && rustup component add rustfmt
+      run: |
+        rustup update stable
+        rustup default stable
+        rustup component add rustfmt
     - name: Run `cargo fmt`
       run: cargo fmt -- --check


### PR DESCRIPTION
Per the failure in https://github.com/bytecodealliance/registry/pull/312, Rust 1.84 deprecated `wasm32-wasi` target, and thus it now needs to be set to either `wasm32-wasip1` or `wasm32-wasip2`.

I wasn't sure if we wanted to target `p1` or `p2`, so I defaulted to `p2`, but happy to switch it to `p1` if that's preferred.