### PR TITLE
Enable serialization for superuser-keys

### DIFF
--- a/crates/server/src/policy/record/authorization.rs
+++ b/crates/server/src/policy/record/authorization.rs
@@ -13,7 +13,7 @@ use warg_protocol::{
 #[derive(Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AuthorizedKeyPolicy {
-    #[serde(skip)]
+    #[serde(default)]
     superuser_keys: IndexSet<KeyID>,
     #[serde(default, rename = "namespace")]
     namespaces: IndexMap<String, LogPolicy>,


### PR DESCRIPTION
Allows setting the `superuser_keys` array in the authorised keys file.